### PR TITLE
fix(test): proptest cap is 2*rps — wall-clock window flip

### DIFF
--- a/src/security.rs
+++ b/src/security.rs
@@ -579,12 +579,16 @@ mod proptests {
                     allowed += 1;
                 }
             }
-            // Within a single 1-second window we cannot admit more than
-            // `rps` requests. We allow equality (exactly rps admits), never
-            // strictly more — that would be a counter race.
+            // The limiter keys its window off `SystemTime::now()`, so a
+            // tight loop on a slow runner (Windows CI) can straddle a
+            // second boundary, reset the counter, and admit up to `rps`
+            // again — i.e. up to `2*rps` for the burst as a whole. We
+            // accept that as the wall-clock-honest upper bound here; the
+            // real invariant we care about is "never unbounded relative
+            // to rps", not "never crosses a window boundary mid-burst".
             prop_assert!(
-                allowed <= rps as usize,
-                "rps={rps}, burst={burst}, allowed={allowed}"
+                allowed <= 2 * rps as usize,
+                "rps={rps}, burst={burst}, allowed={allowed} (>2*rps)"
             );
         }
 
@@ -622,8 +626,13 @@ mod proptests {
                     allowed_b += 1;
                 }
             }
-            prop_assert!(allowed_a <= rps as usize);
-            prop_assert!(allowed_b <= rps as usize);
+            // Same wall-clock relaxation as the cap test above: a burst
+            // straddling a 1-second boundary may admit up to 2*rps for
+            // each IP. The property we still enforce is *isolation* —
+            // saturating IP A must not affect IP B's budget — encoded
+            // implicitly because we count each IP separately.
+            prop_assert!(allowed_a <= 2 * rps as usize);
+            prop_assert!(allowed_b <= 2 * rps as usize);
         }
     }
 }


### PR DESCRIPTION
## Summary

Two property tests in `src/security.rs` asserted `allowed <= rps`, but the rate-limiter keys its 1-second window off `SystemTime::now()`. On slower runners (Windows CI), a tight burst can straddle a second boundary, the counter resets, and the limiter admits up to \`rps\` again — i.e. up to \`2*rps\` for the burst as a whole. That's wall-clock-honest behaviour, not a limiter bug.

Manifested on [PR #74](https://github.com/fabriziosalmi/zion/pull/74)'s Windows job (rps=89, burst=453, allowed=178 = exactly 2·89). [PR #75](https://github.com/fabriziosalmi/zion/pull/75) passed by luck.

## Fix

Relax both invariants to \`<= 2 * rps as usize\` with a comment explaining the boundary-cross. The property we want — counter never grows unbounded relative to rps — is preserved. Pinning the clock would be the strict fix, but the limiter has no clock seam today; adding one to satisfy a test is a tail wagging the dog.

## Test plan

Verified locally with 5000 cases per property, three independent runs:

\`\`\`
PROPTEST_CASES=5000 cargo test --release --bin zion --quiet -- proptests::rate_limiter
run 1: 3 passed
run 2: 3 passed
run 3: 3 passed
\`\`\`

- [ ] CI green on Linux + macOS + Windows
- [ ] After merge: rebase PR #74 onto master to pick this up

🤖 Generated with [Claude Code](https://claude.com/claude-code)