### PR TITLE
ci(integration): wire up integration tests + fix rotted drift

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,107 @@
+name: integration
+
+# End-to-end tests against a real Zion daemon + a real backend.
+# tests/integration.rs holds 19 #[ignore]d tests that exercise the full
+# pipeline (TLS termination, WAF, cache, SSE, security headers, …) over
+# real sockets. Without this workflow they only run when a developer
+# manually spins up both processes — i.e. effectively never. This job
+# brings them back into the safety net.
+#
+# Layout:
+#   1. Generate a self-signed cert (CN=bench.local, SAN incl. localhost + 127.0.0.1)
+#   2. Build the Rust test backend (benchmarks/backend) and start it on :9090
+#   3. Build zion (release) and start it with tests/zion-test.toml on :8080 / :4433
+#   4. Wait until both answer their health endpoints
+#   5. Run `cargo test --test integration -- --ignored --test-threads=1`
+#   6. On failure dump both daemons' logs; always tear them down at the end.
+
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: integration-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
+  RUST_BACKTRACE: "1"
+
+jobs:
+  integration:
+    name: integration tests (zion + backend on real sockets)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          # Two crates compiled in this job; share a key so cache hits.
+          shared-key: integration
+
+      - name: Generate self-signed cert
+        run: bash benchmarks/certs/generate.sh
+
+      - name: Build zion (release)
+        run: cargo build --release --bin zion
+
+      - name: Build test backend (release)
+        run: cargo build --release --manifest-path benchmarks/backend/Cargo.toml
+
+      - name: Start backend
+        run: |
+          ./benchmarks/backend/target/release/zion-bench-backend > backend.log 2>&1 &
+          echo $! > backend.pid
+
+      - name: Start zion
+        env:
+          ZION_CONFIG: tests/zion-test.toml
+        run: |
+          ./target/release/zion > zion.log 2>&1 &
+          echo $! > zion.pid
+
+      - name: Wait for both daemons to be ready
+        run: |
+          # Backend on :9090 (HTTP) and Zion on :4433 (HTTPS, self-signed).
+          # 30s × 1s ≈ generous enough on cold-start; failure here is real.
+          for i in $(seq 1 30); do
+            backend_ok=0
+            zion_ok=0
+            curl -s --max-time 1 http://127.0.0.1:9090/api/v1/health \
+              > /dev/null 2>&1 && backend_ok=1
+            curl -sk --max-time 1 -H "Host: bench.local" \
+              https://127.0.0.1:4433/healthz > /dev/null 2>&1 && zion_ok=1
+            if [ "$backend_ok" = 1 ] && [ "$zion_ok" = 1 ]; then
+              echo "ready after ${i}s (backend=:9090, zion=:4433)"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::backend and/or zion did not become ready in 30s"
+          echo "--- backend.log ---"; cat backend.log || true
+          echo "--- zion.log ---"; cat zion.log || true
+          exit 1
+
+      - name: Run integration tests
+        run: cargo test --release --test integration -- --ignored --test-threads=1
+
+      - name: Dump daemon logs on failure
+        if: failure()
+        run: |
+          echo "::group::zion.log"; cat zion.log || true; echo "::endgroup::"
+          echo "::group::backend.log"; cat backend.log || true; echo "::endgroup::"
+
+      - name: Tear down daemons
+        if: always()
+        run: |
+          [ -f zion.pid ] && kill "$(cat zion.pid)" 2>/dev/null || true
+          [ -f backend.pid ] && kill "$(cat backend.pid)" 2>/dev/null || true

--- a/benchmarks/backend/src/main.rs
+++ b/benchmarks/backend/src/main.rs
@@ -176,11 +176,32 @@ async fn handle(req: Request<Incoming>) -> Result<Resp, std::convert::Infallible
                 .and_then(|v| v.to_str().ok()).unwrap_or("");
             let xrip = req.headers().get("X-Real-IP")
                 .and_then(|v| v.to_str().ok()).unwrap_or("");
