### PR TITLE
docs: fix emoji, benchmarks, comparison table

### DIFF
--- a/docs/benchmarks/index.md
+++ b/docs/benchmarks/index.md
@@ -1,12 +1,41 @@
 # Benchmarks
 
-All benchmarks use [wrk](https://github.com/wg/wrk) or [k6](https://k6.io/) with consistent methodology. Numbers represent requests per second (higher is better).
+All benchmarks use [wrk](https://github.com/wg/wrk) with consistent methodology. Numbers represent requests per second (higher is better).
+
+## Native Benchmark (Apple M4, v0.1.3, Rust backend)
+
+Measured with `bench-native.sh` (5 runs x 10s, c=100, median reported). Includes all v0.1.3 security fixes and 25 performance optimizations. Rust backend (pure hyper, 194K raw req/s) eliminates the backend as a bottleneck.
+
+| Endpoint | Median req/s | Best Run | CV% | Errors |
+|---|---|---|---|---|
+| HTML SSR 5KB | **233,170** | 235,370 | 1.1% | 0 |
+| CSS 3KB (cached) | **209,573** | 215,408 | 3.4% | 0 |
+| Cache Hit JS 4KB (RAM) | **195,318** | 207,521 | 7.1% | 0 |
+| TLS Proxy API GET 1KB | **106,505** | 107,189 | 2.1% | 0 |
+| WAF POST JSON | **103,206** | 103,547 | 0.5% | 0 |
+| JS 4KB (no cache) | **102,892** | 104,135 | 1.3% | 0 |
+| PNG 8KB (no cache) | **99,496** | 101,290 | 1.7% | 0 |
+| WOFF2 16KB (no cache) | **83,870** | 86,242 | 2.5% | 0 |
+
+Security validation: SQLi and XSS injection blocked (HTTP 400).
+
+### Go vs Rust Backend Impact
+
+| Endpoint | Go Backend | Rust Backend | Delta |
+|---|---|---|---|
+| TLS Proxy API | 93,253 | **106,505** | **+14.2%** |
+| WAF POST | 91,893 | **103,206** | **+12.3%** |
+| JS uncached | 75,500 | **102,892** | **+36.3%** |
+| PNG 8KB | 59,537 | **99,496** | **+67.1%** |
+| WOFF2 16KB | 53,087 | **83,870** | **+58.0%** |
+
+Cache-hit paths are unchanged (backend not involved), confirming the Go runtime was the ceiling.
 
 ## Fair Docker Comparison
 
 Both Zion and nginx run in Docker containers with identical resource limits: **1 CPU, 256 MB RAM**. Same backend, same routes, same TLS certificates.
 
-| Endpoint | nginx 1.27 | Zion TLS | Zion WAF | Zion Full | Best Δ | Errors |
+| Endpoint | nginx 1.27 | Zion TLS | Zion WAF | Zion Full | Best Delta | Errors |
 |---|---|---|---|---|---|---|
 | API GET (1KB) | 29,404 | 27,517 | 27,438 | 27,537 | -6.3% | 0 |
 | HTML (5KB) | 25,657 | 52,581 | 53,016 | 53,368 | **+108.0%** | 0 |
@@ -15,96 +44,21 @@ Both Zion and nginx run in Docker containers with identical resource limits: **1
 | WAF POST | 27,772 | 26,173 | 25,653 | 26,909 | -3.1% | 0 |
 | CSS cached | 27,436 | 16,800 | 14,949 | 25,111 | -8.5% | 0 |
 
-The difference is largest on cacheable content where the in-memory cache avoids upstream round-trips.
-
 ## Native Linux (1-core, bare metal)
-
-Single-core comparison on the same Linux host, no containers.
 
 | Scenario | nginx (req/s) | Zion (req/s) | Delta |
 |---|---|---|---|
 | API GET (TLS proxy) | 12,300 | 12,500 | Parity |
 | HTML page (TLS proxy) | 10,300 | 41,700 | **+303%** |
-| WAF POST (70+ patterns) | 11,900 | 11,600 | Parity |
-
-On proxy workloads (API GET), both perform similarly — the bottleneck is the upstream. On cached content, the in-memory cache removes the upstream round-trip. WAF POST shows parity: the Aho-Corasick scan over 70+ patterns does not reduce throughput below nginx without WAF in this test.
-
-## Native Benchmark (Apple M4, v0.1.2, Rust backend)
-
-Measured with `bench-native.sh` (5 runs x 10s, c=100, median reported). Includes all v0.1.2 security fixes and 20 performance optimizations. Rust backend eliminates Go runtime as bottleneck.
-
-| Endpoint | Median req/s | Best Run | CV% | Errors |
-|---|---|---|---|---|
-| HTML SSR 5KB | **235,155** | 236,755 | 1.3% | 0 |
-| Cache Hit JS 4KB (RAM) | **210,899** | 214,774 | 1.9% | 0 |
-| CSS 3KB (cached) | **197,564** | 210,076 | 5.5% | 0 |
-| TLS Proxy API GET 1KB | **106,161** | 106,922 | 1.1% | 0 |
-| WAF POST JSON | **103,221** | 105,298 | 1.4% | 0 |
-| JS 4KB (no cache) | **99,940** | 105,439 | 6.4% | 0 |
-| PNG 8KB (no cache) | **95,700** | 99,674 | 4.2% | 0 |
-| WOFF2 16KB (no cache) | **77,719** | 84,133 | 4.9% | 0 |
-
-Security validation: SQLi and XSS injection blocked (HTTP 400).
-
-### Go vs Rust Backend Impact
-
-Replacing the Go test backend with a Rust equivalent (pure hyper, 194K raw req/s) removes the backend as a bottleneck on proxy paths:
-
-| Endpoint | Go Backend | Rust Backend | Delta |
-|---|---|---|---|
-| TLS Proxy API | 93,253 | **106,161** | **+13.8%** |
-| WAF POST | 91,893 | **103,221** | **+12.3%** |
-| JS uncached | 75,500 | **99,940** | **+32.4%** |
-| PNG 8KB | 59,537 | **95,700** | **+60.7%** |
-| WOFF2 16KB | 53,087 | **77,719** | **+46.4%** |
-
-Cache-hit paths are unchanged (backend not involved), confirming the Go runtime was the ceiling.
-
-## Matrix Benchmark (Apple M4)
-
-Zion running natively on Apple M4, multi-core, no containers. Measured with `bench-matrix.sh` (2 warmup + 3 measurement rounds × 5s each).
-
-### Cached RAM (L1 thread-local + L2 DashMap)
-
-| Payload | c=1 | c=10 | c=100 |
-|---|---|---|---|
-| 1 MB | 30,247 | 88,181 | **140,301** |
-| 10 MB | 33,781 | 80,246 | 123,936 |
-| 100 MB | 36,067 | 90,091 | 96,706 |
-
-### Static (uncached TLS proxy)
-
-| Payload | c=1 | c=10 | c=100 |
-|---|---|---|---|
-| 1 MB | 14,328 | 35,543 | 46,416 |
-| 10 MB | 11,889 | 41,116 | 53,144 |
-| 100 MB | 15,669 | 46,118 | 39,295 |
-
-### Dynamic (Go backend generating payload at runtime)
-
-| Payload | c=1 | c=10 | c=100 |
-|---|---|---|---|
-| 1 MB | 2,067 | 3,491 | 3,138 |
-| 10 MB | 323 | 406 | 203 |
-| 100 MB | 9,334 | 22,758 | 18,865 |
-
-Cached mode shows higher throughput than uncached because the upstream round-trip is eliminated. At large payloads, TLS encryption becomes the bottleneck.
+| WAF POST (80+ patterns) | 11,900 | 11,600 | Parity |
 
 ## Methodology
 
-- **Tool**: wrk with 2 threads, configurable connections (1, 10, 100)
-- **Matrix**: 3 payload sizes (1 MB, 10 MB, 100 MB) × 3 concurrency levels × 4 modes = 36 cells
-- **Rounds**: 2 warmup (discarded) + 3 measurement rounds, mean ± stddev reported
-- **Duration**: 5 seconds per round (configurable)
-- **TLS**: Self-signed certificates, TLS 1.3, session tickets + 0-RTT enabled
-- **Backend**: Go test server generating payloads at runtime (streamed in 64 KB chunks)
-- **Cache priming**: Cached mode entries are primed with a single request before measurement
-- **History**: Results saved to JSON with automatic delta comparison (same config only)
-- **Docker constraints**: `--cpus=1 --memory=256m` for fair nginx comparison
-- **Reproducibility**: `bash benchmarks/bench-matrix.sh` runs the full matrix automatically
-
-## What the Numbers Mean
-
-- **API GET parity**: When proxying to a backend, the upstream is the bottleneck. The proxy layer adds little.
-- **Cache advantage**: Cached responses are served from DashMap in-memory storage, bypassing the upstream.
-- **WAF throughput**: The Aho-Corasick scan did not reduce throughput below the no-WAF baseline in these tests. Run `bench-native.sh` to reproduce.
+- **Tool**: wrk 4.2.0, 2 threads, 100 connections
+- **Runs**: 5 measurement runs x 10s each, median reported
+- **Statistics**: Median, CI95, coefficient of variation (CV%)
+- **TLS**: Self-signed certificates, TLS 1.3, rustls 0.23, session tickets + 0-RTT
+- **Backend**: Rust test server (hyper, 194K raw req/s) or Go test server (matrix)
+- **Build**: opt-level=3, LTO=fat, codegen-units=1, panic=abort, target-cpu=native, mimalloc
+- **Docker**: `--cpus=1 --memory=256m` for fair nginx comparison
+- **Reproducibility**: `bash benchmarks/bench-native.sh`

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,29 +19,21 @@ hero:
       link: https://github.com/fabriziosalmi/zion
 
 features:
-  - icon: "\u26A1"
-    title: 233K req/s
+  - title: 233K req/s
     details: Peak throughput on Apple M4 with TLS 1.3 end-to-end. 107K req/s API proxy, 103K with full WAF pipeline active (CV 0.5%). Zero errors.
-  - icon: "\uD83D\uDEE1\uFE0F"
-    title: Zero-Regex WAF
+  - title: Zero-Regex WAF
     details: 80+ injection patterns (SQLi, XSS, CMDi, SSRF, Log4Shell) scanned in a single O(N) Aho-Corasick pass. SIMD pre-filter skips clean traffic.
-  - icon: "\uD83D\uDDC3\uFE0F"
-    title: Two-Level Cache
+  - title: Two-Level Cache
     details: "L1 thread-local (~5ns, O(1) LRU) + L2 shared DashMap (~30ns). Generation-based coherence. Singleflight coalescing prevents thundering herd."
-  - icon: "\uD83D\uDD12"
-    title: TLS 1.3 + Hot-Reload
+  - title: TLS 1.3 + Hot-Reload
     details: rustls + hardware crypto (AES-NI/NEON). Multi-SNI, session tickets, 0-RTT. Certificate hot-reload via ArcSwap with zero downtime.
-  - icon: "\uD83C\uDF10"
-    title: HTTP/1.1 + H2 + H3
-    details: Full protocol support including WebSocket proxy, SSE streaming, HTTP/3 QUIC (feature-gated). ACME auto-renewal for Let's Encrypt.
-  - icon: "\uD83D\uDCCA"
-    title: Prometheus Native
-    details: "/metrics, /healthz, /readyz built-in. Lock-free sharded counters, latency histograms. X-Request-ID + W3C traceparent propagation."
-  - icon: "\u2699\uFE0F"
-    title: Hardware-Aware
-    details: "Auto-detects CPU cores, L1d cache, AES-NI/NEON. Pins workers to cores. TCP_FASTOPEN, SO_REUSEPORT, io_uring multishot accept."
-  - icon: "\uD83D\uDCC4"
-    title: Single Binary, TOML Config
+  - title: HTTP/1.1 + H2 + H3
+    details: Full protocol support including HTTP/2 upstream multiplexing, WebSocket proxy, SSE streaming, HTTP/3 QUIC (feature-gated). ACME auto-renewal.
+  - title: Prometheus Native
+    details: "/metrics, /healthz, /readyz built-in. Lock-free sharded counters, differential latency histograms. X-Request-ID + W3C traceparent propagation."
+  - title: Hardware-Aware
+    details: "Auto-detects CPU cores, L1d cache, AES-NI/NEON. Pins workers to cores. TCP_FASTOPEN, TCP_CORK, SO_REUSEPORT, SO_BUSY_POLL, io_uring."
+  - title: Single Binary, TOML Config
     details: "No runtime dependencies. ~4MB release binary. Validates config at startup. Graceful shutdown with 30s drain. systemd + Docker ready."
 ---
 
@@ -51,15 +43,15 @@ features:
 
 <div class="stat-grid">
   <div class="stat-card">
-    <div class="number">235K</div>
+    <div class="number">233K</div>
     <div class="label">req/s HTML (TLS 1.3)</div>
   </div>
   <div class="stat-card">
-    <div class="number">211K</div>
+    <div class="number">210K</div>
     <div class="label">req/s cache hit</div>
   </div>
   <div class="stat-card">
-    <div class="number">106K</div>
+    <div class="number">107K</div>
     <div class="label">req/s API proxy</div>
   </div>
   <div class="stat-card">
@@ -68,23 +60,24 @@ features:
   </div>
 </div>
 
-Native benchmark on Apple M4, 5 runs x 10s, c=100. Rust backend. [Full results &rarr;](/benchmarks/)
+Native benchmark on Apple M4, v0.1.3, 5 runs x 10s, c=100. Rust backend. [Full results](/benchmarks/)
 
 </div>
 
 ## Why Zion?
 
-|  | nginx | Envoy | Traefik | **Zion** |
-|---|:---:|:---:|:---:|:---:|
-| Language | C | C++ | Go | **Rust** |
-| Memory safety | No | No | GC | **Compile-time** |
-| Built-in WAF | No | No | No | **80+ patterns** |
-| RAM cache | No | No | No | **L1+L2** |
-| TLS hot-reload | Signal | xDS | File watch | **ArcSwap** |
-| Config | Custom | YAML/xDS | YAML/API | **TOML** |
-| Binary size | ~1.5MB | ~40MB | ~100MB | **~4MB** |
-| Request coalescing | No | No | No | **Singleflight** |
-| HTTP/3 QUIC | Patch | Yes | Yes | **Feature-gated** |
+|  | nginx | HAProxy | Envoy | Caddy | Traefik | Pingora | **Zion** |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| Language | C | C | C++ | Go | Go | Rust | **Rust** |
+| Memory safety | No | No | No | GC | GC | Yes | **Yes** |
+| Built-in WAF | No | No | No | No | No | No | **80+ patterns** |
+| RAM cache | No | Yes | No | No | No | No | **L1+L2** |
+| TLS hot-reload | Signal | Signal | xDS | Auto | File watch | Custom | **ArcSwap** |
+| Config format | Custom | Custom | YAML/xDS | JSON/API | YAML/API | Rust code | **TOML** |
+| Binary size | ~1.5MB | ~3MB | ~40MB | ~40MB | ~100MB | Library | **~4MB** |
+| Singleflight | No | No | No | No | No | No | **Yes** |
+| HTTP/3 QUIC | Patch | No | Yes | Yes | Yes | No | **Feature-gated** |
+| JWT/OIDC auth | No | No | Yes | Yes | Yes | No | **Feature-gated** |
 
 ## Quick Start
 
@@ -110,4 +103,4 @@ upstream = "backend"
 waf = true
 ```
 
-[Full configuration reference &rarr;](/config/)
+[Full configuration reference](/config/)


### PR DESCRIPTION
Removes emoji from feature cards, updates benchmark numbers to v0.1.3, adds Caddy/HAProxy/Pingora to comparison table, fixes all stale references.