### PR TITLE
quality(boot): 3 panics → ZionError + module docs on 5 files

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ Client -> TLS 1.3 -> Security Gates -> Radix Router -> WAF Pipeline (5 gates) ->
 ```
 
 <!-- zion-stats:modules-lines (kept in sync by scripts/update-readme-stats.sh) -->
-30 modules, ~20,600 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
+30 modules, ~20,700 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
 
 ## Benchmarking
 

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -176,8 +176,13 @@ pub fn validate_token(token: &str, profile: &ResolvedAuthProfile) -> Result<Clai
 
 /// Build a resolved auth profile from config.
 /// Called once at startup — pre-computes DecodingKey and Validation.
+///
+/// Returns `Err` if the algorithm is unrecognised or if the profile
+/// configures neither `secret` (HMAC) nor `jwks_url` (OIDC). The error
+/// is a String so the caller (`config::build_router`) can wrap it with
+/// the route/profile name in its own error format.
 #[cfg(feature = "auth")]
-pub fn resolve_auth_profile(config: &AuthProfileConfig) -> ResolvedAuthProfile {
+pub fn resolve_auth_profile(config: &AuthProfileConfig) -> Result<ResolvedAuthProfile, String> {
     let mut alg_str = config.algorithm.clone();
     if alg_str == "HS256" && config.jwks_url.is_some() && config.secret.is_none() {
         alg_str = "RS256".to_string(); // Default to RS256 for asymmetric OIDC profiles
@@ -192,7 +197,7 @@ pub fn resolve_auth_profile(config: &AuthProfileConfig) -> ResolvedAuthProfile {
         "RS512" => Algorithm::RS512,
         "ES256" => Algorithm::ES256,
         "ES384" => Algorithm::ES384,
-        other => panic!("Unsupported JWT algorithm: {other}"),
+        other => return Err(format!("unsupported JWT algorithm: {other}")),
     };
 
     let mut decoding_key = None;
@@ -262,8 +267,10 @@ pub fn resolve_auth_profile(config: &AuthProfileConfig) -> ResolvedAuthProfile {
             }
         });
     } else {
-        eprintln!("FATAL: auth profile requires either 'secret' (HMAC) or 'jwks_url' (OIDC). Neither is set.");
-        std::process::exit(1);
+        return Err(
+            "auth profile requires either 'secret' (HMAC) or 'jwks_url' (OIDC); neither is set"
+                .to_string(),
+        );
     };
 
     let mut validation = Validation::new(algorithm);
@@ -280,13 +287,13 @@ pub fn resolve_auth_profile(config: &AuthProfileConfig) -> ResolvedAuthProfile {
     // Allow 30s clock skew for distributed systems
     validation.leeway = 30;
 
-    ResolvedAuthProfile {
+    Ok(ResolvedAuthProfile {
         jwks_url: config.jwks_url.clone(),
         decoding_key,
         jwk_set: jwk_set_arc,
         validation: Arc::new(validation),
         forward_claims: config.forward_claims,
-    }
+    })
 }
 
 #[cfg(test)]
@@ -347,7 +354,7 @@ mod tests {
             forward_claims: true,
         };
 
-        let profile = resolve_auth_profile(&config);
+        let profile = resolve_auth_profile(&config).expect("valid test profile");
         let result = validate_token(&token, &profile);
         assert!(result.is_ok());
         let decoded = result.unwrap();
@@ -385,7 +392,7 @@ mod tests {
             forward_claims: true,
         };
 
-        let profile = resolve_auth_profile(&config);
+        let profile = resolve_auth_profile(&config).expect("valid test profile");
         let result = validate_token(&token, &profile);
         assert!(result.is_err());
     }
@@ -420,7 +427,7 @@ mod tests {
             forward_claims: true,
         };
 
-        let profile = resolve_auth_profile(&config);
+        let profile = resolve_auth_profile(&config).expect("valid test profile");
         let result = validate_token(&token, &profile);
         assert!(matches!(result, Err(AuthError::Expired)));
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,13 @@
+//! Configuration loading, validation, and router construction.
+//!
+//! Parses `zion.toml` into typed structs (`ZionConfig`), validates the
+//! result (every WAF/auth/cache profile referenced by a route must
+//! exist; CIDRs parse; xff_mode is a known string), and builds the
+//! `matchit::Router<Arc<ResolvedRoute>>` consumed by `dispatch.rs`.
+//!
+//! `build_router` is the single fallible entry point; everything that
+//! turns static TOML into runtime state flows through it.
+
 use matchit::Router;
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -699,7 +709,10 @@ pub fn build_router(config: &ZionConfig) -> Result<Router<Arc<ResolvedRoute>>, S
                 let profile_config = config.auth_profile.get(name).ok_or_else(|| {
                     format!("Auth profile '{}' not found (route '{}')", name, route.path)
                 })?;
-                let resolved = crate::auth::resolve_auth_profile(profile_config);
+                let resolved =
+                    crate::auth::resolve_auth_profile(profile_config).map_err(|e| {
+                        format!("Auth profile '{}' (route '{}'): {}", name, route.path, e)
+                    })?;
                 eprintln!(
                     "  auth: route {} → profile '{}' (alg={})",
                     route.path, name, profile_config.algorithm

--- a/src/config.rs
+++ b/src/config.rs
@@ -709,10 +709,9 @@ pub fn build_router(config: &ZionConfig) -> Result<Router<Arc<ResolvedRoute>>, S
                 let profile_config = config.auth_profile.get(name).ok_or_else(|| {
                     format!("Auth profile '{}' not found (route '{}')", name, route.path)
                 })?;
-                let resolved =
-                    crate::auth::resolve_auth_profile(profile_config).map_err(|e| {
-                        format!("Auth profile '{}' (route '{}'): {}", name, route.path, e)
-                    })?;
+                let resolved = crate::auth::resolve_auth_profile(profile_config).map_err(|e| {
+                    format!("Auth profile '{}' (route '{}'): {}", name, route.path, e)
+                })?;
                 eprintln!(
                     "  auth: route {} → profile '{}' (alg={})",
                     route.path, name, profile_config.algorithm

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -1,3 +1,21 @@
+//! Request dispatch — the per-request state machine.
+//!
+//! Sits between the TLS listener and the upstream/cache. For each
+//! accepted request it walks the pipeline:
+//!
+//!   1. inline fast-path (`/healthz`, `/readyz`, `/metrics`,
+//!      `/_zion/snapshot.json`)
+//!   2. security gates (URI length, method whitelist, rate limiter,
+//!      CORS pre-flight)
+//!   3. radix routing → `Arc<ResolvedRoute>`
+//!   4. WAF pipeline (content-type, size, structural validation,
+//!      entropy, Aho-Corasick scan)
+//!   5. cache lookup or upstream proxy
+//!   6. response hardening (security headers, hop-by-hop strip)
+//!
+//! Hot path: zero allocation in the common case. Everything that turns
+//! a `Request` into a `Response` lives here or is called from here.
+
 use crate::audit::AuditEvent;
 use crate::proxy::ZionBody;
 use crate::{

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,16 @@
+//! Zion Edge Gateway — binary entry point.
+//!
+//! Boots the daemon: parses CLI flags (`zion`, `zion init`, `zion top`,
+//! `zion doctor`, `zion bootstrap`, `zion auto`), loads `zion.toml`,
+//! builds the resolved runtime config (`ResolvedAppConfig::try_build`),
+//! starts the TLS acceptor + listeners (HTTP/HTTPS, optional QUIC),
+//! spawns the cert-watcher, the config-reload watcher, the cache prober
+//! and the audit writer, and finally hands every accepted connection to
+//! `dispatch::handle_request`.
+//!
+//! `main()` returns `error::ZionResult<()>` so any boot-time failure
+//! propagates with a structured exit code instead of panicking.
+
 // Crate-level lint hygiene.
 //
 // We deliberately do NOT silence dead_code / unused_imports / unused_variables
@@ -197,12 +210,13 @@ impl ResolvedAppConfig {
     /// uses it once at boot; subsequent phases call it again on every
     /// hot-reload and atomic-swap the result.
     ///
-    /// Panics at boot if the router cannot be built (bad patterns, unknown
-    /// profiles). During hot-reload, `rebuild()` calls `try_build()` which
-    /// propagates the error cleanly.
-    fn build(config: &config::ZionConfig) -> Self {
-        let router = config::build_router(config)
-            .unwrap_or_else(|e| panic!("fatal: cannot build router at boot: {e}"));
+    /// Returns `Err(ZionError::Config)` if the router cannot be built
+    /// (bad patterns, unknown profiles). At boot the error propagates to
+    /// `main()` and the process exits with the structured ZionResult code;
+    /// during hot-reload the existing snapshot stays in place and the
+    /// new config is rejected with a logged WARN.
+    pub(crate) fn try_build(config: &config::ZionConfig) -> error::ZionResult<Self> {
+        let router = config::build_router(config).map_err(error::ZionError::Config)?;
 
         // Health map: one entry per upstream URL referenced by any route.
         // The same URL can appear in many routes — dedup via FnvHashMap.
@@ -289,7 +303,7 @@ impl ResolvedAppConfig {
             (sov.enabled, sov.log_classification)
         };
 
-        Self {
+        Ok(Self {
             router,
             health_map,
             trusted_proxies,
@@ -302,7 +316,7 @@ impl ResolvedAppConfig {
             sovereign_enabled,
             #[cfg(any(feature = "geo-ita", feature = "geo-eu"))]
             sovereign_log_classification,
-        }
+        })
     }
 }
 
@@ -561,7 +575,7 @@ async fn async_main(platform: &'static bootstrap::Platform) -> error::ZionResult
             tls_acceptor_store.clone(),
             config.tls.clone(),
             Some(quic_reload_tx),
-        );
+        )?;
     }
 
     // 4b. Predictive TTL pre-warming: pre-build TLS config before cert expires
@@ -571,7 +585,7 @@ async fn async_main(platform: &'static bootstrap::Platform) -> error::ZionResult
     // proxies, XFF policy, rate-limit settings — everything that follows
     // from `zion.toml`). This is the single entry point that future
     // hot-reload phases will re-invoke and atomic-swap.
-    let resolved = ResolvedAppConfig::build(&config);
+    let resolved = ResolvedAppConfig::try_build(&config)?;
 
     // Boot-time visibility: structured logs for the bits operators
     // commonly check at startup. (Validation of `xff_mode` happens

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -1,3 +1,14 @@
+//! Upstream HTTP client + request/response forwarding.
+//!
+//! Wraps `hyper-util`'s legacy connection pool with the proxy's own
+//! `XffMode` policy, header rewrites (hop-by-hop strip per RFC 7230,
+//! `X-Request-ID` injection, `X-Forwarded-{For,Host,Proto}`), and the
+//! body type used by every response Zion emits — `ZionBody` aliases
+//! `BoxBody<Bytes, hyper::Error>`.
+//!
+//! HTTP/2 upstream multiplexing is opportunistic via ALPN. Pre-warming
+//! of the connection pool happens at boot in `build_http_client`.
+
 use bytes::Bytes;
 use http_body_util::{combinators::BoxBody, BodyExt, Full};
 use hyper::header::HeaderValue;

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -68,8 +68,11 @@ pub(crate) fn current_generation() -> u64 {
 /// "healthy + latency unknown" defaults; removed URLs are simply
 /// dropped (the old `Arc` will be reclaimed when the last reader
 /// exits, including any in-flight prober iteration).
-fn rebuild(new_config: &ZionConfig, previous: &ResolvedAppConfig) -> ResolvedAppConfig {
-    let mut snap = ResolvedAppConfig::build(new_config);
+fn rebuild(
+    new_config: &ZionConfig,
+    previous: &ResolvedAppConfig,
+) -> Result<ResolvedAppConfig, crate::error::ZionError> {
+    let mut snap = ResolvedAppConfig::try_build(new_config)?;
     let mut merged: fnv::FnvHashMap<String, Arc<health::UpstreamHealth>> =
         fnv::FnvHashMap::default();
     for (url, fresh) in snap.health_map.iter() {
@@ -81,7 +84,7 @@ fn rebuild(new_config: &ZionConfig, previous: &ResolvedAppConfig) -> ResolvedApp
         merged.insert(url.clone(), entry);
     }
     snap.health_map = Arc::new(merged);
-    snap
+    Ok(snap)
 }
 
 /// Spawn the config-file watcher. Returns immediately; the actual
@@ -192,16 +195,26 @@ pub(crate) fn spawn_config_watcher(
                     // Rebuild on the current thread (fast: matchit
                     // construction is microseconds, Aho-Corasick is
                     // already cached per-mode in OnceLock).
-                    // Wrapped in catch_unwind as defense-in-depth: if
-                    // build_router encounters an edge case that validate_config
-                    // missed, the debounce task stays alive instead of dying.
+                    // `try_build` returns a structured error for routine
+                    // failures (bad pattern, unknown profile). The
+                    // catch_unwind around it stays as defense-in-depth
+                    // against any deeper panic that escapes validation.
                     let previous = state_config.load_full();
                     let rebuild_result =
                         std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                             rebuild(&new_config, &previous)
                         }));
                     let new_snapshot = match rebuild_result {
-                        Ok(snap) => snap,
+                        Ok(Ok(snap)) => snap,
+                        Ok(Err(e)) => {
+                            logging::warn(
+                                "config_watcher",
+                                &format!(
+                                    "rebuild rejected new config ({e}), keeping previous snapshot"
+                                ),
+                            );
+                            continue;
+                        }
                         Err(_) => {
                             logging::warn(
                                 "config_watcher",
@@ -311,7 +324,7 @@ mod tests {
         // Bypass disk validation by parsing TOML directly — we only
         // test the rebuild() merging logic, not file I/O.
         let parsed: ZionConfig = toml::from_str(config_toml).unwrap();
-        let merged = rebuild(&parsed, &previous);
+        let merged = rebuild(&parsed, &previous).expect("test config rebuilds");
 
         let merged_arc = merged
             .health_map
@@ -356,7 +369,7 @@ mod tests {
             upstream = "billing"
         "#;
         let parsed: ZionConfig = toml::from_str(config_toml).unwrap();
-        let merged = rebuild(&parsed, &previous);
+        let merged = rebuild(&parsed, &previous).expect("test config rebuilds");
 
         // Old upstream gone, new one present, with default state
         // ("healthy = true, latency = 0", per ResolvedAppConfig::build).
@@ -440,7 +453,7 @@ mod tests {
     fn atomic_swap_preserves_old_snapshot_for_inflight_readers() {
         // Initial snapshot, exposed only via `/api/...`.
         let v1 = parse_inline(TOML_V1);
-        let snap_v1 = ResolvedAppConfig::build(&v1);
+        let snap_v1 = ResolvedAppConfig::try_build(&v1).expect("test config builds");
         let store = ArcSwap::from_pointee(snap_v1);
 
         // Reader A grabs an Arc clone *before* the swap. This models a
@@ -451,7 +464,7 @@ mod tests {
 
         // Hot-reload: build v2 (adds /billing) and swap.
         let v2 = parse_inline(TOML_V2);
-        let snap_v2 = rebuild(&v2, &reader_a);
+        let snap_v2 = rebuild(&v2, &reader_a).expect("test config rebuilds");
         store.store(Arc::new(snap_v2));
 
         // Reader A sees the old routing table (route /api works,
@@ -490,12 +503,12 @@ mod tests {
         // empty `[[route]]` section before the first edit).
         let mut empty = parse_inline(TOML_V1);
         empty.route.clear();
-        let snap_empty = ResolvedAppConfig::build(&empty);
+        let snap_empty = ResolvedAppConfig::try_build(&empty).expect("test config builds");
         let store = ArcSwap::from_pointee(snap_empty);
 
         let v1 = parse_inline(TOML_V1);
         let prev = store.load_full();
-        let snap_v1 = rebuild(&v1, &prev);
+        let snap_v1 = rebuild(&v1, &prev).expect("test config rebuilds");
         store.store(Arc::new(snap_v1));
 
         let after = store.load_full();

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -1,3 +1,17 @@
+//! TLS termination — config loading, hot-reload, SNI cert resolver.
+//!
+//! Loads PEM cert/key pairs from disk, builds a `rustls::ServerConfig`
+//! with the project's tuning (TLS 1.3 only, server cipher order, 0-RTT
+//! eligibility, 16k-entry session cache) and wraps it in a
+//! `tokio_rustls::TlsAcceptor`. SNI per-domain certificates resolve via
+//! an `FnvHashMap` lookup with a default fallback.
+//!
+//! Hot-reload runs as two tasks: a `notify` filesystem watcher debounced
+//! over 2 s, and a reload loop that rebuilds the entire `TlsAcceptor`
+//! and atomically swaps it via `ArcSwap`. The watcher is set up
+//! synchronously before the spawn so a bad cert path fails at boot
+//! with `ZionError::Tls(...)` instead of dying silently in a task.
+
 use arc_swap::ArcSwap;
 use fnv::FnvHashMap;
 use notify::{EventKind, RecursiveMode, Watcher};
@@ -14,6 +28,7 @@ use tokio::sync::Notify;
 use tokio_rustls::TlsAcceptor;
 
 use crate::config::TlsConfig;
+use crate::error::ZionError;
 
 // ═══════════════════════════════════════════════════════════════════
 // GENERATION COUNTER
@@ -295,58 +310,69 @@ pub fn load_tls_config(tls: &TlsConfig) -> Result<ServerConfig, String> {
 /// and hot-swaps the entire TlsAcceptor (with new certs) via ArcSwap.
 /// Atomic swap: new connections get new certs, in-flight connections
 /// continue with old certs until they close. Zero downtime.
+///
+/// Watcher creation and the initial cert-dir watch happen synchronously
+/// before the async task is spawned, so a misconfigured cert path fails
+/// at boot with a structured `ZionError::Tls(...)` instead of dying
+/// silently inside a tokio task.
 pub fn spawn_tls_watcher(
     acceptor_store: Arc<ArcSwap<TlsAcceptor>>,
     tls: TlsConfig,
     quic_reload_tx: Option<tokio::sync::watch::Sender<Option<Arc<rustls::ServerConfig>>>>,
-) {
+) -> Result<(), ZionError> {
     let debounce_signal = Arc::new(Notify::new());
     let signal_clone = debounce_signal.clone();
 
     let watcher_cert_path = tls.cert_path.clone();
     let sni_cert_paths: Vec<String> = tls.sni.iter().map(|s| s.cert_path.clone()).collect();
 
-    let _watcher_handle = tokio::spawn(async move {
-        let signal = signal_clone;
-        let mut watcher = notify::recommended_watcher(move |res: notify::Result<notify::Event>| {
-            if let Ok(event) = res {
-                if matches!(event.kind, EventKind::Modify(_) | EventKind::Create(_)) {
-                    signal.notify_one();
-                }
+    // Set up the watcher up front so the daemon refuses to boot on a bad
+    // cert path. Inside a spawned task this would have crashed only the
+    // watcher (silently), leaving the daemon with no hot-reload.
+    let mut watcher = notify::recommended_watcher(move |res: notify::Result<notify::Event>| {
+        if let Ok(event) = res {
+            if matches!(event.kind, EventKind::Modify(_) | EventKind::Create(_)) {
+                signal_clone.notify_one();
             }
-        })
-        .expect("Failed to create filesystem watcher");
+        }
+    })
+    .map_err(|e| ZionError::Tls(format!("cannot create filesystem watcher: {e}")))?;
 
-        // Watch default cert dir
-        let cert_dir = Path::new(&watcher_cert_path)
-            .parent()
-            .unwrap_or_else(|| Path::new("/etc/ssl/zion/"));
-        watcher
-            .watch(cert_dir, RecursiveMode::NonRecursive)
-            .unwrap_or_else(|e| panic!("Cannot watch {}: {}", cert_dir.display(), e));
+    let cert_dir = Path::new(&watcher_cert_path)
+        .parent()
+        .unwrap_or_else(|| Path::new("/etc/ssl/zion/"))
+        .to_path_buf();
+    watcher
+        .watch(&cert_dir, RecursiveMode::NonRecursive)
+        .map_err(|e| ZionError::Tls(format!("cannot watch {}: {e}", cert_dir.display())))?;
 
-        // Watch all SNI cert directories (they may live in different paths)
-        let mut watched_dirs = std::collections::HashSet::new();
-        watched_dirs.insert(cert_dir.to_path_buf());
-        for sni_path in &sni_cert_paths {
-            if let Some(sni_dir) = Path::new(sni_path).parent() {
-                if watched_dirs.insert(sni_dir.to_path_buf()) {
-                    if let Err(e) = watcher.watch(sni_dir, RecursiveMode::NonRecursive) {
-                        eprintln!(
-                            "  warning: cannot watch SNI dir {}: {}",
-                            sni_dir.display(),
-                            e
-                        );
-                    }
+    // SNI dirs are best-effort — log on failure but don't fail boot.
+    let mut watched_dirs = std::collections::HashSet::new();
+    watched_dirs.insert(cert_dir.clone());
+    for sni_path in &sni_cert_paths {
+        if let Some(sni_dir) = Path::new(sni_path).parent() {
+            if watched_dirs.insert(sni_dir.to_path_buf()) {
+                if let Err(e) = watcher.watch(sni_dir, RecursiveMode::NonRecursive) {
+                    eprintln!(
+                        "  warning: cannot watch SNI dir {}: {}",
+                        sni_dir.display(),
+                        e
+                    );
                 }
             }
         }
+    }
 
-        eprintln!(
-            "  tls watcher active on {} (+{} SNI dirs)",
-            cert_dir.display(),
-            watched_dirs.len() - 1
-        );
+    eprintln!(
+        "  tls watcher active on {} (+{} SNI dirs)",
+        cert_dir.display(),
+        watched_dirs.len() - 1
+    );
+
+    // Move the watcher into the spawn so `Drop` on the watcher (which
+    // unregisters all paths) only happens when the daemon exits.
+    let _watcher_handle = tokio::spawn(async move {
+        let _watcher = watcher;
         std::future::pending::<()>().await;
     });
 
@@ -388,6 +414,8 @@ pub fn spawn_tls_watcher(
             }
         }
     });
+
+    Ok(())
 }
 
 // ═══════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Replaces the three remaining boot-time \`panic!\`/\`exit(1)\` sites with structured \`ZionResult\` propagation so a misconfigured daemon dies with a clean exit and message instead of a Rust panic stack-trace.

| Site | Before | After |
|---|---|---|
| \`src/main.rs::ResolvedAppConfig::build\` | \`panic!(\"fatal: cannot build router at boot\")\` | renamed to \`try_build\` returning \`ZionResult<Self>\`; \`main()\` propagates with \`?\` |
| \`src/auth.rs::resolve_auth_profile\` | \`panic!(\"Unsupported JWT algorithm\")\` and \`std::process::exit(1)\` for missing secret/jwks_url | returns \`Result<_, String>\`; caller in \`config.rs\` wraps with route/profile name |
| \`src/tls.rs::spawn_tls_watcher\` | \`unwrap_or_else(\|e\| panic!(\"Cannot watch …\"))\` *inside* a \`tokio::spawn\`  → silent watcher death | returns \`Result<(), ZionError>\`; watcher creation + cert-dir watch hoisted out of the task so bad paths fail at boot |

Hot-reload was already protected by \`catch_unwind\`; with the new \`try_build\` it now also has the structured error path — a rejected new config is logged and the previous snapshot stays in place. \`catch_unwind\` is kept as defense-in-depth.

Module-level \`//!\` docstrings added on the five files that lacked them per the codebase audit: \`config.rs\`, \`dispatch.rs\`, \`main.rs\`, \`proxy.rs\`, \`tls.rs\`.

## Test plan

\`\`\`
cargo check                                              OK
cargo check  --all-features                              OK
cargo clippy --all-targets             -- -D warnings    OK
cargo clippy --all-targets --all-features -- -D warnings OK
cargo test   --release                   421 passed
cargo test   --release --all-features    463 passed
\`\`\`

- [ ] CI green on Linux + macOS + Windows
- [ ] After merge: 0 \`panic!\` in production paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)