### PR TITLE
docs: fix 70+ patterns, 32 KB buffer, aws-lc-rs references

### DIFF
--- a/docs/config/tls.md
+++ b/docs/config/tls.md
@@ -1,6 +1,6 @@
 # TLS & SNI
 
-Zion terminates TLS using [rustls](https://github.com/rustls/rustls) with the aws-lc-rs cryptography backend. No OpenSSL dependency.
+Zion terminates TLS using [rustls](https://github.com/rustls/rustls) with the ring cryptography backend. No OpenSSL dependency.
 
 ## Basic Configuration
 

--- a/docs/config/waf.md
+++ b/docs/config/waf.md
@@ -115,7 +115,7 @@ GET, HEAD, DELETE, and OPTIONS requests skip gates 2–6 (no body to inspect).
 
 Gate 3 uses an [Aho-Corasick](https://en.wikipedia.org/wiki/Aho%E2%80%93Corasick_algorithm) automaton — a single O(N) pass over the body that scans **all patterns simultaneously**. No regex, no backtracking, no ReDoS risk.
 
-**70+ patterns in 7 categories:**
+**192 patterns in 14 categories:**
 
 ### SQL Injection (19 patterns)
 ```

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -6,7 +6,7 @@ Zion is a TLS reverse proxy with a built-in WAF, written in Rust. One binary, on
 
 | Feature | Implementation |
 |---|---|
-| TLS termination | rustls (aws-lc-rs backend), TLS 1.2/1.3, ALPN, SNI |
+| TLS termination | rustls (ring crypto backend), TLS 1.2/1.3, ALPN, SNI |
 | Routing | Radix tree via `matchit` crate |
 | WAF | 6-gate pipeline: body size, content-type, Aho-Corasick pattern match, entropy, simd-json validation, payload profiling |
 | Caching | In-memory two-level cache: thread-local L1 + shared DashMap L2, TTL + max-entry eviction |

--- a/docs/security/hardening.md
+++ b/docs/security/hardening.md
@@ -36,7 +36,7 @@ Hyper is configured with reduced header limits compared to defaults:
 | Parameter | Zion | Hyper Default |
 |---|---|---|
 | Max header count | 64 | 100 |
-| Max header buffer | 32 KB | 400 KB |
+| Max header buffer | 16 KB | 400 KB |
 
 ## Rate Limiting
 

--- a/docs/security/index.md
+++ b/docs/security/index.md
@@ -38,7 +38,7 @@ Request Body
     ▼
 ┌─ Gate 3: Aho-Corasick Injection Scanner ─────────┐
 │  O(N) pass over body (N = body length)           │
-│  70+ patterns scanned simultaneously             │
+│  192 patterns scanned simultaneously             │
 │  Case-insensitive matching (ASCII)               │
 │  Built once via OnceLock on first request        │
 └──────────────────────────────────────────────────┘


### PR DESCRIPTION
5 fixes. Verified zero stale refs remaining.