### PR TITLE
polish: SPDX header on every Rust file + unsafe SAFETY audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ Client -> TLS 1.3 -> Security Gates -> Radix Router -> WAF Pipeline (5 gates) ->
 ```
 
 <!-- zion-stats:modules-lines (kept in sync by scripts/update-readme-stats.sh) -->
-30 modules, ~20,700 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
+30 modules, ~20,800 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
 
 ## Benchmarking
 

--- a/src/acme.rs
+++ b/src/acme.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 //! ACME auto-renewal — handles HTTP-01 challenges and certificate renewal.
 //!
 //! Flow:

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 //! Audit log — HMAC-SHA256-chained, JSON-line events for compliance.
 //!
 //! Goals (in priority order):

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 //! Zion Auth Gate — JWT/OIDC validation middleware.
 //!
 //! Feature-gated: compile with `--features auth` to enable.

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 //! Zion Bootstrap — hardware detection, auto-tuning, performance tier.
 //!
 //! At startup, probes the OS and hardware to enable the best available

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 //! Two-level cache: L1 thread-local + L2 shared DashMap.
 //!
 //! L1: per-thread, zero contention, ~5ns lookup. LRU eviction.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 //! Tiny zero-dep CLI dispatcher.
 //!
 //! Zion historically took zero positional arguments — everything was env-driven

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 //! Configuration loading, validation, and router construction.
 //!
 //! Parses `zion.toml` into typed structs (`ZionConfig`), validates the

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 //! Request dispatch — the per-request state machine.
 //!
 //! Sits between the TLS listener and the upstream/cache. For each

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 //! `zion doctor` — environment diagnostic.
 //!
 //! Runs a checklist of common production gotchas (fd limit, privileged

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 //! Unified error type — `ZionError`.
 //!
 //! Replaces the historical `Box<dyn std::error::Error>` returned by `main`

--- a/src/health.rs
+++ b/src/health.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 //! Upstream health checking — types and query function.
 //!
 //! Health state is shared with the request path via `HealthMap`

--- a/src/init.rs
+++ b/src/init.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 //! `zion init` — interactive zion.toml wizard.
 //!
 //! From zero to a running daemon in 30 seconds. The wizard:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 //! Public library surface for testing / fuzzing / external tooling.
 //!
 //! Zion ships as a single binary (`src/main.rs`); 99% of its modules are

--- a/src/listener.rs
+++ b/src/listener.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 //! Listener supervisor — Phase 1.5 of the dynamic-config plan.
 //!
 //! Watches `state.config` (an `ArcSwap<ResolvedAppConfig>`) for changes

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 //! Zion structured logging — zero-dependency, minimal, fast.
 //!
 //! Two formats:

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 //! Zion Edge Gateway — binary entry point.
 //!
 //! Boots the daemon: parses CLI flags (`zion`, `zion init`, `zion top`,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 //! Zion metrics — lock-free atomic counters + latency histograms, Prometheus text format.
 //! Zero-dependency, zero-alloc on the hot path (only atomic increments).
 

--- a/src/net.rs
+++ b/src/net.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 //! Network socket tuning and listener management.
 //!
 //! Platform-specific TCP optimizations extracted from main.rs for clarity.
@@ -117,6 +118,10 @@ fn tune_listener(_socket: &socket2::Socket) {}
 pub fn tune_accepted(stream: &tokio::net::TcpStream) {
     use std::os::unix::io::AsRawFd;
     let fd = stream.as_raw_fd();
+    // SAFETY: FFI setsockopt for TCP_QUICKACK and SO_BUSY_POLL is sound because `fd` is
+    // obtained from a live `&TcpStream` (so it remains open for the duration of this call),
+    // both option values are stack-local `i32`s with `socklen_t = sizeof::<i32>()`, and the
+    // kernel silently no-ops unsupported options instead of corrupting state.
     unsafe {
         // TCP_QUICKACK: send ACK immediately (don't wait for delayed ACK timer)
         let val: i32 = 1;

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 //! Observability — distributed tracing, W3C Trace Context, OTLP export.
 //!
 //! Two layers:

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 //! Upstream HTTP client + request/response forwarding.
 //!
 //! Wraps `hyper-util`'s legacy connection pool with the proxy's own

--- a/src/quic.rs
+++ b/src/quic.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 //! Zion HTTP/3 (QUIC) listener — feature-gated via `--features http3`.
 //!
 //! Architecture: runs alongside the TCP TLS listener on the same port (UDP :443).

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 //! Config hot-reload — Phase 1 of the dynamic-config plan.
 //!
 //! Watches `zion.toml` (or whatever `ZION_CONFIG` points at) for

--- a/src/security.rs
+++ b/src/security.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 //! Security primitives — CORS, rate limiting, validation, and response hardening.
 //!
 //! Extracted from main.rs (C-01) to reduce monolith complexity.

--- a/src/sovereign/data_eu.rs
+++ b/src/sovereign/data_eu.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 //! Baked-in EU CIDR ranges for sovereign edge classification.
 //!
 //! This is a stub for Phase 2. The full EU dataset will be generated

--- a/src/sovereign/data_ita.rs
+++ b/src/sovereign/data_ita.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 //! Baked-in Italian CIDR ranges for sovereign edge classification.
 //!
 //! Data sources (all public, verifiable):

--- a/src/sovereign/mod.rs
+++ b/src/sovereign/mod.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 //! Zion Sovereign Edge — IP classification and regional intelligence.
 //!
 //! Compile with `--features geo-ita` to bake Italian ASN/CIDR data into

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 //! TLS termination — config loading, hot-reload, SNI cert resolver.
 //!
 //! Loads PEM cert/key pairs from disk, builds a `rustls::ServerConfig`

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 //! `zion top` — live TUI dashboard.
 //!
 //! Polls `/_zion/snapshot.json` from a running Zion instance and renders a

--- a/src/uring.rs
+++ b/src/uring.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 //! io_uring-accelerated accept loop for Linux.
 //!
 //! Uses multishot accept: one SQE yields multiple CQEs, so the kernel batches

--- a/src/waf.rs
+++ b/src/waf.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 //! Zion WAF — 5-gate request inspection pipeline (Aho-Corasick, entropy, simd-json).
 //!
 //! Architecture: 5-gate pipeline, fail-fast, zero-regex.

--- a/tests/chaos.rs
+++ b/tests/chaos.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 //! Chaos integration tests — failure-mode coverage that the unit test
 //! suite alone can't reach.
 //!

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 //! Zion Edge Gateway — Integration Tests
 //!
 //! Validates the full proxy stack end-to-end:


### PR DESCRIPTION
## Summary

Two compliance/safety polishes that have nothing to do with each other but cost the same review effort, so bundled.

**SPDX header on every Rust file** — `// SPDX-License-Identifier: Apache-2.0` prepended to all 32 `src/**/*.rs` + `tests/*.rs` files. Mechanical (one bash one-liner). Makes the licence machine-readable for SBOM tools, licence scanners, and OSSF Scorecard's License-File check without anyone grepping LICENSE.

**Complete `unsafe` SAFETY audit** — read every \`unsafe\` block in \`src/\` (11 sites across \`net.rs\`, \`uring.rs\`, \`audit.rs\`, \`init.rs\`, \`tls.rs\`). 10/11 already carried a \`// SAFETY:\` note. The one missing was \`src/net.rs:120\` (\`tune_accepted\`); added a note: fd is borrowed from a live \`&TcpStream\`, option values are stack-local \`i32\` with matching \`socklen_t\`, kernel silently no-ops unsupported options.

## Test plan

\`\`\`
cargo check                                              OK
cargo fmt --all -- --check                               OK
cargo clippy --all-targets -- -D warnings                OK
cargo test   --release                   421 passed
cargo test   --release --all-features    463 passed
scripts/update-readme-stats.sh --check   already in sync
\`\`\`

- [ ] CI green
- [ ] After merge: every \`unsafe\` block in src/ has a SAFETY note within 6 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)