### PR TITLE
docs(readme): surface v0.2.x tracks; drop stale TCP_CORK + multishot claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ Payload x concurrency grid -- measures end-to-end TLS throughput. These numbers 
 
 ## Features
 
+**v0.2.x Tracks (feature-gated, default-off)**
+- **XDP pre-filter** (`--features xdp`, Linux): eBPF LPM-trie drop at the NIC driver layer. Blocked source IPs never reach the userspace TLS handshake — frees CPU for legitimate traffic and keeps the WAF gate cheap.
+- **kTLS post-handshake offload** (`--features ktls`, Linux 5.10+ with `CONFIG_TLS=y`): once the rustls handshake completes the socket is flipped into in-kernel TLS via `SOL_TLS`. Removes the userspace AEAD trip and unlocks `sendfile`-class zero-copy for static cache hits. Handshake cipher must be TLS 1.3 AES-GCM or ChaCha20-Poly1305. Falls back to userspace TLS on upgrade failure.
+- **ML-augmented WAF** (`--features ml-waf`): 16-dim feature extractor + tract-onnx scorer on the WAF hot path, 200µs p99 budget. The score is reported as a metric and travels into the request as a header — never a hard gate; the local Aho-Corasick + entropy gate stays authoritative.
+- **AIMP serverless mesh** (`--features sovereign-aimp`): Ed25519-signed UDP gossip of WAF rule deltas + IP-reputation across a fleet, source-bound revocation, replay LRU, ts-window admission, last-writer-wins merge, periodic anti-entropy. No central control plane — each node keeps serving with its last known map when the mesh partitions. Configure under `[sovereign_aimp]` in `zion.toml` (or via `ZION_AIMP_*` env vars for back-compat).
+
 **Core Proxy**
 - TLS 1.3 termination (rustls + hardware crypto: AES-NI, AES-CE)
 - HTTP/2 upstream multiplexing (hyper-rustls ALPN negotiation)
@@ -142,8 +148,8 @@ Payload x concurrency grid -- measures end-to-end TLS throughput. These numbers 
 - Platform JSON dump for CI / automation (`zion bootstrap`)
 - WAF Shadow Mode (`waf_shadow = true`) — log + count, never block
 - JSON snapshot endpoint (`/_zion/snapshot.json`, internal-only)
-- TCP tuning: TCP_NODELAY, TCP_DEFER_ACCEPT, TCP_FASTOPEN, TCP_QUICKACK, TCP_CORK, SO_BUSY_POLL
-- SO_REUSEPORT, sys_membarrier, io_uring multishot accept (Linux)
+- TCP tuning: TCP_NODELAY, TCP_DEFER_ACCEPT, TCP_FASTOPEN, TCP_QUICKACK, SO_BUSY_POLL
+- SO_REUSEPORT, sys_membarrier, io_uring single-shot accept (Linux, `--features io-uring-accept`)
 - `target-cpu=native` build optimization, PGO build script included
 - systemd unit file + Docker HEALTHCHECK
 


### PR DESCRIPTION
## Summary

The repo home page README was still describing v0.1.x — readers had
no way to see XDP / kTLS / ML-WAF / AIMP unless they dug into the
CHANGELOG. The docs site fixed this in #90; this PR syncs the README.

## Changes (1 file, additive)

* New top-level **"v0.2.x Tracks (feature-gated, default-off)"** block in `## Features`. Each bullet names the feature flag and the actual runtime payoff:
  - `--features xdp` — eBPF LPM-trie drop at NIC driver layer
  - `--features ktls` — in-kernel TLS post-handshake (Linux 5.10+)
  - `--features ml-waf` — ONNX score on the WAF hot path; signal, not a gate
  - `--features sovereign-aimp` — Ed25519-signed mesh with anti-entropy + `[sovereign_aimp]` TOML
* **Stale claims removed**:
  - `TCP_CORK` was removed in v0.2.1 (commit fd81910) — caused the deterministic ~200 ms /healthz stall. Dropped from the TCP-tuning bullet.
  - `io_uring multishot accept` → `io_uring single-shot accept (--features io-uring-accept)` — switched in v0.2.2 / PR #89 to close the ENOTSOCK race under load.

## Test plan

- [ ] CI green on this PR (`version-sync`, `readme-stats-sync`, `check`, `DCO`)
- [ ] After merge: docs site nav still says v0.2.2; rendered README on github.com shows the v0.2.x track block

🤖 Generated with [Claude Code](https://claude.com/claude-code)