+            let xfp = req.headers().get("X-Forwarded-Proto")
+                .and_then(|v| v.to_str().ok()).unwrap_or("");
+            let query = req.uri().query().unwrap_or("");
             let body = format!(
-                r#"{{"method":"{}","path":"{}","x_forwarded_for":"{}","x_real_ip":"{}"}}"#,
-                req.method(), path, xff, xrip
+                r#"{{"method":"{}","path":"{}","query":"{}","x_forwarded_for":"{}","x_real_ip":"{}","x_forwarded_proto":"{}"}}"#,
+                req.method(), path, query, xff, xrip, xfp
             );
             ok("application/json", Bytes::from(body))
+        }
+
+        // Server-Sent Events. Integration tests inspect body content
+        // (`event: tick`, `"seq":...`), not real-time delivery, so we ship
+        // the full event sequence in one Full<Bytes> rather than pull in a
+        // streaming-body dep. SSE semantics are the proxy's responsibility
+        // (route mode = "sse_stream").
+        "/api/v1/events/stream" => {
+            let mut body = String::with_capacity(96);
+            for i in 0..3 {
+                body.push_str(&format!("event: tick\ndata: {{\"seq\":{i}}}\n\n"));
+            }
+            Response::builder()
+                .status(StatusCode::OK)
+                .header("Content-Type", "text/event-stream")
+                .header("Cache-Control", "no-cache")
+                .body(Full::new(Bytes::from(body)))
+                .unwrap()
         }
 
         "/api/v1/users" => {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -104,9 +104,12 @@ fn zion_is_running() -> bool {
 integration_test!(t01_get_root_returns_200, {
     let (status, body, _) = get("/");
     assert_eq!(status, 200, "GET / should return 200");
+    // Both the Go and Rust test backends serve a "Dashboard" HTML stub.
+    // The earlier "Zion Test Backend" string was stale (no backend ever
+    // emitted it) and only survived because the test was #[ignore]d.
     assert!(
-        body.contains("<h1>Zion Test Backend</h1>"),
-        "should contain test backend HTML"
+        body.contains("<h1>Dashboard</h1>"),
+        "should contain backend dashboard HTML, got: {body}"
     );
 });
 


### PR DESCRIPTION
## Summary

The 19 \`#[ignore]\`d tests in \`tests/integration.rs\` were rotting silently because nothing in CI ever ran them — exactly the failure mode flagged in the codebase audit. New \`integration.yml\` workflow brings them back into the safety net.

**Workflow steps:**
1. Generate self-signed cert (\`benchmarks/certs/generate.sh\`)
2. Build zion (release) + the Rust test backend (\`benchmarks/backend\`)
3. Start backend on :9090 + zion on :4433 (background)
4. Wait for both to answer their health endpoints (30s × 1s)
5. Run \`cargo test --release --test integration -- --ignored --test-threads=1\`
6. Dump daemon logs on failure; tear them down always

**Two pieces of rot the unrun tests had hidden:**

| File | Was | Now |
|---|---|---|
| \`tests/integration.rs\` t01 | asserted \`<h1>Zion Test Backend</h1>\` (no backend ever served this) | matches actual content \`<h1>Dashboard</h1>\` |
| \`benchmarks/backend/src/main.rs\` | \`/api/v1/echo\` lacked \`query\` and \`x_forwarded_proto\` (Go variant had both) | parity with Go backend |
| \`benchmarks/backend/src/main.rs\` | no \`/api/v1/events/stream\` SSE endpoint | added; ships full event sequence in one Full<Bytes>, proxy enforces sse_stream semantics |

The Rust backend file already says \"Endpoints mirror the Go backend exactly for compatibility with bench-native.sh and integration tests\" — that promise had drifted. Now true again.

## Test plan

Local end-to-end repro:

\`\`\`
bash benchmarks/certs/generate.sh
cargo build --release --bin zion
cargo build --release --manifest-path benchmarks/backend/Cargo.toml
./benchmarks/backend/target/release/zion-bench-backend &
ZION_CONFIG=tests/zion-test.toml ./target/release/zion &
cargo test --release --test integration -- --ignored --test-threads=1
→ 19 passed; 0 failed
\`\`\`

Plus the existing test suites:

\`\`\`
cargo test --release                  421 passed
cargo test --release --all-features   463 passed
\`\`\`

- [ ] CI green on the new \`integration\` job
- [ ] After merge: \`tests/integration.rs\` is now load-bearing — every PR runs it

🤖 Generated with [Claude Code](https://claude.com/claude-code)