### PR TITLE
chore(readme): SSOT stats — fix recursive count + CI guard

### DIFF
--- a/.github/workflows/readme-stats-sync.yml
+++ b/.github/workflows/readme-stats-sync.yml
@@ -1,0 +1,33 @@
+name: readme-stats-sync
+
+# README headline numbers (module count, LoC, unit-test count) must stay
+# in sync with the codebase. scripts/update-readme-stats.sh is the SSOT
+# for how they are computed; this workflow runs it in --check mode on
+# every PR and on every push to master. Drift = build red.
+
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_COLOR: always
+      CARGO_INCREMENTAL: 0
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      - name: Verify README stats SSOT
+        run: bash scripts/update-readme-stats.sh --check

--- a/README.md
+++ b/README.md
@@ -174,8 +174,19 @@ Build flavors:
 cargo build --release                            # bare daemon, lean binary
 cargo build --release --features init            # + zion init wizard with cert generation
 cargo build --release --features tui             # + zion top live dashboard
-cargo build --release --features acme            # + Let's Encrypt auto-renewal
+cargo build --release --features acme            # + Let's Encrypt auto-renewal (HTTP-01)
+cargo build --release --features auth            # + JWT/OIDC authentication gate
+cargo build --release --features http3           # + HTTP/3 QUIC listener
+cargo build --release --features otel            # + OpenTelemetry tracing + OTLP export
+cargo build --release --features fips            # + FIPS 140-3 build (aws-lc-rs validated backend)
+cargo build --release --features geo-ita         # + Italian ASN/gov/ISP ranges (sovereign edge)
 cargo build --release --features io-uring-accept # Linux 5.19+: multishot accept
+```
+
+Stack flavors for a "max" build:
+
+```bash
+cargo build --release --features init,tui,acme,auth,http3,otel
 ```
 
 ## Live Dashboard (`zion top`)
@@ -255,7 +266,7 @@ Client -> TLS 1.3 -> Security Gates -> Radix Router -> WAF Pipeline (5 gates) ->
 ```
 
 <!-- zion-stats:modules-lines (kept in sync by scripts/update-readme-stats.sh) -->
-21 modules, ~15,900 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
+30 modules, ~20,600 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
 
 ## Benchmarking
 
@@ -281,7 +292,7 @@ Results saved to `benchmarks/bench-history.json` with automatic delta comparison
 ## Testing
 
 ```bash
-# Unit tests (300) <!-- zion-stats:test-count (kept in sync by scripts/update-readme-stats.sh) -->
+# Unit tests (421) <!-- zion-stats:test-count (kept in sync by scripts/update-readme-stats.sh) -->
 cargo test
 
 # Integration tests (19 -- requires running Zion + backend)

--- a/scripts/update-readme-stats.sh
+++ b/scripts/update-readme-stats.sh
@@ -2,18 +2,20 @@
 # update-readme-stats.sh — keep README badges in sync with the codebase.
 #
 # Three numbers drift fastest in this repo and burn credibility when stale:
-#   * module count    — how many `src/*.rs` files there are
-#   * line count      — total Rust LoC in `src/`
-#   * unit-test count — what `cargo test --release --bin zion` reports
+#   * module count    — every `*.rs` file under `src/` (recursive)
+#   * line count      — total Rust LoC under `src/` (recursive)
+#   * unit-test count — sum across lib + main bin + chaos suites (the
+#                       integration suite is reported separately in the
+#                       README and is excluded here on purpose)
 #
 # This script is the single source of truth for how those numbers are
 # computed. It rewrites three lines in README.md, anchored on HTML
 # marker comments so it's robust to surrounding-text edits:
 #
-#     21 modules, ~15,800 lines of Rust. See [arch ...]
+#     30 modules, ~20,600 lines of Rust. See [arch ...]
 #     <!-- zion-stats:modules-lines (kept in sync ...) -->
 #
-#     # Unit tests (300) <!-- zion-stats:test-count ... -->
+#     # Unit tests (421) <!-- zion-stats:test-count ... -->
 #
 # Usage:
 #   bash scripts/update-readme-stats.sh             # rewrite README in place
@@ -37,23 +39,29 @@ if [[ "${1:-}" == "--check" ]]; then
 fi
 
 # ── compute counts ──────────────────────────────────────────────────────
-modules=$(find src -maxdepth 1 -name '*.rs' -type f | wc -l | awk '{print $1}')
+# Recurse — `src/sovereign/` and any future submodule directory must be
+# counted. The previous depth=1 implementation silently undercounted.
+modules=$(find src -name '*.rs' -type f | wc -l | awk '{print $1}')
 
-lines_total=$(wc -l src/*.rs | tail -1 | awk '{print $1}')
+lines_total=$(find src -name '*.rs' -type f -exec cat {} + | wc -l | awk '{print $1}')
 # Round to nearest 100 for the README — the precise count fluctuates with
 # every edit and the headline number doesn't need that resolution.
 # Thousands-separator formatting is done in Python below (BSD printf on
 # macOS does not honour `%'d` outside specific locales).
 lines_rounded=$(( (lines_total + 50) / 100 * 100 ))
 
-# Unit-test count: parse the canonical wrap-up line. We accept the first
-# successful run only; a 0-count or failing run aborts so we never paste
-# bad numbers into the README.
-test_output=$(cargo test --release --bin zion --quiet 2>&1 || true)
+# Unit-test count: aggregate across every "test result: ok. N passed"
+# line cargo emits for lib + main bin + chaos. Integration tests live in
+# tests/integration.rs and are #[ignore]d by default — they are reported
+# separately in the README and excluded here.
+#
+# Cargo is ground truth: a static `grep '#[test]'` undercounts because
+# proptest! macros expand into runtime test cases that share a single
+# attribute in source.
+test_output=$(cargo test --release --lib --bin zion --test chaos --quiet 2>&1 || true)
 tests=$(printf "%s" "$test_output" \
     | grep -E '^test result: ok\. [0-9]+ passed' \
-    | head -1 \
-    | awk '{print $4}')
+    | awk '{s+=$4} END {print s}')
 if [[ -z "${tests:-}" || "$tests" == "0" ]]; then
     echo "FATAL: could not extract a non-zero test count from cargo test output" >&2
     echo "       (last 20 lines follow)" >&2


### PR DESCRIPTION
## Summary

`scripts/update-readme-stats.sh` had two silent-drift bugs:

| Bug | Impact |
|---|---|
| `find -maxdepth 1` + `wc -l src/*.rs` | `src/sovereign/` (and any future subdir) ignored — undercount of modules and LoC |
| `head -1` on the `test result: ok.` lines | Only the *first* suite (lib, 49 tests) counted; main bin (368) + chaos (4) dropped |

After re-running the corrected script:

| Metric | Before | After |
|---|---|---|
| Modules | 21 | **30** |
| LoC src/ | ~15,900 | **~20,600** |
| Unit tests | 300 | **421** |

A new `readme-stats-sync.yml` workflow runs the script in `--check` mode on every PR and on every push to master — same draconian pattern as `version-sync.yml`. Drift = build red, no more "next person notices six months later".

`README.md` "Build flavors" expanded to cover every public feature: `auth`, `http3`, `otel`, `fips`, `geo-ita` (`sovereign-signals` and `reqwest` left out as internal/experimental).

## Test plan

- [x] `bash scripts/update-readme-stats.sh` — runs cleanly, writes correct numbers
- [x] `bash scripts/update-readme-stats.sh --check` — idempotent, exit 0
- [ ] CI: `readme-stats-sync` workflow green on this PR
- [ ] CI: existing checks (CI Success, version-sync, dco-check, supply-chain) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)