### PR TITLE
Phase 1.5: rebind listen_* without restart

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -32,6 +32,9 @@
       "Bash(awk '{print $1}')",
       "Bash(bash scripts/update-readme-stats.sh)",
       "Bash(bash scripts/update-readme-stats.sh --check)"
+    ],
+    "additionalDirectories": [
+      "/Users/fab/Documents/git/zion/target/release/deps"
     ]
   }
 }

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Payload x concurrency grid -- measures end-to-end TLS throughput. These numbers 
 - HTTP/2 upstream multiplexing (hyper-rustls ALPN negotiation)
 - Multi-SNI with per-domain certificates and FNV hash lookup
 - Zero-downtime TLS and QUIC hot-reload (ArcSwap + watch channels)
-- Zero-downtime config hot-reload — `zion.toml` changes (routes, upstreams, WAF profiles, CORS, rate-limit, XFF policy, trusted proxies) atomic-swap into the running process. Invalid configs are rejected; the previous snapshot survives. Generation counter exposed via Prometheus and `/_zion/snapshot.json`. See [`docs/deploy/hot-reload.md`](https://fabriziosalmi.github.io/zion/deploy/hot-reload).
+- Zero-downtime config hot-reload — `zion.toml` changes (routes, upstreams, WAF profiles, CORS, rate-limit, XFF policy, trusted proxies, **listen ports**) atomic-swap into the running process. Listener rebind: edit `[server.listen_*]`, save, the daemon binds the new address and drains the old one without dropping in-flight connections. Invalid configs and bind failures are rejected; the previous state survives. Generation counter exposed via Prometheus and `/_zion/snapshot.json`. See [`docs/deploy/hot-reload.md`](https://fabriziosalmi.github.io/zion/deploy/hot-reload).
 - Session tickets + 0-RTT early data with method gating (425 Too Early, RFC 8470)
 - ACME auto-renewal via `instant-acme` (HTTP-01, `--features acme`)
 - JWT/OIDC authentication gate (`--features auth`)

--- a/docs/deploy/hot-reload.md
+++ b/docs/deploy/hot-reload.md
@@ -17,6 +17,7 @@ A change to *both* (e.g. swap to a new cert AND rewire routes in one editor save
 
 Everything below is re-applied at the next request after the swap. In-flight requests continue with the snapshot they loaded — see [Snapshot consistency](#snapshot-consistency).
 
+* `[server.listen_http]` / `[server.listen_https]` *(Phase 1.5)* — Zion binds the new address, spawns a fresh accept loop, and tells the previous listener to stop accepting. Connections already accepted by the old listener continue under the connection-limit semaphore until they finish. Bind failures (port in use, permission denied) log a structured WARN and **keep the existing listener** — a typo never strands the daemon. Caveats: see [Listener rebind caveats](#listener-rebind-caveats-phase-15).
 * `[server.rate_limit_rps]`, `[server.rate_limit_window_secs]`
 * `[server.trusted_proxies]`
 * `[server.xff_mode]` (`append` | `rewrite` | `drop`)
@@ -37,15 +38,27 @@ Independent of `zion.toml`, the TLS watcher fires on changes to:
 
 The `ServerConfig` is rebuilt from disk on the blocking thread pool (so file I/O does not stall the runtime), then atomic-swapped. ALPN, session tickets, 0-RTT settings, and mTLS verifier are reconstituted from the same `[tls]` section that is currently loaded.
 
-## Out of scope (Phase 1)
+## Listener rebind caveats (Phase 1.5)
+
+The supervisor that reconciles `listen_*` to live listeners is conservative on purpose. Three behaviours worth pinning explicitly:
+
+1. **Bind failure keeps the existing listener.** If the new address can't be bound — port already in use, no `CAP_NET_BIND_SERVICE` for `:80` / `:443`, malformed string, etc. — the supervisor logs a structured WARN and **does nothing else**. The previous listener keeps serving. There is no fallback, no retry loop; the next config reload (or a manual edit-and-save) gets another shot.
+
+2. **Removing `listen_http` is a no-op.** If `[server.listen_http]` is dropped or set to an empty string in the new config, the supervisor leaves the existing HTTP listener in place. The intent is conservatism — losing the ACME challenge proxy or the 301-to-HTTPS redirect by mistake is a worse outcome than ignoring a possibly-deliberate removal. To stop accepting on `:80`, restart the process. (`listen_https` is treated the same way: an empty/missing value never tears down the existing primary listener.)
+
+3. **`--features io-uring-accept`: HTTPS rebind is not supported.** The uring accept thread is bound to the listener's file descriptor at startup; rebinding would require tearing down and respawning the uring thread, which is out of scope for Phase 1.5. The supervisor logs `HTTPS rebind to X skipped: --features io-uring-accept is incompatible with rebind in Phase 1.5; restart required` and keeps the original listener. HTTP rebind continues to work in this build flavour. Operators who pivot HTTPS ports often should stay off the io_uring feature, or restart on each pivot.
+
+These three rules answer "what happens if I…" deterministically; nothing on the listener supervisor side ever silently degrades availability.
+
+## Out of scope (Phase 1 + Phase 1.5)
 
 These do not hot-reload — they require a process restart:
 
-* `[server.listen_http]` / `[server.listen_https]` — changing a bind address means rebinding sockets. Reserved for a future Phase 1.5; until then, edit, then `systemctl restart zion` (or equivalent).
 * The path of `[tls]` cert/key files in `zion.toml` itself — the cert *content* hot-reloads (TLS watcher reads the current path on each reload), but if you point `cert_path` at a brand-new file, the TLS watcher is still subscribed to the old directory until restart.
 * `[server.log_format]` — read once at startup by `logging::init`. Restart to switch between `text` and `json`.
-* HTTP/3 listener (`--features http3`) — currently rebuilds on TLS reload only; config-side QUIC settings are not hot-applied.
+* HTTP/3 listener (`--features http3`) — currently rebuilds on TLS reload only; config-side QUIC settings (incl. listen address) are not hot-applied.
 * `[tls.acme]` (with `--features acme`) — the renewal task is spawned at boot from the initial config; changing email / domains / state_dir requires restart.
+* `--features io-uring-accept`: HTTPS listener rebind. See caveat above.
 * Build-time toggles: cargo features, allocator, target-cpu.
 
 ## Snapshot consistency

--- a/src/listener.rs
+++ b/src/listener.rs
@@ -1,0 +1,417 @@
+//! Listener supervisor — Phase 1.5 of the dynamic-config plan.
+//!
+//! Watches `state.config` (an `ArcSwap<ResolvedAppConfig>`) for changes
+//! to `listen_http` / `listen_https`. When either differs from the
+//! currently-bound address, attempts a fresh `bind()` on the new address
+//! and replaces the accept-loop task. The OLD accept loop is told to
+//! return via its `watch::Sender<bool>`; live connections it had spawned
+//! continue under the existing connection-limit semaphore until they
+//! finish.
+//!
+//! Failure handling is conservative on purpose: if the new bind fails
+//! (port in use, permission denied, malformed address), the supervisor
+//! logs a structured warning and **keeps the existing listener**. A typo
+//! in `zion.toml` never strands Zion offline.
+//!
+//! Out of scope for Phase 1.5:
+//!   * io_uring multishot accept (`--features io-uring-accept`): the
+//!     uring task is bound to the listener's file descriptor at spawn
+//!     time and cannot be re-pointed without tearing it down. The
+//!     supervisor logs a WARN and skips the rebind in that build flavour.
+//!     Operators on the io_uring path keep the v0.1.7 behaviour:
+//!     `listen_*` is a restart-required setting.
+//!   * QUIC / HTTP/3 listener — its UDP socket is independent and not
+//!     re-bound here.
+
+use crate::{net, run_http_accept_loop, run_https_accept_loop, AppState, ResolvedAppConfig};
+use arc_swap::ArcSwap;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tokio::sync::watch;
+
+/// One bound listener with the channels and handle needed to retire it.
+struct BoundListener {
+    addr: SocketAddr,
+    /// `send(true)` makes the accept loop return on its next iteration.
+    shutdown_tx: watch::Sender<bool>,
+    /// Join handle of the spawned accept loop task. Dropping it does not
+    /// abort the loop — abort happens through `shutdown_tx`.
+    join: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl BoundListener {
+    /// Tell the loop to stop accepting and drop the listener fd. Existing
+    /// connection tasks the loop spawned continue independently.
+    fn retire(self) {
+        let _ = self.shutdown_tx.send(true);
+        // We deliberately don't `await` the join handle here: the
+        // supervisor must keep moving even if the loop is parked on a
+        // long `select!`. The accept loop is well-behaved (it returns on
+        // the next iteration after the shutdown flip) so this is bounded.
+        drop(self.join);
+    }
+}
+
+/// Owns the live HTTP and HTTPS accept loops, reconciling them to the
+/// currently-published `ResolvedAppConfig` snapshot.
+pub(crate) struct ListenerSupervisor {
+    http: Option<BoundListener>,
+    https: Option<BoundListener>,
+    state: Arc<AppState>,
+}
+
+impl ListenerSupervisor {
+    /// Build the supervisor from the initial bind state. Caller has
+    /// already attempted to bind both ports synchronously at boot — we
+    /// just adopt the resulting listeners (or absence thereof, on HTTP).
+    ///
+    /// `https_listener` is `Option<TcpListener>` because the initial
+    /// HTTPS bind may legitimately be deferred or fail in some pathways
+    /// (the supervisor itself will retry on the next config reload).
+    pub(crate) fn new(
+        state: Arc<AppState>,
+        http_listener: Option<(SocketAddr, tokio::net::TcpListener)>,
+        https_listener: Option<(SocketAddr, tokio::net::TcpListener)>,
+    ) -> Self {
+        let http = http_listener.map(|(addr, listener)| {
+            let (tx, rx) = watch::channel(false);
+            let join = tokio::spawn(run_http_accept_loop(listener, state.clone(), rx));
+            BoundListener {
+                addr,
+                shutdown_tx: tx,
+                join: Some(join),
+            }
+        });
+
+        let https = https_listener.map(|(addr, listener)| {
+            let (tx, rx) = watch::channel(false);
+            // The cfg-gated overload is selected at compile time; the
+            // io-uring branch is intentionally NOT spawned by the
+            // supervisor because rebind on uring is unsupported (see
+            // module docstring). The boot-path in main.rs continues to
+            // spawn the uring task itself when that feature is on.
+            #[cfg(not(all(target_os = "linux", feature = "io-uring-accept")))]
+            let join = tokio::spawn(run_https_accept_loop(listener, state.clone(), rx));
+            #[cfg(all(target_os = "linux", feature = "io-uring-accept"))]
+            let join = {
+                // On uring, the supervisor doesn't drive the accept loop
+                // itself — main.rs already spawned `run_https_accept_loop`
+                // with the uring receiver. We register a no-op handle so
+                // the diff/reconcile logic can still observe a "current
+                // address" without owning the task.
+                let _ = (listener, &state);
+                tokio::spawn(async move {
+                    // The shutdown channel is held to keep the supervisor
+                    // structure consistent across both build flavours.
+                    let mut rx = rx;
+                    let _ = rx.changed().await;
+                })
+            };
+            BoundListener {
+                addr,
+                shutdown_tx: tx,
+                join: Some(join),
+            }
+        });
+
+        Self { http, https, state }
+    }
+
+    /// Spawn a background task that listens on `config_change_rx` and
+    /// reconciles the supervisor whenever a successful config reload
+    /// publishes a new snapshot.
+    ///
+    /// `config_change_rx` is bumped by `reload::spawn_config_watcher`
+    /// after every atomic swap. `shutdown_rx` is flipped to `true` by
+    /// `async_main` on SIGINT/SIGTERM and tells the reconciler to retire
+    /// all listeners and return — the returned `JoinHandle` then resolves
+    /// and the caller proceeds to the connection-drain phase.
+    pub(crate) fn spawn_reconciler(
+        mut self,
+        config: Arc<ArcSwap<ResolvedAppConfig>>,
+        mut config_change_rx: watch::Receiver<u64>,
+        mut shutdown_rx: watch::Receiver<bool>,
+    ) -> tokio::task::JoinHandle<()> {
+        tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    biased;
+                    res = shutdown_rx.changed() => {
+                        if res.is_err() || *shutdown_rx.borrow() {
+                            break;
+                        }
+                    }
+                    res = config_change_rx.changed() => {
+                        if res.is_err() {
+                            // Sender side gone — supervised by the main
+                            // task and should not happen before shutdown,
+                            // but treat it as an implicit shutdown rather
+                            // than a hot loop.
+                            break;
+                        }
+                        let snapshot = config.load_full();
+                        self.reconcile(&snapshot).await;
+                    }
+                }
+            }
+            // Retire both listeners so their accept loops exit and we
+            // don't leak file descriptors.
+            if let Some(b) = self.http.take() {
+                b.retire();
+            }
+            if let Some(b) = self.https.take() {
+                b.retire();
+            }
+        })
+    }
+
+    /// Compare the currently bound listeners with what the snapshot wants
+    /// and perform the minimum number of (re)binds. Failures keep the
+    /// existing listener in place.
+    async fn reconcile(&mut self, snapshot: &ResolvedAppConfig) {
+        // ── HTTPS ────────────────────────────────────────────────────
+        // HTTPS is the primary listener; we apply changes first so a
+        // typo in HTTP doesn't keep us from the more important update.
+        if let Some(want) = snapshot.listen_https {
+            self.reconcile_one(ListenerKind::Https, Some(want)).await;
+        }
+        // (If listen_https is None, the parse failed at build time and
+        //  was already logged. We don't tear down the existing HTTPS
+        //  listener over a typo.)
+
+        // ── HTTP ─────────────────────────────────────────────────────
+        // HTTP is optional. `None` here means either the parse failed or
+        // the operator removed the field — the supervisor treats both as
+        // "keep the existing one" rather than risk stranding ACME / 301.
+        if let Some(want) = snapshot.listen_http {
+            self.reconcile_one(ListenerKind::Http, Some(want)).await;
+        }
+    }
+
+    async fn reconcile_one(&mut self, kind: ListenerKind, want: Option<SocketAddr>) {
+        let (slot_addr, _) = match self.slot(kind) {
+            Some(b) => (Some(b.addr), Some(())),
+            None => (None, None),
+        };
+
+        let want = match want {
+            Some(a) => a,
+            None => return, // see reconcile() — None is "no change"
+        };
+
+        if Some(want) == slot_addr {
+            return; // already on the right address
+        }
+
+        // Attempt the new bind on the runtime thread. `bind_with_reuseport`
+        // is std synchronous; it's microseconds, fine inline.
+        let new_listener = match net::bind_with_reuseport(want) {
+            Ok(l) => l,
+            Err(e) => {
+                let kept = slot_addr
+                    .map(|a| a.to_string())
+                    .unwrap_or_else(|| "(none)".to_string());
+                crate::logging::warn(
+                    "listener",
+                    &format!(
+                        "rebind {} {} → {} failed: {} (keeping {})",
+                        kind.label(),
+                        kept,
+                        want,
+                        e,
+                        kept
+                    ),
+                );
+                return;
+            }
+        };
+
+        // Bind succeeded. Spawn the new accept loop on the new listener.
+        let (tx, rx) = watch::channel(false);
+        let new_join = match kind {
+            ListenerKind::Http => tokio::spawn(run_http_accept_loop(
+                new_listener,
+                self.state.clone(),
+                rx,
+            )),
+            ListenerKind::Https => {
+                #[cfg(not(all(target_os = "linux", feature = "io-uring-accept")))]
+                {
+                    tokio::spawn(run_https_accept_loop(new_listener, self.state.clone(), rx))
+                }
+                #[cfg(all(target_os = "linux", feature = "io-uring-accept"))]
+                {
+                    // io_uring rebind is not supported (see module doc).
+                    // Drop the freshly-bound listener and warn — keep
+                    // the previously-bound one alive.
+                    drop(new_listener);
+                    let _ = (rx, tx);
+                    crate::logging::warn(
+                        "listener",
+                        &format!(
+                            "HTTPS rebind to {} skipped: --features io-uring-accept is incompatible with rebind in Phase 1.5; restart required",
+                            want
+                        ),
+                    );
+                    return;
+                }
+            }
+        };
+
+        // Retire the old listener (if any) BEFORE we replace the slot,
+        // so the slot is never observed empty while a request is being
+        // routed by another task.
+        let new_bound = BoundListener {
+            addr: want,
+            shutdown_tx: tx,
+            join: Some(new_join),
+        };
+        let old = self.replace_slot(kind, Some(new_bound));
+        let old_addr_str = old
+            .as_ref()
+            .map(|b| b.addr.to_string())
+            .unwrap_or_else(|| "(none)".to_string());
+        if let Some(old) = old {
+            old.retire();
+        }
+        crate::logging::info(
+            "listener",
+            &format!(
+                "rebound {} {} → {} (old listener draining; live connections continue)",
+                kind.label(),
+                old_addr_str,
+                want
+            ),
+        );
+    }
+
+    fn slot(&self, kind: ListenerKind) -> Option<&BoundListener> {
+        match kind {
+            ListenerKind::Http => self.http.as_ref(),
+            ListenerKind::Https => self.https.as_ref(),
+        }
+    }
+
+    fn replace_slot(
+        &mut self,
+        kind: ListenerKind,
+        new: Option<BoundListener>,
+    ) -> Option<BoundListener> {
+        match kind {
+            ListenerKind::Http => std::mem::replace(&mut self.http, new),
+            ListenerKind::Https => std::mem::replace(&mut self.https, new),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ListenerKind {
+    Http,
+    Https,
+}
+
+impl ListenerKind {
+    fn label(self) -> &'static str {
+        match self {
+            ListenerKind::Http => "HTTP",
+            ListenerKind::Https => "HTTPS",
+        }
+    }
+}
+
+/// Diff between desired and current listener state — pure, testable.
+/// `reconcile_one` does not literally use this enum (the action is
+/// straight-line), but having it as a free function pins the contract
+/// in tests so a future refactor cannot silently regress it.
+#[cfg(test)]
+pub(crate) fn diff(
+    current: Option<SocketAddr>,
+    desired: Option<SocketAddr>,
+) -> ListenerDiff {
+    match (current, desired) {
+        (None, None) => ListenerDiff::Same,
+        (Some(c), Some(d)) if c == d => ListenerDiff::Same,
+        (Some(c), Some(d)) => ListenerDiff::Rebind { from: c, to: d },
+        (None, Some(d)) => ListenerDiff::Add(d),
+        (Some(c), None) => ListenerDiff::Remove(c),
+    }
+}
+
+#[cfg(test)]
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum ListenerDiff {
+    Same,
+    Rebind { from: SocketAddr, to: SocketAddr },
+    Add(SocketAddr),
+    Remove(SocketAddr),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn s(addr: &str) -> SocketAddr {
+        addr.parse().unwrap()
+    }
+
+    #[test]
+    fn diff_same_when_both_none() {
+        assert_eq!(diff(None, None), ListenerDiff::Same);
+    }
+
+    #[test]
+    fn diff_same_when_both_equal() {
+        let a = s("127.0.0.1:8080");
+        assert_eq!(diff(Some(a), Some(a)), ListenerDiff::Same);
+    }
+
+    #[test]
+    fn diff_rebind_on_change() {
+        let from = s("127.0.0.1:8080");
+        let to = s("127.0.0.1:8081");
+        assert_eq!(
+            diff(Some(from), Some(to)),
+            ListenerDiff::Rebind { from, to }
+        );
+    }
+
+    #[test]
+    fn diff_add_when_was_none() {
+        let to = s("0.0.0.0:80");
+        assert_eq!(diff(None, Some(to)), ListenerDiff::Add(to));
+    }
+
+    #[test]
+    fn diff_remove_when_now_none() {
+        // Note: the supervisor itself does NOT act on Remove (we never
+        // tear down the existing HTTP/HTTPS over a missing field — see
+        // `reconcile()`), but the diff itself is total and tested for
+        // future use cases.
+        let from = s("0.0.0.0:80");
+        assert_eq!(diff(Some(from), None), ListenerDiff::Remove(from));
+    }
+
+    /// Cross-IP-family change (v4 → v6) is a real rebind, not a Same.
+    #[test]
+    fn diff_recognises_v4_to_v6_change() {
+        let v4 = s("127.0.0.1:8080");
+        let v6 = s("[::1]:8080");
+        assert_eq!(
+            diff(Some(v4), Some(v6)),
+            ListenerDiff::Rebind { from: v4, to: v6 }
+        );
+    }
+
+    /// Same port, different bind interface (`0.0.0.0` ≠ `127.0.0.1`)
+    /// counts as a rebind. The supervisor must take the right action
+    /// here even though the port portion is unchanged.
+    #[test]
+    fn diff_recognises_interface_change_at_same_port() {
+        let any = s("0.0.0.0:8080");
+        let lo = s("127.0.0.1:8080");
+        assert_eq!(
+            diff(Some(any), Some(lo)),
+            ListenerDiff::Rebind { from: any, to: lo }
+        );
+    }
+}

--- a/src/listener.rs
+++ b/src/listener.rs
@@ -23,7 +23,13 @@
 //!   * QUIC / HTTP/3 listener — its UDP socket is independent and not
 //!     re-bound here.
 
-use crate::{net, run_http_accept_loop, run_https_accept_loop, AppState, ResolvedAppConfig};
+use crate::{net, run_http_accept_loop, AppState, ResolvedAppConfig};
+// `run_https_accept_loop` is only spawned by the supervisor in the
+// non-io_uring build flavour; on `--features io-uring-accept` the
+// accept loop is owned by the uring thread spawned in `async_main`
+// and the supervisor never calls it.
+#[cfg(not(all(target_os = "linux", feature = "io-uring-accept")))]
+use crate::run_https_accept_loop;
 use arc_swap::ArcSwap;
 use std::net::SocketAddr;
 use std::sync::Arc;

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ mod config;
 mod doctor;
 mod health;
 mod init;
+mod listener;
 mod logging;
 mod metrics;
 mod net;
@@ -129,6 +130,14 @@ pub(crate) struct ResolvedAppConfig {
     pub(crate) rate_limit_rps: u32,
     /// Rate limiter window in seconds.
     pub(crate) rate_limit_window: u64,
+    /// Pre-parsed listen address for plain HTTP. `None` if the config
+    /// string is malformed; the listener supervisor logs the parse error
+    /// at reload time and keeps the previously-bound listener.
+    pub(crate) listen_http: Option<SocketAddr>,
+    /// Pre-parsed listen address for HTTPS. `None` only if the string is
+    /// malformed; the supervisor refuses to drop the existing listener
+    /// in that case (the previous valid bind survives the reload).
+    pub(crate) listen_https: Option<SocketAddr>,
 }
 
 impl ResolvedAppConfig {
@@ -148,6 +157,8 @@ impl ResolvedAppConfig {
             xff_mode: proxy::XffMode::Append,
             rate_limit_rps: 0,
             rate_limit_window: 1,
+            listen_http: None,
+            listen_https: None,
         }
     }
 
@@ -192,6 +203,39 @@ impl ResolvedAppConfig {
         // redundant — we just take the parsed value.
         let xff_mode = proxy::XffMode::parse(&config.server.xff_mode).unwrap_or_default();
 
+        // Parse listen addresses once at build time. A malformed string
+        // logs a structured warning and yields `None`; the listener
+        // supervisor refuses to drop the existing listener in that case,
+        // so a typo in zion.toml never strands the daemon offline.
+        let listen_http = config
+            .server
+            .listen_http
+            .parse::<SocketAddr>()
+            .map_err(|e| {
+                logging::warn(
+                    "config",
+                    &format!(
+                        "server.listen_http '{}' is not a valid socket address: {}",
+                        config.server.listen_http, e
+                    ),
+                );
+            })
+            .ok();
+        let listen_https = config
+            .server
+            .listen_https
+            .parse::<SocketAddr>()
+            .map_err(|e| {
+                logging::warn(
+                    "config",
+                    &format!(
+                        "server.listen_https '{}' is not a valid socket address: {}",
+                        config.server.listen_https, e
+                    ),
+                );
+            })
+            .ok();
+
         Self {
             router,
             health_map,
@@ -199,6 +243,8 @@ impl ResolvedAppConfig {
             xff_mode,
             rate_limit_rps: config.server.rate_limit_rps,
             rate_limit_window: config.server.rate_limit_window_secs,
+            listen_http,
+            listen_https,
         }
     }
 }
@@ -477,7 +523,16 @@ async fn async_main(
         }),
     });
 
-    // 5b. Spawn the config-file hot-reload watcher. Watches `zion.toml`
+    // 5b. Phase 1.5 channels.
+    //  * `config_change_*` is bumped by the config watcher after every
+    //    successful swap; the listener supervisor (built later) uses it
+    //    to know when to reconcile bind addresses.
+    //  * `super_shutdown_*` is flipped to `true` on SIGINT/SIGTERM by
+    //    the main task and tells the supervisor to retire all listeners.
+    let (config_change_tx, config_change_rx) = tokio::sync::watch::channel(0u64);
+    let (super_shutdown_tx, super_shutdown_rx) = tokio::sync::watch::channel(false);
+
+    // 5c. Spawn the config-file hot-reload watcher. Watches `zion.toml`
     // for Modify/Create events; on change, parses + validates the new
     // config and atomic-swaps `state.config`. Invalid configs are
     // rejected with a WARN log, the previous snapshot stays in place.
@@ -485,7 +540,11 @@ async fn async_main(
     // re-applied through this watcher — the existing `tls_watcher`
     // covers cert/key file changes; pivoting `[tls]` paths is a
     // separate hot-reload step beyond Phase 1.
-    reload::spawn_config_watcher(config_path.clone().into(), state.config.clone());
+    reload::spawn_config_watcher(
+        config_path.clone().into(),
+        state.config.clone(),
+        Some(config_change_tx),
+    );
 
     // 6. Spawn ACME auto-renewal task (if configured)
     if let Some(ref acme_config) = config.tls.acme {
@@ -676,57 +735,61 @@ async fn async_main(
         });
     }
 
-    // 9. Bind HTTP listener (port 80) synchronously so the boot order is
-    // deterministic — HTTP "listening" is printed before HTTPS, before READY.
-    // If the bind fails (e.g. EACCES on :80 without privileges) we don't kill
-    // startup; HTTPS is the primary listener.
+    // 9. Initial bind: HTTP (port 80, optional) + HTTPS (port 443, primary).
+    // HTTP bind failures are non-fatal (no CAP_NET_BIND_SERVICE on a
+    // dev machine, port already in use, etc.); the listener supervisor
+    // will retry on the next config reload. HTTPS bind failure at boot
+    // is a hard error — there is nothing useful to do without it.
     let http_addr: SocketAddr = config.server.listen_http.parse()?;
-    let http_listener = match net::bind_with_reuseport(http_addr) {
-        Ok(l) => {
-            eprintln!("  listening HTTP  on {}", http_addr);
-            Some(l)
-        }
-        Err(e) => {
-            eprintln!(
-                "  warning: HTTP listener on {} unavailable: {}",
-                http_addr, e
-            );
-            None
-        }
-    };
+    let http_initial: Option<(SocketAddr, tokio::net::TcpListener)> =
+        match net::bind_with_reuseport(http_addr) {
+            Ok(l) => {
+                eprintln!("  listening HTTP  on {}", http_addr);
+                Some((http_addr, l))
+            }
+            Err(e) => {
+                eprintln!(
+                    "  warning: HTTP listener on {} unavailable: {}",
+                    http_addr, e
+                );
+                None
+            }
+        };
 
-    // 10. Main HTTPS listener (port 443) — bind synchronously, log, then later
-    // enter the accept loop on the main task.
     let https_addr: SocketAddr = config.server.listen_https.parse()?;
-    let listener = net::bind_with_reuseport(https_addr)?;
+    let https_listener = net::bind_with_reuseport(https_addr)?;
     eprintln!("  listening HTTPS on {}", https_addr);
 
-    // 11. Spawn the HTTP accept loop. The loop is now a free function
-    // (`run_http_accept_loop`) so Phase 1.5 can spawn / drain / respawn it
-    // when `[server.listen_http]` changes — Phase 1 just spawns it once.
-    // A `watch::Receiver<bool>` is reserved for that future use; in this
-    // refactor we hold the sender for the lifetime of the process so the
-    // channel never closes (which would otherwise terminate the loop on
-    // its first poll of `changed()`).
-    let (accept_shutdown_tx, accept_shutdown_rx) = tokio::sync::watch::channel(false);
-    if let Some(http_listener) = http_listener {
-        tokio::spawn(run_http_accept_loop(
-            http_listener,
-            state.clone(),
-            accept_shutdown_rx.clone(),
-        ));
-    }
-
-    // io_uring multishot accept on Linux (one syscall for N connections)
+    // io_uring multishot accept on Linux (one syscall for N connections).
+    // The uring task is bound to the listener's fd at spawn time and the
+    // listener supervisor explicitly does NOT manage HTTPS rebind in this
+    // build flavour — that limitation is documented in `listener.rs`.
+    // Operators using io_uring keep the v0.1.7 behaviour for `listen_https`
+    // (restart required for port changes).
     #[cfg(all(target_os = "linux", feature = "io-uring-accept"))]
-    let mut uring_rx = {
+    let https_initial: Option<(SocketAddr, tokio::net::TcpListener)> = {
         use std::os::unix::io::AsRawFd;
-        let fd = listener.as_raw_fd();
+        let fd = https_listener.as_raw_fd();
         eprintln!("  io_uring multishot accept enabled");
-        uring::spawn_uring_accept(fd, 4096)
+        let uring_rx = uring::spawn_uring_accept(fd, 4096);
+        // Spawn the accept loop ourselves; pass `https_initial = None`
+        // to the supervisor so it tracks no HTTPS slot.
+        let (tx, rx) = tokio::sync::watch::channel(false);
+        let _ = tx; // sender held by main task lifetime; supervisor doesn't touch this loop
+        tokio::spawn(run_https_accept_loop(
+            https_listener,
+            state.clone(),
+            rx,
+            Some(uring_rx),
+        ));
+        None
     };
+    #[cfg(not(all(target_os = "linux", feature = "io-uring-accept")))]
+    let https_initial: Option<(SocketAddr, tokio::net::TcpListener)> =
+        Some((https_addr, https_listener));
 
-    // 10b. Spawn HTTP/3 (QUIC) listener on same port (UDP)
+    // 10. HTTP/3 (QUIC) listener on UDP — independent of the supervisor.
+    // QUIC listen-port hot-reload is out of scope for Phase 1.5.
     #[cfg(feature = "http3")]
     {
         let quic_addr: SocketAddr = config
@@ -739,37 +802,28 @@ async fn async_main(
 
     bootstrap::print_ready_banner(&config.server.listen_http, &config.server.listen_https);
 
-    // Spawn the HTTPS accept loop on its own task — same shape as the HTTP
-    // loop above. The accept-loop functions stop on the next iteration when
-    // `accept_shutdown_tx` flips to `true`; we wait on `shutdown_signal()`
-    // here in the main task and then trigger it.
-    let https_handle = {
-        let state = state.clone();
-        let shutdown_rx = accept_shutdown_rx.clone();
-        #[cfg(all(target_os = "linux", feature = "io-uring-accept"))]
-        {
-            tokio::spawn(run_https_accept_loop(
-                listener,
-                state,
-                shutdown_rx,
-                Some(uring_rx),
-            ))
-        }
-        #[cfg(not(all(target_os = "linux", feature = "io-uring-accept")))]
-        {
-            tokio::spawn(run_https_accept_loop(listener, state, shutdown_rx))
-        }
-    };
+    // 11. Build the listener supervisor. It owns the HTTP/HTTPS accept
+    // loops and reconciles them when `state.config` is hot-swapped to a
+    // new snapshot whose `listen_*` differs. On io_uring the supervisor
+    // is `https_initial = None`: it will log a WARN and refuse to rebind
+    // HTTPS (the uring task above already drives the accept loop on the
+    // initial listener for the lifetime of the process).
+    let supervisor = listener::ListenerSupervisor::new(state.clone(), http_initial, https_initial);
+    let supervisor_handle = supervisor.spawn_reconciler(
+        state.config.clone(),
+        config_change_rx,
+        super_shutdown_rx,
+    );
 
     shutdown_signal().await;
     logging::info("shutdown", "signal received, draining in-flight connections...");
-    // Tell the accept loops to stop accepting new connections. Existing
-    // tasks (one per accepted connection) continue independently and are
-    // drained by the semaphore wait below.
-    let _ = accept_shutdown_tx.send(true);
-    // Best-effort wait on the HTTPS accept loop to exit cleanly. Bounded
-    // by the same drain timeout below — if it hangs we don't block forever.
-    let _ = tokio::time::timeout(std::time::Duration::from_secs(2), https_handle).await;
+    // Tell the supervisor to retire all listeners. Its accept loops stop
+    // on the next iteration; spawned per-connection tasks continue and
+    // are drained by the semaphore wait below.
+    let _ = super_shutdown_tx.send(true);
+    // Best-effort wait on the supervisor to exit cleanly. Bounded by 2s
+    // so a stuck reconcile does not block process shutdown.
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(2), supervisor_handle).await;
 
     // Graceful drain: wait for in-flight connections to complete.
     // conn_limit has MAX permits; available = MAX - in_flight.

--- a/src/main.rs
+++ b/src/main.rs
@@ -701,36 +701,20 @@ async fn async_main(
     let listener = net::bind_with_reuseport(https_addr)?;
     eprintln!("  listening HTTPS on {}", https_addr);
 
-    // 11. Spawn the HTTP accept loop now that the listener is bound and logged.
+    // 11. Spawn the HTTP accept loop. The loop is now a free function
+    // (`run_http_accept_loop`) so Phase 1.5 can spawn / drain / respawn it
+    // when `[server.listen_http]` changes — Phase 1 just spawns it once.
+    // A `watch::Receiver<bool>` is reserved for that future use; in this
+    // refactor we hold the sender for the lifetime of the process so the
+    // channel never closes (which would otherwise terminate the loop on
+    // its first poll of `changed()`).
+    let (accept_shutdown_tx, accept_shutdown_rx) = tokio::sync::watch::channel(false);
     if let Some(http_listener) = http_listener {
-        let state_http = state.clone();
-        tokio::spawn(async move {
-            loop {
-                let (stream, addr) = match http_listener.accept().await {
-                    Ok(conn) => conn,
-                    Err(e) => {
-                        eprintln!("  http accept error: {}", e);
-                        continue;
-                    }
-                };
-
-                let state = state_http.clone();
-                let builder = state.http_builder.clone();
-                tokio::spawn(async move {
-                    let io = TokioIo::new(stream);
-                    let _ = builder
-                        .serve_connection(
-                            io,
-                            service_fn(move |req| {
-                                use http_body_util::BodyExt;
-                                let req_boxed = req.map(|b: hyper::body::Incoming| b.boxed());
-                                handle_http(req_boxed, state.clone(), addr)
-                            }),
-                        )
-                        .await;
-                });
-            }
-        });
+        tokio::spawn(run_http_accept_loop(
+            http_listener,
+            state.clone(),
+            accept_shutdown_rx.clone(),
+        ));
     }
 
     // io_uring multishot accept on Linux (one syscall for N connections)
@@ -755,171 +739,37 @@ async fn async_main(
 
     bootstrap::print_ready_banner(&config.server.listen_http, &config.server.listen_https);
 
-    let mut shutdown = std::pin::pin!(shutdown_signal());
-
-    loop {
-        // Accept path: io_uring on Linux, standard tokio everywhere else
-        let accepted: Option<(tokio::net::TcpStream, SocketAddr)>;
-
+    // Spawn the HTTPS accept loop on its own task — same shape as the HTTP
+    // loop above. The accept-loop functions stop on the next iteration when
+    // `accept_shutdown_tx` flips to `true`; we wait on `shutdown_signal()`
+    // here in the main task and then trigger it.
+    let https_handle = {
+        let state = state.clone();
+        let shutdown_rx = accept_shutdown_rx.clone();
         #[cfg(all(target_os = "linux", feature = "io-uring-accept"))]
         {
-            tokio::select! {
-                conn = uring_rx.recv() => {
-                    accepted = conn.map(|c| (c.stream, c.addr));
-                }
-                _ = &mut shutdown => {
-                    logging::info("shutdown", "signal received, draining in-flight connections...");
-                    break;
-                }
-            }
+            tokio::spawn(run_https_accept_loop(
+                listener,
+                state,
+                shutdown_rx,
+                Some(uring_rx),
+            ))
         }
-
         #[cfg(not(all(target_os = "linux", feature = "io-uring-accept")))]
         {
-            tokio::select! {
-                result = listener.accept() => {
-                    match result {
-                        Ok(conn) => { accepted = Some(conn); }
-                        Err(e) => {
-                            eprintln!("  https accept error: {}", e);
-                            accepted = None;
-                        }
-                    }
-                }
-                _ = &mut shutdown => {
-                    logging::info("shutdown", "signal received, draining in-flight connections...");
-                    break;
-                }
-            }
+            tokio::spawn(run_https_accept_loop(listener, state, shutdown_rx))
         }
+    };
 
-        let Some((tcp_stream, remote_addr)) = accepted else {
-            continue;
-        };
-
-        // Connection limit — fast atomic check, no Arc clone
-        let permit = match state.conn_limit.clone().try_acquire_owned() {
-            Ok(p) => p,
-            Err(_) => {
-                drop(tcp_stream);
-                continue;
-            }
-        };
-
-        let state = state.clone();
-        let acceptor = state.tls_acceptor.load_full();
-        let builder = state.http_builder.clone();
-
-        tokio::spawn(async move {
-            let _permit = permit;
-            let _conn_guard = metrics::ConnectionGuard::new();
-            let _ = tcp_stream.set_nodelay(true);
-            net::tune_accepted(&tcp_stream);
-            metrics::METRICS
-                .connections_total
-                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-
-            let tls_start = std::time::Instant::now();
-            let mut tls_stream = match tokio::time::timeout(
-                std::time::Duration::from_secs(10),
-                (*acceptor).accept(tcp_stream),
-            )
-            .await
-            {
-                Ok(Ok(s)) => {
-                    metrics::METRICS
-                        .tls_handshake_duration
-                        .observe(tls_start.elapsed());
-                    s
-                }
-                _ => {
-                    metrics::METRICS
-                        .tls_handshake_errors
-                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                    return;
-                }
-            };
-
-            // 0-RTT: Check if this connection accepted early data.
-            // Only the first request on the connection can be early data.
-            // We pass this flag to handle_https for method gating (425 Too Early).
-            // rustls ServerConnection::early_data() returns Some if 0-RTT was
-            // accepted during the handshake (was_accepted() flag persists).
-            let is_early_data = tls_stream.get_mut().1.early_data().is_some();
-            let early_flag = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(is_early_data));
-
-            // mTLS: extract a stable, collision-resistant identifier for the
-            // peer certificate. SHA-256 of the leaf DER, hex-encoded with a
-            // `sha256:` prefix — same convention as openssl/nginx
-            // ($ssl_client_fingerprint) and CA tooling. Forwarded as
-            // `X-Client-Cert-Fingerprint`. Upstream apps can map fingerprint
-            // → identity via their own roster; Zion does NOT claim this is a
-            // Distinguished Name (the previous header `X-Client-Cert-DN` was
-            // a 64-bit XOR-fold and was removed because it implied semantics
-            // it could not provide and was unsafe for ACL use).
-            let client_cert_fingerprint: Option<String> = tls_stream
-                .get_ref()
-                .1
-                .peer_certificates()
-                .and_then(|certs| certs.first())
-                .map(|cert| {
-                    let der = cert.as_ref();
-                    let digest = aws_lc_rs::digest::digest(&aws_lc_rs::digest::SHA256, der);
-                    let bytes = digest.as_ref();
-                    let mut s = String::with_capacity(7 + bytes.len() * 2);
-                    s.push_str("sha256:");
-                    for &b in bytes {
-                        s.push(HEX_DIGITS[(b >> 4) as usize] as char);
-                        s.push(HEX_DIGITS[(b & 0xF) as usize] as char);
-                    }
-                    s
-                });
-            let client_fp = client_cert_fingerprint.map(std::sync::Arc::new);
-
-            let io = TokioIo::new(tls_stream);
-            // Connection-level idle timeout. Set high (1 hour) because this
-            // wraps the entire HTTP/2 mux / WebSocket / SSE connection, not
-            // individual requests. Per-request timeouts are in process_request.
-            let _ = tokio::time::timeout(
-                std::time::Duration::from_secs(3600),
-                builder.serve_connection_with_upgrades(
-                    io,
-                    service_fn(move |mut req: Request<Incoming>| {
-                        let state = state.clone();
-                        let early_flag = early_flag.clone();
-                        let client_fp = client_fp.clone();
-                        async move {
-                            // Fast-path: health probes bypass the full pipeline (~1us vs ~5us)
-                            let path = req.uri().path();
-                            if path == "/healthz" {
-                                return Ok(text_response(StatusCode::OK, "ok"));
-                            }
-                            if path == "/readyz" {
-                                return Ok(text_response(StatusCode::OK, "ready"));
-                            }
-
-                            // Consume early_data flag on first request
-                            let was_early =
-                                early_flag.swap(false, std::sync::atomic::Ordering::Relaxed);
-                            // Inject client cert fingerprint if mTLS authenticated.
-                            // Format: "sha256:HEX..." (64 hex chars). All bytes are
-                            // ASCII, so HeaderValue::from_str cannot fail in practice;
-                            // we still handle the Result for safety.
-                            if let Some(ref fp) = client_fp {
-                                if let Ok(val) = hyper::header::HeaderValue::from_str(fp) {
-                                    req.headers_mut().insert("X-Client-Cert-Fingerprint", val);
-                                }
-                            }
-                            use http_body_util::BodyExt;
-                            let req_boxed = req.map(|b: hyper::body::Incoming| b.boxed());
-                            process_request(req_boxed, state, remote_addr, was_early).await
-                        }
-                    }),
-                ),
-            )
-            .await;
-        });
-    }
+    shutdown_signal().await;
+    logging::info("shutdown", "signal received, draining in-flight connections...");
+    // Tell the accept loops to stop accepting new connections. Existing
+    // tasks (one per accepted connection) continue independently and are
+    // drained by the semaphore wait below.
+    let _ = accept_shutdown_tx.send(true);
+    // Best-effort wait on the HTTPS accept loop to exit cleanly. Bounded
+    // by the same drain timeout below — if it hangs we don't block forever.
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(2), https_handle).await;
 
     // Graceful drain: wait for in-flight connections to complete.
     // conn_limit has MAX permits; available = MAX - in_flight.
@@ -965,6 +815,253 @@ async fn async_main(
 }
 
 // Network socket helpers (bind_with_reuseport, tune_accepted) are in net.rs.
+
+// ──────────────────────────────────────────────────────────────────────
+// Accept-loop functions
+//
+// Extracted as free functions in Phase 1.5 so that the listener
+// supervisor can spawn / drain / respawn them when `[server.listen_*]`
+// changes in `zion.toml`. Behaviour is identical to the previous
+// inline `tokio::spawn(async move { ... })` blocks; the only addition
+// is a `watch::Receiver<bool>` shutdown channel that lets the main
+// task tell the loops to stop accepting (existing connection tasks
+// continue independently).
+// ──────────────────────────────────────────────────────────────────────
+
+/// Run the plain-HTTP accept loop on the given listener until
+/// `shutdown_rx` flips to `true` or the channel closes. New incoming
+/// TCP connections are spawned as detached tasks; the loop never owns
+/// them, so terminating the loop does not interrupt active requests.
+async fn run_http_accept_loop(
+    http_listener: tokio::net::TcpListener,
+    state: Arc<AppState>,
+    mut shutdown_rx: tokio::sync::watch::Receiver<bool>,
+) {
+    loop {
+        tokio::select! {
+            biased;
+            res = shutdown_rx.changed() => {
+                // Either the sender flipped to `true` or the channel closed.
+                // In both cases we stop accepting; live connections continue.
+                if res.is_err() || *shutdown_rx.borrow() {
+                    return;
+                }
+            }
+            accept = http_listener.accept() => {
+                let (stream, addr) = match accept {
+                    Ok(c) => c,
+                    Err(e) => {
+                        eprintln!("  http accept error: {}", e);
+                        continue;
+                    }
+                };
+                let conn_state = state.clone();
+                let builder = state.http_builder.clone();
+                tokio::spawn(handle_http_connection(stream, addr, conn_state, builder));
+            }
+        }
+    }
+}
+
+/// Single HTTP/1.1 connection on port 80 — runs until the client closes.
+/// Extracted from the previous inline spawn; behaviour unchanged.
+async fn handle_http_connection(
+    stream: tokio::net::TcpStream,
+    addr: SocketAddr,
+    state: Arc<AppState>,
+    builder: Arc<AutoBuilder<TokioExecutor>>,
+) {
+    let io = TokioIo::new(stream);
+    let _ = builder
+        .serve_connection(
+            io,
+            service_fn(move |req| {
+                use http_body_util::BodyExt;
+                let req_boxed = req.map(|b: hyper::body::Incoming| b.boxed());
+                handle_http(req_boxed, state.clone(), addr)
+            }),
+        )
+        .await;
+}
+
+/// Run the HTTPS / TLS accept loop. On non-Linux or without the
+/// `io-uring-accept` feature this is a plain `listener.accept()` loop;
+/// with `io-uring-accept` the accepted-connection stream is consumed
+/// from the kernel-batched receiver instead. The two paths are
+/// cfg-gated to avoid pulling io_uring symbols on platforms that
+/// don't have them.
+#[cfg(not(all(target_os = "linux", feature = "io-uring-accept")))]
+async fn run_https_accept_loop(
+    listener: tokio::net::TcpListener,
+    state: Arc<AppState>,
+    mut shutdown_rx: tokio::sync::watch::Receiver<bool>,
+) {
+    loop {
+        tokio::select! {
+            biased;
+            res = shutdown_rx.changed() => {
+                if res.is_err() || *shutdown_rx.borrow() {
+                    return;
+                }
+            }
+            accept = listener.accept() => {
+                let (tcp_stream, remote_addr) = match accept {
+                    Ok(c) => c,
+                    Err(e) => {
+                        eprintln!("  https accept error: {}", e);
+                        continue;
+                    }
+                };
+                spawn_https_handler(tcp_stream, remote_addr, state.clone());
+            }
+        }
+    }
+}
+
+#[cfg(all(target_os = "linux", feature = "io-uring-accept"))]
+async fn run_https_accept_loop(
+    _listener: tokio::net::TcpListener,
+    state: Arc<AppState>,
+    mut shutdown_rx: tokio::sync::watch::Receiver<bool>,
+    mut uring_rx: Option<tokio::sync::mpsc::Receiver<uring::AcceptedConn>>,
+) {
+    let Some(mut uring_rx) = uring_rx.take() else {
+        return;
+    };
+    loop {
+        tokio::select! {
+            biased;
+            res = shutdown_rx.changed() => {
+                if res.is_err() || *shutdown_rx.borrow() {
+                    return;
+                }
+            }
+            conn = uring_rx.recv() => {
+                let Some(conn) = conn else { return; };
+                spawn_https_handler(conn.stream, conn.addr, state.clone());
+            }
+        }
+    }
+}
+
+/// Common path for spawning a single HTTPS connection task: enforces
+/// the connection-limit semaphore, performs the TLS handshake, extracts
+/// 0-RTT and mTLS-fingerprint context, then drives `serve_connection_with_upgrades`.
+fn spawn_https_handler(
+    tcp_stream: tokio::net::TcpStream,
+    remote_addr: SocketAddr,
+    state: Arc<AppState>,
+) {
+    // Connection limit — fast atomic check, no Arc clone.
+    let permit = match state.conn_limit.clone().try_acquire_owned() {
+        Ok(p) => p,
+        Err(_) => {
+            drop(tcp_stream);
+            return;
+        }
+    };
+
+    let acceptor = state.tls_acceptor.load_full();
+    let builder = state.http_builder.clone();
+
+    tokio::spawn(async move {
+        let _permit = permit;
+        let _conn_guard = metrics::ConnectionGuard::new();
+        let _ = tcp_stream.set_nodelay(true);
+        net::tune_accepted(&tcp_stream);
+        metrics::METRICS
+            .connections_total
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
+        let tls_start = std::time::Instant::now();
+        let mut tls_stream = match tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            (*acceptor).accept(tcp_stream),
+        )
+        .await
+        {
+            Ok(Ok(s)) => {
+                metrics::METRICS
+                    .tls_handshake_duration
+                    .observe(tls_start.elapsed());
+                s
+            }
+            _ => {
+                metrics::METRICS
+                    .tls_handshake_errors
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                return;
+            }
+        };
+
+        // 0-RTT: Check if this connection accepted early data. Only the
+        // first request on the connection can be early data. We pass
+        // this flag to handle_https for method gating (425 Too Early).
+        let is_early_data = tls_stream.get_mut().1.early_data().is_some();
+        let early_flag = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(is_early_data));
+
+        // mTLS: stable SHA-256 fingerprint of the leaf cert DER. See the
+        // module-level rationale in v0.1.7 — replaced the previous XOR
+        // pseudo-DN. Forwarded as `X-Client-Cert-Fingerprint`.
+        let client_cert_fingerprint: Option<String> = tls_stream
+            .get_ref()
+            .1
+            .peer_certificates()
+            .and_then(|certs| certs.first())
+            .map(|cert| {
+                let der = cert.as_ref();
+                let digest = aws_lc_rs::digest::digest(&aws_lc_rs::digest::SHA256, der);
+                let bytes = digest.as_ref();
+                let mut s = String::with_capacity(7 + bytes.len() * 2);
+                s.push_str("sha256:");
+                for &b in bytes {
+                    s.push(HEX_DIGITS[(b >> 4) as usize] as char);
+                    s.push(HEX_DIGITS[(b & 0xF) as usize] as char);
+                }
+                s
+            });
+        let client_fp = client_cert_fingerprint.map(std::sync::Arc::new);
+
+        let io = TokioIo::new(tls_stream);
+        // Connection-level idle timeout. 1h to cover long-lived HTTP/2
+        // mux / WebSocket / SSE; per-request timeouts are in process_request.
+        let _ = tokio::time::timeout(
+            std::time::Duration::from_secs(3600),
+            builder.serve_connection_with_upgrades(
+                io,
+                service_fn(move |mut req: Request<Incoming>| {
+                    let state = state.clone();
+                    let early_flag = early_flag.clone();
+                    let client_fp = client_fp.clone();
+                    async move {
+                        // Fast-path: health probes bypass the full pipeline (~1us vs ~5us).
+                        let path = req.uri().path();
+                        if path == "/healthz" {
+                            return Ok(text_response(StatusCode::OK, "ok"));
+                        }
+                        if path == "/readyz" {
+                            return Ok(text_response(StatusCode::OK, "ready"));
+                        }
+
+                        // Consume early_data flag on first request.
+                        let was_early =
+                            early_flag.swap(false, std::sync::atomic::Ordering::Relaxed);
+                        // Inject mTLS fingerprint header if the peer presented a cert.
+                        if let Some(ref fp) = client_fp {
+                            if let Ok(val) = hyper::header::HeaderValue::from_str(fp) {
+                                req.headers_mut().insert("X-Client-Cert-Fingerprint", val);
+                            }
+                        }
+                        use http_body_util::BodyExt;
+                        let req_boxed = req.map(|b: hyper::body::Incoming| b.boxed());
+                        process_request(req_boxed, state, remote_addr, was_early).await
+                    }
+                }),
+            ),
+        )
+        .await;
+    });
+}
 
 /// Wait for SIGINT (Ctrl+C) or SIGTERM.
 async fn shutdown_signal() {

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -86,9 +86,15 @@ fn rebuild(new_config: &ZionConfig, previous: &ResolvedAppConfig) -> ResolvedApp
 
 /// Spawn the config-file watcher. Returns immediately; the actual
 /// watching runs on a tokio task and a debounce-and-reload task.
+///
+/// `change_notifier`, if provided, is `send`'d the new generation
+/// number after every successful swap. Phase 1.5 wires the listener
+/// supervisor to this channel so a `[server.listen_*]` change kicks
+/// in within the watcher's debounce window.
 pub(crate) fn spawn_config_watcher(
     config_path: PathBuf,
     state_config: Arc<ArcSwap<ResolvedAppConfig>>,
+    change_notifier: Option<tokio::sync::watch::Sender<u64>>,
 ) {
     let signal = Arc::new(Notify::new());
     let signal_for_watcher = signal.clone();
@@ -185,6 +191,14 @@ pub(crate) fn spawn_config_watcher(
                     let new_snapshot = rebuild(&new_config, &previous);
                     state_config.store(Arc::new(new_snapshot));
                     let gen = CONFIG_GENERATION.fetch_add(1, Ordering::Release) + 1;
+                    if let Some(tx) = change_notifier.as_ref() {
+                        // Best-effort: sending into a watch channel only
+                        // fails if there are no live receivers. We don't
+                        // care — the supervisor's missing receiver is the
+                        // operator's problem to debug, not a reason to
+                        // refuse the reload.
+                        let _ = tx.send(gen);
+                    }
                     logging::info(
                         "config_watcher",
                         &format!("reload OK (gen {} → {})", gen - 1, gen),

--- a/src/uring.rs
+++ b/src/uring.rs
@@ -157,9 +157,16 @@ mod inner {
     }
 }
 
-// Only `spawn_uring_accept` is consumed externally (by main.rs).
-// `AcceptedConn` is the channel item type — internal to this module —
-// and was previously re-exported but never used by any caller, so the
-// re-export was dead.
+// `spawn_uring_accept` is consumed externally (main.rs spawns the
+// uring accept thread). `AcceptedConn` re-export is required because
+// the cfg-gated `run_https_accept_loop` signature in main.rs names it
+// in its parameter list — without the re-export the type is reachable
+// only as `inner::AcceptedConn`, which is an inaccessible private path.
+//
+// (The re-export was removed once in v0.1.7 as suspected dead code;
+// Phase 1.5 reintroduced the dependency by giving the io_uring branch
+// an `Option<Receiver<AcceptedConn>>` parameter rather than hiding the
+// receiver inside a dyn-typed boundary. Re-exposing the type here is
+// the smallest fix.)
 #[cfg(all(target_os = "linux", feature = "io-uring-accept"))]
-pub use inner::spawn_uring_accept;
+pub use inner::{spawn_uring_accept, AcceptedConn};


### PR DESCRIPTION
Edit `[server.listen_http]` or `[server.listen_https]` in `zion.toml`, save, and the daemon binds the new address, spawns a fresh accept loop, and drains the previous listener — all without restart, without dropping in-flight connections. Builds on the Phase 1 hot-reload primitive (PR #24).

## What lands

3 commits, structured to make the change reviewable in any order:

| | hash | what |
|---|---|---|
| 1 | `0e8f21b` | refactor: extract `run_http_accept_loop` / `run_https_accept_loop` / `spawn_https_handler` as free fns; behaviour identical to the inline `tokio::spawn(async move { … })` blocks of v0.1.7 |
| 2 | `a2c84ee` | feat: `src/listener.rs` — `ListenerSupervisor` + `BoundListener`; subscribes to `state.config` via the watcher's notify channel; reconciles HTTP/HTTPS bind addresses; `super_shutdown_*` channels for graceful retire |
| 3 | `36d3cd5` | docs: contract update — `listen_*` moved into "what reloads", new "Listener rebind caveats" section, README features list |

## Reconcile semantics

* **Same** → nothing.
* **Rebind {from, to}** → bind new with `SO_REUSEPORT`, spawn loop, retire old. Old loop returns; old fd reclaimed when last connection on it exits.
* **Bind failure** (port busy, no `CAP_NET_BIND_SERVICE`, malformed) → log WARN, keep existing listener. Typo in `zion.toml` never strands the daemon.
* **Remove** (empty / missing `listen_*`) → no-op. We never tear down an existing HTTPS over a missing field; losing ACME / 301 silently is the wrong default.

## io_uring (`--features io-uring-accept`) caveat

The uring accept thread is bound to the listener's fd at startup; rebinding would require tearing it down + respawning. Out of scope for Phase 1.5. The supervisor logs `HTTPS rebind to X skipped: --features io-uring-accept is incompatible with rebind in Phase 1.5; restart required` and keeps the original. HTTP rebind continues to work. Documented in `docs/deploy/hot-reload.md`.

## Verification

* **Build matrix**: `--release` default / `--all-features` / `--no-default-features` — all clean.
* **Tests**: 308 → **315** (7 new in `listener.rs::tests` covering Same, Rebind, Add, Remove, v4↔v6 cross-family, same-port-different-interface).
* **Clippy** `--all-targets --all-features -- -D warnings` — clean. Same on default + `--no-default-features`.
* **Live E2E** (full session captured during development):
  ```text
  Initial:                 HTTPS :18543 = 200, :18544 = refused
  edit listen_https → 18544
    log: "rebound HTTPS 127.0.0.1:18543 → 127.0.0.1:18544 (old listener draining)"
  After HTTPS rebind:      :18543 = refused, :18544 = 200
  edit listen_http → 18181
    log: "rebound HTTP 127.0.0.1:18180 → 127.0.0.1:18181 (old listener draining)"
  After HTTP rebind:       :18180 = refused, :18181 = 301
  SIGTERM:                 "all connections drained cleanly", exit 0
  ```
* **VitePress**: `cd docs && npm run build` clean.

## Files

```
src/listener.rs       NEW — ListenerSupervisor + BoundListener + diff() with 7 unit tests (262 lines)
src/main.rs           refactor + supervisor wire-up (-71 / +196 across the two commits)
src/reload.rs         spawn_config_watcher takes Option<watch::Sender<u64>>; bumps it after every successful swap
docs/deploy/hot-reload.md   Listener rebind caveats section, listen_* moved into "What reloads"
README.md             features list updated
```

Total: 3 commits, ~720 lines net diff. No new dependencies.