### PR TITLE
chore(release): v0.1.12 — security + quality bundle

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,7 +21,7 @@ A clear and concise description of what you expected to happen.
 **Environment (please complete the following information):**
  - OS: [e.g. Linux, macOS]
  - Architecture: [e.g. arm64, amd64]
- - Zion Version: [e.g. 0.1.11]
+ - Zion Version: [e.g. 0.1.12]
 
 **Additional context**
 Add any other context about the problem here (e.g. logs with `RUST_LOG=trace`, upstream backend type like Go/Node).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,102 @@
 
 All notable changes to Zion Edge Gateway are documented here.
 
+## [0.1.12] - 2026-05-06
+
+Quality + security release. Closes one Dependabot security alert (medium)
+on the `--features auth` build path, removes the boot-time panic surface,
+extends the SSOT version guard to every documented version reference,
+and brings the `#[ignore]`d integration suite under CI guard so it stops
+rotting silently.
+
+### Security
+
+- **`jsonwebtoken` 9.3.1 → 10.3.0**: closes the GHSA Type Confusion that
+  could lead to authorization bypass on the `--features auth` JWT
+  validator. v10 enforces an explicit choice of CryptoProvider; pinned
+  to `aws_lc_rs` to stay aligned with rustls's backend (and the FIPS
+  build path). (#43)
+
+### Reliability
+
+- **3 boot-time `panic!` / `exit(1)` sites → structured `ZionError`**
+  propagation in `src/main.rs` (router build), `src/auth.rs` (JWT
+  algorithm + missing secret/jwks_url), `src/tls.rs` (cert-dir watcher
+  setup hoisted out of the spawned task). Hot-reload also benefits via
+  the new `try_build` returning `Result`. (#78)
+- **Flaky `rate_limiter_caps_at_rps_within_window` proptest fixed**:
+  invariant relaxed to `<= 2 * rps as usize` to honour the wall-clock
+  window flip the limiter exposes (`SystemTime::now()`-keyed window),
+  with the cross-window scenario explained in a comment. (#77)
+
+### Hardening / Process
+
+- **`Cargo.toml` becomes the version SSOT** for the project. `Cargo.lock`,
+  `deploy/helm/zion/Chart.yaml`, README, `docs/security/supply-chain.md`,
+  `SECURITY.md`, `docs/deploy/hot-reload.md`, and the bug-report issue
+  template are now CI-checked against canonical (#75, #80).
+  `scripts/bump-version.sh X.Y.Z` propagates to all 7 sites atomically.
+- **DCO sign-off enforced locally** via `.githooks/prepare-commit-msg`
+  (auto-injects the trailer) and `commit-msg` (refuses commits without
+  one). `scripts/install-hooks.sh` switched to
+  `git config core.hooksPath .githooks` so hooks update on `git pull`. (#75)
+- **README headline numbers (modules / LoC / tests) become an SSOT**
+  produced by `scripts/update-readme-stats.sh`; CI fails on drift.
+  Underlying script bug fixed: previously did `find -maxdepth 1` and
+  `wc -l src/*.rs`, missing `src/sovereign/`. (#76)
+
+### Quality / Polish
+
+- **SPDX `Apache-2.0` header on every Rust file** (32 files in `src/` +
+  `tests/`) so the licence is machine-readable for SBOM scanners. (#79)
+- **Complete `unsafe` SAFETY audit**: 11/11 unsafe blocks now carry a
+  `// SAFETY:` note; added the missing one on `src/net.rs::tune_accepted`. (#79)
+- **Module-level docstrings** added on the five files that lacked them:
+  `config.rs`, `dispatch.rs`, `main.rs`, `proxy.rs`, `tls.rs`. (#78)
+- **Dead-code cleanup**: 5 unreachable items removed
+  (`cache.rs::ensure_l1`, `bootstrap.rs::tune_accepted_socket`,
+  `tune_listener_socket`, `Platform.recv_buf`, `auth.rs::AuthError::MissingToken`).
+  The remaining ~45 `#[allow(dead_code)]` annotations are intentional
+  (feature-gated, future-API hooks, deser-only struct fields, test
+  helpers) and already documented. (#81)
+- **Stale `RELEASE_NOTES.md` removed**: it was a v0.1.6-specific
+  announcement that nobody refreshed; `CHANGELOG.md` + GitHub Releases
+  cover the role. (#83)
+- **README OpenSSF Baseline badge** in place of the broken Scorecard
+  badge (publish_results was disabled in v0.1.10 to satisfy the
+  Scorecard webapp constraint, which in turn broke the badge endpoint). (#74)
+
+### CI
+
+- **New `integration` workflow**: spins up the test backend on `:9090`
+  and zion on `:4433` (with a self-signed cert via
+  `benchmarks/certs/generate.sh`) and runs the 19 `#[ignore]`d
+  integration tests. They were rotting silently — now load-bearing on
+  every PR. (#82)
+  - Two pieces of rot the unrun tests had hidden are also fixed in this
+    release: `tests/integration.rs::t01` asserted `<h1>Zion Test Backend</h1>`
+    (no backend ever served this string), and the Rust test backend
+    lacked the `query` / `x_forwarded_proto` echo fields and the
+    `/api/v1/events/stream` SSE endpoint that the tests rely on.
+- **New `version-sync` and `readme-stats-sync` workflows** wire the SSOT
+  scripts above into per-PR enforcement. (#75, #76)
+- **Branch protection cleaned**: dropped `SBOM (CycloneDX)` from
+  required status checks (release-only, was never green on PRs and made
+  every PR `mergeStateStatus: BLOCKED`); fixed `DCO` → `dco-check` name
+  mismatch.
+
+### Verification
+
+```text
+cargo fmt --all -- --check                          # OK
+cargo clippy --locked --all-targets --all-features -- -D warnings   # OK
+cargo test  --release                  → 421 passed (lib + main bin + chaos)
+cargo test  --release --all-features   → 463 passed
+integration tests (CI)                 → 19 passed
+scripts/check-version-sync.sh          # OK across 7 reference sites
+scripts/update-readme-stats.sh --check # in sync
+```
+
 ## [0.1.11] - 2026-05-06
 
 Process hardening — version becomes single-source-of-truth, DCO sign-off

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3534,7 +3534,7 @@ dependencies = [
 
 [[package]]
 name = "zion"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "aho-corasick",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zion"
-version = "0.1.11"
+version = "0.1.12"
 edition = "2021"
 # MSRV is the *core* default-features build (TLS proxy + WAF + cache + metrics).
 # Opt-in features (acme, auth, init, http3) pull crypto/i18n crates that have

--- a/README.md
+++ b/README.md
@@ -326,12 +326,12 @@ commands. The short version:
 
 ```bash
 # Binary release (Sigstore-backed provenance via gh CLI)
-gh release download v0.1.11 -R fabriziosalmi/zion -p '*x86_64-unknown-linux-musl*' -p 'SHA256SUMS'
+gh release download v0.1.12 -R fabriziosalmi/zion -p '*x86_64-unknown-linux-musl*' -p 'SHA256SUMS'
 sha256sum --check --ignore-missing SHA256SUMS
-gh attestation verify zion-v0.1.11-x86_64-unknown-linux-musl.tar.gz --owner fabriziosalmi
+gh attestation verify zion-v0.1.12-x86_64-unknown-linux-musl.tar.gz --owner fabriziosalmi
 
 # Container image (cosign keyless)
-cosign verify ghcr.io/fabriziosalmi/zion:v0.1.11 \
+cosign verify ghcr.io/fabriziosalmi/zion:v0.1.12 \
     --certificate-identity-regexp "^https://github.com/fabriziosalmi/zion/\\.github/workflows/release\\.yml@refs/tags/v" \
     --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ from their containing minor — i.e. the latest `0.1.x` is always patched.
 | Version | Supported |
 | ------- | --------- |
 | 0.1.x (latest minor) | Yes |
-| < 0.1.11 | No |
+| < 0.1.12 | No |
 
 ## Reporting a Vulnerability
 

--- a/deploy/helm/zion/Chart.yaml
+++ b/deploy/helm/zion/Chart.yaml
@@ -3,7 +3,7 @@ name: zion
 description: Zion Edge Gateway — high-performance Rust TLS reverse proxy with WAF
 type: application
 version: 0.2.2
-appVersion: "0.1.11"
+appVersion: "0.1.12"
 home: https://fabriziosalmi.github.io/zion
 sources:
   - https://github.com/fabriziosalmi/zion

--- a/docs/deploy/hot-reload.md
+++ b/docs/deploy/hot-reload.md
@@ -130,7 +130,7 @@ Two surfaces report the reload state:
 
   ```json
   {
-    "version": "0.1.11",
+    "version": "0.1.12",
     "timestamp_ms": 1714425600000,
     "uptime_secs": 3712,
     "config_generation": 5,

--- a/docs/security/supply-chain.md
+++ b/docs/security/supply-chain.md
@@ -46,8 +46,8 @@ You need the GitHub CLI (`gh >= 2.49`) and `cosign >= 2.2`.
 
 ```bash
 # 1. Download the artifact + SHA256SUMS from the release page.
-gh release download v0.1.11 -R fabriziosalmi/zion \
-    -p 'zion-v0.1.11-x86_64-unknown-linux-musl.tar.gz' \
+gh release download v0.1.12 -R fabriziosalmi/zion \
+    -p 'zion-v0.1.12-x86_64-unknown-linux-musl.tar.gz' \
     -p 'SHA256SUMS' \
     -p 'zion-sbom.cdx.json'
 
@@ -55,7 +55,7 @@ gh release download v0.1.11 -R fabriziosalmi/zion \
 sha256sum --check --ignore-missing SHA256SUMS
 
 # 3. Verify the SLSA build provenance bound to the artifact's hash.
-gh attestation verify zion-v0.1.11-x86_64-unknown-linux-musl.tar.gz \
+gh attestation verify zion-v0.1.12-x86_64-unknown-linux-musl.tar.gz \
     --owner fabriziosalmi
 
 # Step 3 fails if:
@@ -78,7 +78,7 @@ grype zion-sbom.cdx.json
 ## Verifying a container image
 
 ```bash
-IMAGE=ghcr.io/fabriziosalmi/zion:v0.1.11
+IMAGE=ghcr.io/fabriziosalmi/zion:v0.1.12
 
 # 1. Pin to the digest immediately — tags are mutable, digests are not.
 DIGEST=$(crane digest "$IMAGE")
@@ -120,7 +120,7 @@ deterministically, and pins the Rust toolchain via
 [`rust-toolchain.toml`](../../rust-toolchain.toml). To reproduce locally:
 
 ```bash
-git checkout v0.1.11
+git checkout v0.1.12
 export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)
 # Linux musl example — matches the release artifact byte-for-byte
 # (modulo strip's stable behavior on your distro).


### PR DESCRIPTION
## Summary

Patch release bundling 10 commits since v0.1.11. Headline reasons to cut now:

1. **Security** — closes a Dependabot \`medium\` alert on \`jsonwebtoken\` (Type Confusion → potential authorization bypass on \`--features auth\`).
2. **Reliability** — boot-time panic surface eliminated; flaky proptest stabilised.
3. **Process** — version + README-stats SSOT guards now cover the 7 sites people kept letting drift; integration suite no longer rots silently.

| Section | What landed |
|---|---|
| Security | jsonwebtoken 9.3.1 → 10.3.0 + aws_lc_rs CryptoProvider (#43) |
| Reliability | 3 boot panics → \`ZionError\` (#78); flaky proptest \`<= 2*rps\` (#77) |
| Hardening | version SSOT (#75, #80); DCO local hooks (#75); README stats SSOT (#76) |
| Polish | SPDX on 32 files + unsafe audit (#79); module docs (#78); -5 dead-code items (#81); RELEASE_NOTES removed (#83); OpenSSF badge (#74) |
| CI | new \`integration\` workflow (#82) + \`version-sync\` + \`readme-stats-sync\` |

Plus a pre-release housekeeping (not in this PR): the orphan \`v1.1.0\` and \`v1.2.0\` ghost tags from a long-abandoned release-train have been deleted from origin so v0.1.12 surfaces cleanly as the latest tag.

## Verification

\`\`\`
cargo fmt --all -- --check                           # OK
cargo clippy --locked --all-targets --all-features -- -D warnings   # OK
cargo test  --release                  → 421 passed
cargo test  --release --all-features   → 463 passed
integration tests (CI on master HEAD)  → 19 passed
scripts/check-version-sync.sh          # OK across 7 sites
scripts/update-readme-stats.sh --check # in sync
\`\`\`

## Post-merge

\`\`\`
git tag -a v0.1.12 -m "v0.1.12"
git push origin v0.1.12
\`\`\`

→ triggers \`release.yml\` (multi-arch builds + cosign + SBOM + GitHub Release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)