### PR TITLE
chore(ssot): extend version check to SECURITY/hot-reload/bug-report

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,7 +21,7 @@ A clear and concise description of what you expected to happen.
 **Environment (please complete the following information):**
  - OS: [e.g. Linux, macOS]
  - Architecture: [e.g. arm64, amd64]
- - Zion Version: [e.g. 0.1.6]
+ - Zion Version: [e.g. 0.1.11]
 
 **Additional context**
 Add any other context about the problem here (e.g. logs with `RUST_LOG=trace`, upstream backend type like Go/Node).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ from their containing minor — i.e. the latest `0.1.x` is always patched.
 | Version | Supported |
 | ------- | --------- |
 | 0.1.x (latest minor) | Yes |
-| < 0.1.7 | No |
+| < 0.1.11 | No |
 
 ## Reporting a Vulnerability
 

--- a/deploy/helm/zion/Chart.yaml
+++ b/deploy/helm/zion/Chart.yaml
@@ -19,7 +19,7 @@ annotations:
   artifacthub.io/license: Apache-2.0
   artifacthub.io/changes: |
     - kind: changed
-      description: Bump appVersion to 0.1.9 (Tracks A-E quality release)
+      description: Bump appVersion to 0.1.11 (process hardening — version SSOT, draconian DCO, boot-panic refactor)
     - kind: added
       description: ZION_AUDIT_HMAC_KEY wired from a Kubernetes Secret when [audit] is enabled
     - kind: added

--- a/docs/deploy/hot-reload.md
+++ b/docs/deploy/hot-reload.md
@@ -130,7 +130,7 @@ Two surfaces report the reload state:
 
   ```json
   {
-    "version": "0.1.7",
+    "version": "0.1.11",
     "timestamp_ms": 1714425600000,
     "uptime_secs": 3712,
     "config_generation": 5,

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -64,6 +64,13 @@ for f in "${REF_FILES[@]}"; do
   sedi "s/v$OLD/v$NEW/g" "$f"
 done
 
+# 3b. Tailored single-line replacements where the version appears in a
+# fixed context without the `v` prefix (SECURITY table, JSON examples,
+# issue templates). Mirrors the PATTERN_CHECKS in check-version-sync.sh.
+[[ -f SECURITY.md ]] && sedi "s/^\| < $OLD \| No \|/| < $NEW | No |/" SECURITY.md
+[[ -f docs/deploy/hot-reload.md ]] && sedi "s/(\"version\":[[:space:]]*\")$OLD(\")/\1$NEW\2/" docs/deploy/hot-reload.md
+[[ -f .github/ISSUE_TEMPLATE/bug_report.md ]] && sedi "s/(Zion Version: \[e\.g\.) $OLD(\])/\1 $NEW\2/" .github/ISSUE_TEMPLATE/bug_report.md
+
 # 4. Refresh Cargo.lock so the workspace package entry matches.
 # Prefer offline to avoid network during a release bump; fall back if that fails.
 if cargo check --offline --quiet >/dev/null 2>&1; then

--- a/scripts/check-version-sync.sh
+++ b/scripts/check-version-sync.sh
@@ -61,9 +61,9 @@ if [[ -f "$CHART_FILE" ]]; then
   fi
 fi
 
-# ── 4. README and docs must reference only the current vX.Y.Z tag ──────────
-# CHANGELOG is intentionally excluded — it is append-only and references
-# every prior release.
+# ── 4. Files that reference vX.Y.Z must use the current tag ────────────────
+# CHANGELOG, RELEASE_NOTES, ADRs, and perf/roadmap reference past versions
+# on purpose (historical record) — excluded from this check.
 REF_FILES=(
   "README.md"
   "docs/security/supply-chain.md"
@@ -78,6 +78,26 @@ for f in "${REF_FILES[@]}"; do
       note_drift "$f references $v (expected $EXPECTED_TAG):"
       echo "$occurrences"
     done <<< "$bad_versions"
+  fi
+done
+
+# ── 5. Tailored single-line checks ─────────────────────────────────────────
+# Files where the version appears in a fixed context — we extract the value
+# and compare it directly. Cheaper and more precise than a generic regex.
+#
+# Each entry: "label|file|extractor regex"
+# The extractor is a sed -E expression returning ONLY the version.
+PATTERN_CHECKS=(
+  "SECURITY supported-versions|SECURITY.md|s/^\| < ([0-9]+\.[0-9]+\.[0-9]+) \| No \|.*/\1/p"
+  "hot-reload.md snapshot example|docs/deploy/hot-reload.md|s/.*\"version\":[[:space:]]*\"([0-9]+\.[0-9]+\.[0-9]+)\".*/\1/p"
+  "bug_report.md template default|.github/ISSUE_TEMPLATE/bug_report.md|s/.*Zion Version: \[e\.g\. ([0-9]+\.[0-9]+\.[0-9]+)\].*/\1/p"
+)
+for entry in "${PATTERN_CHECKS[@]}"; do
+  IFS='|' read -r label file extractor <<< "$entry"
+  [[ -f "$file" ]] || continue
+  found=$(sed -nE "$extractor" "$file" | head -1)
+  if [[ -n "$found" && "$found" != "$PACKAGE_VERSION_CORE" ]]; then
+    note_drift "$file ($label) references $found (expected $PACKAGE_VERSION_CORE)"
   fi
 done
 


### PR DESCRIPTION
## Summary

Audit of every hardcoded \`vX.Y.Z\` / \`X.Y.Z\` reference across the repo surfaced 4 drift sites the existing SSOT check didn't cover:

| File | Stale | Bumped to |
|---|---|---|
| \`SECURITY.md\` | \`\| < 0.1.7 \| No \|\` | \`< 0.1.11\` |
| \`docs/deploy/hot-reload.md\` | \`"version": "0.1.7"\` | \`"0.1.11"\` |
| \`.github/ISSUE_TEMPLATE/bug_report.md\` | \`e.g. 0.1.6\` | \`e.g. 0.1.11\` |
| \`deploy/helm/zion/Chart.yaml\` | \`description: Bump appVersion to 0.1.9 ...\` | \`...to 0.1.11 ...\` |

These are not \`vX.Y.Z\` patterns (no \`v\` prefix, surrounded by fixed context like \`| < N |\`, \`"version": "N"\`, \`e.g. N\`), so the existing generic regex in \`check-version-sync.sh\` didn't catch them. Added a tailored single-line check per file (extractor sed regex + direct comparison) — drift on each is now a hard CI failure.

\`bump-version.sh\` extended in lockstep so future \`scripts/bump-version.sh X.Y.Z\` propagates to all three new sites. Chart description left to per-release manual edit (it's a CHANGELOG-style annotation, not a repeated value).

**Historical references intentionally left alone:**
- \`CHANGELOG.md\`, \`RELEASE_NOTES.md\` — release archives
- \`docs/adr/0006-*\`, \`0007-*\` — ADRs documenting decisions made at v0.1.7 / v0.1.8
- \`docs/perf/roadmap.md\` — timeline narrative

## Test plan

\`\`\`
scripts/check-version-sync.sh              OK on master
scripts/bump-version.sh 0.1.99 (dry-run)   propagates 7 sites
Drift injection on each new site           all 3 caught + reported
cargo check                                OK
\`\`\`

- [ ] CI green (CI Success, version-sync, readme-stats-sync, supply-chain, codeql, dco)
- [ ] After merge: future bumps via \`bump-version.sh\` cover all 7 sites

🤖 Generated with [Claude Code](https://claude.com/claude-code)