### PR TITLE
feat(perf): Criterion microbench harness (#54)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,139 @@
+# Microbench — Criterion harness for the v0.2 perf-ceiling work (issue #54).
+#
+# Trigger: manual `workflow_dispatch` only. Microbenchmarks need a stable,
+# noise-free runner; the GitHub-hosted ubuntu-latest is too noisy for
+# reliable variance numbers, so this workflow is opt-in and the comparison
+# is best-effort. The numbers it posts are *signals*, not gates — a regression
+# alert here means "look", not "fail the build".
+#
+# What the workflow does:
+#   1. Build the bench binaries (release profile + debug-info, see Cargo.toml).
+#   2. Run criterion against the PR head, capture target/criterion/*.json.
+#   3. If invoked from a PR, build master at the merge-base and re-run, then
+#      diff the two estimates.json trees to surface deltas.
+#   4. Post the delta summary as a single PR comment (compact table).
+#
+# Artifact retention is 14 days — long enough for a humans-in-the-loop review
+# cycle, short enough to keep storage bills sensible.
+
+name: bench
+
+on:
+  workflow_dispatch:
+    inputs:
+      bench:
+        description: "Bench filter (criterion regex). Empty = all benches."
+        required: false
+        default: ""
+      pr:
+        description: "Pull request number to compare against (optional)."
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: bench-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
+  RUST_BACKTRACE: "1"
+
+jobs:
+  criterion:
+    name: criterion (ubuntu-latest)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2
+
+      - name: bench (head)
+        run: |
+          mkdir -p bench-out/head
+          cargo bench --no-default-features --bench waf_streaming -- "${{ inputs.bench }}" || exit 1
+          cargo bench --no-default-features --bench traceparent  -- "${{ inputs.bench }}"
+          cargo bench --no-default-features --bench audit_hmac   -- "${{ inputs.bench }}"
+          cargo bench --no-default-features --bench sovereign    -- "${{ inputs.bench }}"
+          cargo bench --no-default-features --bench cache_lookup -- "${{ inputs.bench }}"
+          # criterion writes per-bench JSON estimates under target/criterion/.
+          # Snapshot them now so the master rebuild below cannot clobber them.
+          cp -R target/criterion bench-out/head/criterion
+
+      - name: bench (master baseline)
+        if: github.event_name == 'pull_request' || inputs.pr != ''
+        run: |
+          mkdir -p bench-out/master
+          # Determine merge-base. For workflow_dispatch with a PR input,
+          # `gh pr view` would resolve the head ref; we fall back to
+          # comparing against origin/master tip.
+          BASE=$(git merge-base HEAD origin/master || echo origin/master)
+          git -c advice.detachedHead=false checkout "$BASE"
+          # Reuse cargo cache; clean only the criterion output.
+          rm -rf target/criterion
+          cargo bench --no-default-features --bench waf_streaming -- "${{ inputs.bench }}"
+          cargo bench --no-default-features --bench traceparent  -- "${{ inputs.bench }}"
+          cargo bench --no-default-features --bench audit_hmac   -- "${{ inputs.bench }}"
+          cargo bench --no-default-features --bench sovereign    -- "${{ inputs.bench }}"
+          cargo bench --no-default-features --bench cache_lookup -- "${{ inputs.bench }}"
+          cp -R target/criterion bench-out/master/criterion
+          git checkout -
+
+      - name: diff vs master
+        if: github.event_name == 'pull_request' || inputs.pr != ''
+        run: |
+          python3 scripts/criterion-diff.py \
+            --head bench-out/head/criterion \
+            --base bench-out/master/criterion \
+            --threshold-pct 5 \
+            --out bench-out/delta.md
+          cat bench-out/delta.md
+
+      - name: upload artifacts
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
+        with:
+          name: criterion-${{ github.run_id }}
+          path: bench-out/
+          retention-days: 14
+          if-no-files-found: error
+
+      - name: comment on PR
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = 'bench-out/delta.md';
+            if (!fs.existsSync(path)) { return; }
+            const body = fs.readFileSync(path, 'utf8');
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.user.type === 'Bot' && c.body.startsWith('<!-- bench-bot -->'));
+            const tagged = `<!-- bench-bot -->\n${body}`;
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: tagged,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: tagged,
+              });
+            }

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,18 @@
 /target
 *.DS_Store
 
-# Benchmark results (generated, large, machine-specific)
-benchmarks/results/
+# Benchmark results (generated, large, machine-specific). We ignore each
+# child rather than the directory itself because git cannot re-include
+# files below a fully-excluded directory (see `gitignore(5)` — "It is not
+# possible to re-include a file if a parent directory of that file is
+# excluded.").
+benchmarks/results/*
+!benchmarks/results/criterion
+benchmarks/results/criterion/*
+# Criterion baseline JSON IS checked in (issue #54): it's small,
+# hand-curated, and the trend-tracking signal lives in version control
+# rather than CI cache.
+!benchmarks/results/criterion/baseline.json
 
 # Generated benchmark artifacts
 benchmarks/results/**/*.svg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to Zion Edge Gateway are documented here.
 
+## [Unreleased]
+
+### Added
+
+- **Criterion microbench harness** — five `cargo bench` targets under
+  `benches/` (waf_streaming, sovereign, traceparent, audit_hmac,
+  cache_lookup) covering the hot-path components named in
+  [docs/perf/roadmap.md](docs/perf/roadmap.md). Numbers checked in at
+  `benchmarks/results/criterion/baseline.json` for trend tracking; CI
+  workflow `bench.yml` runs the suite on manual dispatch and posts a
+  delta-vs-master summary as a PR comment. See
+  [docs/perf/microbench.md](docs/perf/microbench.md). (#54)
+
+### Changed
+
+- **`WafMode` and `WafProfile` moved from `config` to `waf`** — semantic
+  home, and lets the bench harness construct profiles via the lib
+  surface without dragging the full config-loader dependency graph.
+  `config::{WafMode, WafProfile}` re-exports preserve every existing
+  import site; no breaking change.
+
 ## [0.2.2] - 2026-05-08
 
 Wire-up release. v0.2.0 / v0.2.1 introduced the XDP / ML-WAF / AIMP

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,6 +122,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -475,7 +481,7 @@ dependencies = [
  "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -570,6 +576,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -639,6 +651,33 @@ dependencies = [
  "cipher",
  "poly1305",
  "zeroize",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -857,6 +896,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -1921,6 +1994,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2570,6 +2654,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2967,7 +3057,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -4085,6 +4175,16 @@ checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -5351,6 +5451,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "core_affinity",
+ "criterion",
  "crossterm 0.28.1",
  "dashmap 6.1.0",
  "fnv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -218,6 +218,36 @@ sovereign-aimp = ["sovereign-signals", "dep:aimp_node", "dep:rmp-serde"]
 # Track C — property-based testing (proptest) only used by `cargo test`.
 [dev-dependencies]
 proptest = { version = "1", default-features = false, features = ["std"] }
+# Criterion microbench harness (issue #54). Pinned to 0.5; the `html_reports`
+# default feature is dropped — we publish a JSON baseline (target/criterion/
+# *.json) and the GitHub Actions runner has no browser to render HTML in.
+criterion = { version = "0.5", default-features = false, features = ["cargo_bench_support"] }
+# DashMap is also a runtime dep, but the cache-lookup bench needs to construct
+# its own L2-shaped fixture without dragging in `crate::cache` (which pulls
+# bootstrap/metrics/reload). Listing it here is a no-op for the binary.
+
+# ─── Microbenchmark targets (issue #54) ──────────────────────────────────
+# `harness = false` disables the libtest harness so `criterion::criterion_main!`
+# can take over. Each entry maps to a file under `benches/`.
+[[bench]]
+name = "waf_streaming"
+harness = false
+
+[[bench]]
+name = "sovereign"
+harness = false
+
+[[bench]]
+name = "traceparent"
+harness = false
+
+[[bench]]
+name = "audit_hmac"
+harness = false
+
+[[bench]]
+name = "cache_lookup"
+harness = false
 
 [profile.release]
 opt-level = 3
@@ -225,3 +255,12 @@ lto = "fat"
 codegen-units = 1
 strip = true
 panic = "abort"
+
+# Bench profile inherits release optimizations but keeps debug info enabled
+# for flamegraph/perf attribution. Same opt-level as release ensures bench
+# numbers reflect the shipped binary, not a debug build.
+[profile.bench]
+opt-level = 3
+lto = "thin"
+codegen-units = 16
+debug = true

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ Results saved to `benchmarks/bench-history.json` with automatic delta comparison
 ## Testing
 
 ```bash
-# Unit tests (421) <!-- zion-stats:test-count (kept in sync by scripts/update-readme-stats.sh) -->
+# Unit tests (533) <!-- zion-stats:test-count (kept in sync by scripts/update-readme-stats.sh) -->
 cargo test
 
 # Integration tests (19 -- requires running Zion + backend)

--- a/benches/audit_hmac.rs
+++ b/benches/audit_hmac.rs
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Microbench: audit log HMAC chain throughput.
+//!
+//! Tracks two surfaces that compose the audit-log hot path:
+//!   * `compute_hmac` — pure HMAC-SHA256 over `event_json || '|' || prev_hash`;
+//!   * `sign_event` — full `serialize → hmac → wrap` for one chain link.
+//!
+//! Throughput is reported in events/sec. The audit writer is async (mpsc),
+//! so this bench measures the *signing* cost only — the disk-flush cost is
+//! orthogonal and lives in a separate harness.
+
+use aws_lc_rs::hmac;
+use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+use zion::audit::{compute_hmac, genesis_hash, sign_event, AuditEvent};
+
+fn key() -> hmac::Key {
+    // 32 bytes of stable test material — `cargo bench` reruns must be
+    // deterministic so criterion's regression detector works.
+    let raw = [0xA5u8; 32];
+    hmac::Key::new(hmac::HMAC_SHA256, &raw)
+}
+
+fn typical_event() -> AuditEvent {
+    AuditEvent {
+        seq: 1,
+        ts: "2026-05-08T12:00:00Z".into(),
+        kind: "request_blocked",
+        trace_id: Some("0af7651916cd43dd8448eb211c80319c".into()),
+        remote_ip: Some("203.0.113.5".into()),
+        method: Some("POST".into()),
+        path: Some("/api/v1/widgets".into()),
+        detail: Some("waf=balanced reason=injection_pattern_detected".into()),
+    }
+}
+
+fn bench_compute_hmac(c: &mut Criterion) {
+    let k = key();
+    let event = typical_event();
+    let json = serde_json::to_string(&event).unwrap();
+    let prev = genesis_hash(&k);
+
+    let mut g = c.benchmark_group("audit/compute_hmac");
+    g.throughput(Throughput::Bytes(json.len() as u64));
+    g.bench_function("typical_event", |b| {
+        b.iter(|| {
+            let h = compute_hmac(black_box(&k), black_box(&json), black_box(&prev));
+            black_box(h)
+        })
+    });
+    // Larger detail blob — represents an `auth_failure` with a verbose
+    // audit detail field. Worst-case shape we encode in production.
+    let big_event = AuditEvent {
+        detail: Some("x".repeat(2048)),
+        ..typical_event()
+    };
+    let big_json = serde_json::to_string(&big_event).unwrap();
+    g.throughput(Throughput::Bytes(big_json.len() as u64));
+    g.bench_function("verbose_2kb_detail", |b| {
+        b.iter(|| {
+            let h = compute_hmac(black_box(&k), black_box(&big_json), black_box(&prev));
+            black_box(h)
+        })
+    });
+    g.finish();
+}
+
+fn bench_sign_event(c: &mut Criterion) {
+    let k = key();
+    let mut g = c.benchmark_group("audit/sign_event");
+    g.throughput(Throughput::Elements(1));
+    g.bench_function("single_link", |b| {
+        let prev = genesis_hash(&k);
+        b.iter_batched(
+            || (typical_event(), prev.clone()),
+            |(ev, prev)| {
+                let (signed, new_prev) = sign_event(black_box(&k), ev, prev).unwrap();
+                black_box((signed, new_prev))
+            },
+            criterion::BatchSize::SmallInput,
+        )
+    });
+    g.finish();
+}
+
+fn bench_chain_throughput(c: &mut Criterion) {
+    // Sustained chain throughput: how many events/sec can we sign if each
+    // event's `prev_hash` feeds the next? This is the bottleneck for the
+    // audit writer when the queue is saturated.
+    let k = key();
+    let mut g = c.benchmark_group("audit/chain");
+    g.throughput(Throughput::Elements(64));
+    g.bench_function("64_link_chain", |b| {
+        b.iter(|| {
+            let mut prev = genesis_hash(black_box(&k));
+            for _ in 0..64 {
+                let (_, new_prev) = sign_event(&k, typical_event(), prev).unwrap();
+                prev = new_prev;
+            }
+            black_box(prev)
+        })
+    });
+    g.finish();
+}
+
+fn bench_genesis(c: &mut Criterion) {
+    let k = key();
+    c.bench_function("audit/genesis_hash", |b| {
+        b.iter(|| black_box(genesis_hash(black_box(&k))))
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_compute_hmac,
+    bench_sign_event,
+    bench_chain_throughput,
+    bench_genesis
+);
+criterion_main!(benches);

--- a/benches/cache_lookup.rs
+++ b/benches/cache_lookup.rs
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Microbench: cache lookup paths.
+//!
+//! Measures the same shape `crate::cache::StaticCache` exposes, but on
+//! synthetic fixtures so the bench does not pull in `crate::bootstrap`,
+//! `crate::metrics`, or `crate::reload` (none of which fit a portable
+//! lib surface — they touch hardware probes and global atomics owned
+//! by the binary).
+//!
+//! What's modeled:
+//!   * **L1 hit**: thread-local `HashMap<Arc<str>, Bytes>` lookup. Same
+//!     data shape as `cache::L1Cache` (LRU touched only on miss; hits
+//!     are pure reads).
+//!   * **L2 hit**: `dashmap::DashMap<Arc<str>, Bytes>` get + clone of
+//!     a small body. Mirrors the production hot path step-for-step.
+//!   * **Full miss**: lookup against an empty L1 + L2 (`get` returns
+//!     `None`).
+//!   * **Singleflight coalesce**: when N callers race on the same miss,
+//!     only one origin fetch fires; the rest park on a oneshot. Modeled
+//!     here with `tokio::sync::OnceCell` to bound the contention cost.
+//!
+//! If `crate::cache` ever grows a more reachable test surface (e.g.
+//! `pub use cache::StaticCache` from `lib.rs`), this bench should be
+//! migrated to it. Until then, the synthetic shape is close enough to
+//! detect regressions in the *algorithms* — not the wiring.
+
+use bytes::Bytes;
+use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+use dashmap::DashMap;
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+const POPULATED: usize = 10_000;
+const SMALL_BODY: usize = 256;
+
+fn body(size: usize) -> Bytes {
+    Bytes::from(vec![b'x'; size])
+}
+
+fn make_keys(n: usize) -> Vec<Arc<str>> {
+    (0..n)
+        .map(|i| Arc::<str>::from(format!("/path/segment/{i}")))
+        .collect()
+}
+
+fn populated_l2(n: usize) -> (DashMap<Arc<str>, Bytes>, Vec<Arc<str>>) {
+    let map = DashMap::with_capacity(n);
+    let keys = make_keys(n);
+    for k in &keys {
+        map.insert(k.clone(), body(SMALL_BODY));
+    }
+    (map, keys)
+}
+
+thread_local! {
+    static L1_FIXTURE: RefCell<HashMap<Arc<str>, Bytes>> = RefCell::new(HashMap::new());
+}
+
+fn populate_thread_local(keys: &[Arc<str>]) {
+    L1_FIXTURE.with(|m| {
+        let mut m = m.borrow_mut();
+        m.clear();
+        for k in keys {
+            m.insert(k.clone(), body(SMALL_BODY));
+        }
+    });
+}
+
+fn bench_l1_hit(c: &mut Criterion) {
+    let keys = make_keys(POPULATED);
+    populate_thread_local(&keys);
+    let probe = keys[POPULATED / 2].clone();
+
+    let mut g = c.benchmark_group("cache/l1");
+    g.throughput(Throughput::Elements(1));
+    g.bench_function("hit", |b| {
+        b.iter(|| {
+            L1_FIXTURE.with(|m| {
+                let m = m.borrow();
+                let r = m.get(black_box(&*probe));
+                black_box(r.cloned())
+            })
+        })
+    });
+    g.bench_function("miss", |b| {
+        let absent: Arc<str> = Arc::from("/not/in/l1");
+        b.iter(|| {
+            L1_FIXTURE.with(|m| {
+                let m = m.borrow();
+                black_box(m.get(black_box(&*absent)).cloned())
+            })
+        })
+    });
+    g.finish();
+}
+
+fn bench_l2_hit(c: &mut Criterion) {
+    let (map, keys) = populated_l2(POPULATED);
+    let probe = keys[POPULATED / 2].clone();
+    let absent: Arc<str> = Arc::from("/not/in/l2");
+
+    let mut g = c.benchmark_group("cache/l2");
+    g.throughput(Throughput::Elements(1));
+    g.bench_function("hit", |b| {
+        b.iter(|| {
+            let entry = map.get(black_box(&probe));
+            black_box(entry.map(|e| e.value().clone()))
+        })
+    });
+    g.bench_function("miss", |b| {
+        b.iter(|| {
+            let entry = map.get(black_box(&absent));
+            black_box(entry.is_none())
+        })
+    });
+    g.finish();
+}
+
+fn bench_full_miss(c: &mut Criterion) {
+    // Empty L1 + L2: both reads miss, we measure the cost of failing fast.
+    let l2: DashMap<Arc<str>, Bytes> = DashMap::new();
+    let probe: Arc<str> = Arc::from("/anything");
+
+    let mut g = c.benchmark_group("cache/full_miss");
+    g.throughput(Throughput::Elements(1));
+    g.bench_function("l1_then_l2_both_miss", |b| {
+        b.iter(|| {
+            let l1_hit = L1_FIXTURE.with(|m| m.borrow().get(&*probe).cloned());
+            if l1_hit.is_some() {
+                return black_box(l1_hit);
+            }
+            let entry = l2.get(black_box(&probe));
+            black_box(entry.map(|e| e.value().clone()))
+        })
+    });
+    g.finish();
+}
+
+fn bench_singleflight_coalesce(c: &mut Criterion) {
+    // Coalesce model: N callers race on the same miss. Without coalescing
+    // each caller would fire an origin fetch; with `OnceCell` only the
+    // first does the work, the rest park on it. We bench the single-call
+    // path here (no contention) — the value is the regression baseline:
+    // any future singleflight-coalesce implementation must not regress
+    // this number in the uncontended case.
+    use tokio::sync::OnceCell;
+    let cell: OnceCell<Bytes> = OnceCell::new();
+    cell.set(body(SMALL_BODY)).unwrap();
+
+    let mut g = c.benchmark_group("cache/singleflight");
+    g.throughput(Throughput::Elements(1));
+    g.bench_function("oncecell_uncontended_get", |b| {
+        b.iter(|| black_box(cell.get().cloned()))
+    });
+    g.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_l1_hit,
+    bench_l2_hit,
+    bench_full_miss,
+    bench_singleflight_coalesce
+);
+criterion_main!(benches);

--- a/benches/sovereign.rs
+++ b/benches/sovereign.rs
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Microbench: Sovereign Edge Intelligence — IP classification + counters.
+//!
+//! Tracks two surfaces:
+//!   * `record_classification` — single relaxed `fetch_add` on a per-class
+//!     atomic counter. The previous `format!()`-based label path was
+//!     replaced with `IpClass::index() → CLASS_COUNTERS[i]`, eliminating
+//!     a `String` allocation on every request. The current cost should be
+//!     in the low-nanosecond range; this bench guards the regression.
+//!   * `classify` — `O(log N)` binary search over a sorted `CidrEntry`
+//!     array for IPv4. With no `geo-*` feature the dataset is empty and
+//!     the function is purely the `match` over `IpAddr`; the result is a
+//!     baseline that downstream binaries with `geo-ita` can compare
+//!     against to size their classification overhead.
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use zion::sovereign::{classify, record_classification, IpClass};
+
+fn bench_record_classification(c: &mut Criterion) {
+    let mut g = c.benchmark_group("sovereign/record_classification");
+    g.throughput(Throughput::Elements(1));
+    // The previous `format!()` baseline allocated ~16 B/call. The current
+    // path is 1 atomic increment. Keep this bench so the regression is
+    // visible if anyone refactors `record_classification` and re-introduces
+    // a String allocation.
+    g.bench_function("residential_ita", |b| {
+        b.iter(|| record_classification(black_box(IpClass::ResidentialIta)))
+    });
+    g.bench_function("unknown", |b| {
+        b.iter(|| record_classification(black_box(IpClass::Unknown)))
+    });
+    g.bench_function("gov_ita", |b| {
+        b.iter(|| record_classification(black_box(IpClass::GovIta)))
+    });
+    g.finish();
+}
+
+fn bench_classify(c: &mut Criterion) {
+    let mut g = c.benchmark_group("sovereign/classify");
+    g.throughput(Throughput::Elements(1));
+
+    // IPv4 in the residential-ITA range (Telecom Italia: 79.16.0.0/14).
+    // With `geo-ita` enabled the classifier returns ResidentialIta;
+    // without the feature, the dataset is empty so this measures the
+    // bare match + binary-search-on-empty cost.
+    let v4 = IpAddr::V4(Ipv4Addr::new(79, 17, 100, 200));
+    g.bench_function("ipv4_in_range", |b| {
+        b.iter(|| black_box(classify(black_box(v4))))
+    });
+
+    // IPv4-mapped IPv6 (`::ffff:a.b.c.d`) — should hit the v4 path.
+    let mapped = IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0x4f11, 0x64c8));
+    g.bench_function("ipv6_v4mapped", |b| {
+        b.iter(|| black_box(classify(black_box(mapped))))
+    });
+
+    // Pure IPv6 — must early-return Unknown without entering the search.
+    let v6 = IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1));
+    g.bench_function("ipv6_pure", |b| {
+        b.iter(|| black_box(classify(black_box(v6))))
+    });
+
+    // Public IPv4 outside any baked range — full O(log N) miss.
+    let miss = IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8));
+    g.bench_function("ipv4_miss", |b| {
+        b.iter(|| black_box(classify(black_box(miss))))
+    });
+    g.finish();
+}
+
+fn bench_label_lookup(c: &mut Criterion) {
+    // `IpClass::as_str` is on the metrics-render path. Constant-time match;
+    // benched here so any refactor that replaces it with a `format!()` or
+    // `.to_string()` is caught immediately.
+    let mut g = c.benchmark_group("sovereign/as_str");
+    g.bench_function("residential_ita", |b| {
+        b.iter(|| black_box(black_box(IpClass::ResidentialIta).as_str()))
+    });
+    g.bench_function("unknown", |b| {
+        b.iter(|| black_box(black_box(IpClass::Unknown).as_str()))
+    });
+    g.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_record_classification,
+    bench_classify,
+    bench_label_lookup
+);
+criterion_main!(benches);

--- a/benches/traceparent.rs
+++ b/benches/traceparent.rs
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Microbench: W3C `traceparent` parser.
+//!
+//! Tracks `zion::observability::parse_traceparent` on three input shapes:
+//!   * RFC-valid header (the happy path);
+//!   * outright garbage (a regression bench for the anti-panic guarantee — a
+//!     zero-byte / overflowed input must return `None`, never panic);
+//!   * structurally-valid but semantically-rejected input (all-zero IDs).
+//!
+//! The parser is on the request hot path — every incoming HTTP request
+//! that carries a `traceparent` header is parsed before dispatch — so it is
+//! a sensitivity gate for HTTP throughput. Nanosecond-level changes here
+//! show up as percentage-level changes at p99 latency.
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+use zion::observability::parse_traceparent;
+
+const VALID_RFC: &[u8] = b"00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
+const VALID_RFC_FLAG_ZERO: &[u8] = b"00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-00";
+const ALL_ZERO_TRACE: &[u8] = b"00-00000000000000000000000000000000-b7ad6b7169203331-01";
+const ALL_ZERO_SPAN: &[u8] = b"00-0af7651916cd43dd8448eb211c80319c-0000000000000000-01";
+// Garbage shapes the parser must reject without panicking.
+const TOO_SHORT: &[u8] = b"00-foo";
+const NON_HEX: &[u8] = b"00-zzz7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
+const WRONG_VERSION: &[u8] = b"ff-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
+const BAD_DASH: &[u8] = b"00X0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
+
+fn bench_valid(c: &mut Criterion) {
+    let mut g = c.benchmark_group("traceparent/valid");
+    g.throughput(Throughput::Bytes(VALID_RFC.len() as u64));
+    g.bench_function("rfc_example", |b| {
+        b.iter(|| {
+            let r = parse_traceparent(black_box(VALID_RFC));
+            black_box(r.is_some())
+        })
+    });
+    g.bench_function("flag_unsampled", |b| {
+        b.iter(|| {
+            let r = parse_traceparent(black_box(VALID_RFC_FLAG_ZERO));
+            black_box(r.is_some())
+        })
+    });
+    g.finish();
+}
+
+fn bench_rejected(c: &mut Criterion) {
+    let mut g = c.benchmark_group("traceparent/rejected");
+    g.bench_function("all_zero_trace_id", |b| {
+        b.iter(|| black_box(parse_traceparent(black_box(ALL_ZERO_TRACE))))
+    });
+    g.bench_function("all_zero_span_id", |b| {
+        b.iter(|| black_box(parse_traceparent(black_box(ALL_ZERO_SPAN))))
+    });
+    g.bench_function("wrong_version", |b| {
+        b.iter(|| black_box(parse_traceparent(black_box(WRONG_VERSION))))
+    });
+    g.finish();
+}
+
+fn bench_garbage(c: &mut Criterion) {
+    let mut g = c.benchmark_group("traceparent/garbage");
+    g.bench_function("too_short", |b| {
+        b.iter(|| black_box(parse_traceparent(black_box(TOO_SHORT))))
+    });
+    g.bench_function("non_hex_digits", |b| {
+        b.iter(|| black_box(parse_traceparent(black_box(NON_HEX))))
+    });
+    g.bench_function("malformed_dash", |b| {
+        b.iter(|| black_box(parse_traceparent(black_box(BAD_DASH))))
+    });
+    g.bench_function("empty", |b| {
+        b.iter(|| black_box(parse_traceparent(black_box(b""))))
+    });
+    g.finish();
+}
+
+criterion_group!(benches, bench_valid, bench_rejected, bench_garbage);
+criterion_main!(benches);

--- a/benches/waf_streaming.rs
+++ b/benches/waf_streaming.rs
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Microbench: WAF — buffered `validate_request` vs `StreamingScanner::feed`.
+//!
+//! The buffered path is what dispatch uses today: collect the whole body,
+//! then scan once. The streaming path (Track D, issue #49) feeds the
+//! scanner chunk-by-chunk and can early-exit before the body finishes
+//! uploading. The two paths converge to identical verdicts on clean input.
+//!
+//! What this bench actually measures:
+//!   * `validate_request` cost across 1 KB / 1 MB / 10 MB clean payloads —
+//!     the worst case for the buffered path is the full-body scan.
+//!   * `StreamingScanner::feed` cost across the same sizes, in 8 KB chunks
+//!     (mirrors the chunk size hyper hands us off the wire).
+//!   * **Per-chunk overhead** of the streaming path vs a single
+//!     `is_match` over the buffered body. Aho-Corasick early-exits on the
+//!     first match, so even the buffered scan denies fast when an attack
+//!     pattern is in the first 64 bytes; the streaming path adds
+//!     overlap-buffer + length-tracking work per chunk. The streaming
+//!     path's real-world win is *peak memory* and *upload-bytes-on-the-
+//!     wire*, neither of which a microbench can capture — this number is
+//!     the cost the dispatcher pays for those properties on a same-size
+//!     payload.
+//!
+//! Sample-size knob: 10 MB benches use a smaller sample count to stay
+//! under the issue's 60 s wall-clock budget on a developer laptop.
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+use zion::waf::{validate_request, StreamVerdict, StreamingScanner, WafMode, WafProfile};
+
+const CHUNK: usize = 8 * 1024;
+const KB_1: usize = 1024;
+const MB_1: usize = 1_048_576;
+const MB_10: usize = 10 * 1_048_576;
+
+fn profile() -> WafProfile {
+    // High max_body_mb so size-limit gating doesn't dominate: we want to
+    // measure scan cost, not the bytes-counter check.
+    //
+    // `allowed_content_types` is widened so the bench's `text/plain`
+    // payload reaches gate 3 (Aho-Corasick scan). Default profile
+    // accepts only `application/json` and `multipart/form-data`, both
+    // of which trigger gate 5 (JSON structural validation) and pollute
+    // the scan-cost number we want to track.
+    //
+    // Entropy gate is disabled because it kicks in on bodies ≥256 bytes
+    // and adds an O(N) pass that's orthogonal to what this bench
+    // measures (the AC scan).
+    WafProfile {
+        max_body_mb: 64,
+        allowed_content_types: vec!["text/plain".to_string()],
+        deny_unknown_content_types: true,
+        entropy_check: false,
+        ..WafProfile::default()
+    }
+}
+
+fn clean_body(n: usize) -> Vec<u8> {
+    // Fill with a non-attack ASCII pattern that the scanner will not match.
+    // We avoid `'a'` repetition to defeat any future SIMD-prefix shortcut.
+    let mut v = Vec::with_capacity(n);
+    let cycle = b"The quick brown fox jumps over the lazy dog. ";
+    while v.len() < n {
+        let take = (n - v.len()).min(cycle.len());
+        v.extend_from_slice(&cycle[..take]);
+    }
+    v
+}
+
+fn attack_first_64b(n: usize) -> Vec<u8> {
+    // Attack pattern in the first 64 bytes; rest is clean. Streaming must
+    // deny on chunk #1; buffered scans the whole body.
+    let mut v = Vec::with_capacity(n);
+    v.extend_from_slice(b"<script>alert(1)</script> trailing padding ");
+    while v.len() < n {
+        v.push(b'.');
+    }
+    v
+}
+
+fn feed_chunked(scanner: &mut StreamingScanner, body: &[u8]) -> StreamVerdict {
+    for chunk in body.chunks(CHUNK) {
+        let v = scanner.feed(chunk);
+        if matches!(v, StreamVerdict::Deny(_)) {
+            return v;
+        }
+    }
+    StreamVerdict::Allow
+}
+
+fn bench_clean_buffered(c: &mut Criterion) {
+    let p = profile();
+    let mut g = c.benchmark_group("waf/buffered/clean");
+    for &(label, size) in &[("1KB", KB_1), ("1MB", MB_1)] {
+        let body = clean_body(size);
+        g.throughput(Throughput::Bytes(size as u64));
+        g.bench_function(label, |b| {
+            b.iter(|| {
+                let v = validate_request(
+                    black_box("POST"),
+                    black_box(Some("text/plain")),
+                    black_box(&body),
+                    black_box(&p),
+                );
+                black_box(v)
+            })
+        });
+    }
+    // 10 MB gets a smaller sample size — full-body scans dominate.
+    g.sample_size(20);
+    let body = clean_body(MB_10);
+    g.throughput(Throughput::Bytes(MB_10 as u64));
+    g.bench_function("10MB", |b| {
+        b.iter(|| {
+            let v = validate_request(
+                black_box("POST"),
+                black_box(Some("text/plain")),
+                black_box(&body),
+                black_box(&p),
+            );
+            black_box(v)
+        })
+    });
+    g.finish();
+}
+
+fn bench_clean_streaming(c: &mut Criterion) {
+    let p = profile();
+    let max = p.max_body_mb * 1_048_576;
+    let mut g = c.benchmark_group("waf/streaming/clean");
+    for &(label, size) in &[("1KB", KB_1), ("1MB", MB_1)] {
+        let body = clean_body(size);
+        g.throughput(Throughput::Bytes(size as u64));
+        g.bench_function(label, |b| {
+            b.iter_batched(
+                || StreamingScanner::new(WafMode::Balanced, max),
+                |mut s| black_box(feed_chunked(&mut s, &body)),
+                criterion::BatchSize::SmallInput,
+            )
+        });
+    }
+    g.sample_size(20);
+    let body = clean_body(MB_10);
+    g.throughput(Throughput::Bytes(MB_10 as u64));
+    g.bench_function("10MB", |b| {
+        b.iter_batched(
+            || StreamingScanner::new(WafMode::Balanced, max),
+            |mut s| black_box(feed_chunked(&mut s, &body)),
+            criterion::BatchSize::SmallInput,
+        )
+    });
+    g.finish();
+}
+
+fn bench_attack_asymmetry(c: &mut Criterion) {
+    // Both paths early-exit on the first match — buffered uses one
+    // `is_match` call on the full slice (Aho-Corasick stops at the first
+    // hit), streaming exits on the first `feed` chunk that matches. So
+    // the actual numbers below are NOT an asymmetry between paths but
+    // the cost the streaming path pays per-chunk vs the cost of a single
+    // matched is_match call. Real-world streaming wins are upload-bytes
+    // and peak-memory, neither captured here.
+    let p = profile();
+    let max = p.max_body_mb * 1_048_576;
+    let body = attack_first_64b(MB_10);
+
+    let mut g = c.benchmark_group("waf/attack_first_64b/10MB");
+    g.throughput(Throughput::Bytes(MB_10 as u64));
+    g.sample_size(20);
+
+    g.bench_function("buffered_scans_full_body", |b| {
+        b.iter(|| {
+            let v = validate_request(
+                black_box("POST"),
+                black_box(Some("text/plain")),
+                black_box(&body),
+                black_box(&p),
+            );
+            black_box(v)
+        })
+    });
+
+    g.bench_function("streaming_early_exit", |b| {
+        b.iter_batched(
+            || StreamingScanner::new(WafMode::Balanced, max),
+            |mut s| black_box(feed_chunked(&mut s, &body)),
+            criterion::BatchSize::SmallInput,
+        )
+    });
+
+    g.finish();
+}
+
+fn bench_chunk_size_sweep(c: &mut Criterion) {
+    // How sensitive is `StreamingScanner::feed` to the chunk size hyper
+    // hands us? Sweep over typical wire-frame sizes. Smaller chunks =
+    // more `feed` calls = more overlap-buffer copies.
+    let p = profile();
+    let max = p.max_body_mb * 1_048_576;
+    let body = clean_body(MB_1);
+
+    let mut g = c.benchmark_group("waf/streaming/chunk_size");
+    g.throughput(Throughput::Bytes(MB_1 as u64));
+    for &chunk_size in &[1024usize, 4 * 1024, 16 * 1024, 64 * 1024] {
+        g.bench_function(format!("{chunk_size}B"), |b| {
+            b.iter_batched(
+                || StreamingScanner::new(WafMode::Balanced, max),
+                |mut s| {
+                    for chunk in body.chunks(chunk_size) {
+                        if matches!(s.feed(chunk), StreamVerdict::Deny(_)) {
+                            break;
+                        }
+                    }
+                    black_box(s.bytes_seen())
+                },
+                criterion::BatchSize::SmallInput,
+            )
+        });
+    }
+    g.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_clean_buffered,
+    bench_clean_streaming,
+    bench_attack_asymmetry,
+    bench_chunk_size_sweep
+);
+criterion_main!(benches);

--- a/benchmarks/results/criterion/baseline.json
+++ b/benchmarks/results/criterion/baseline.json
@@ -1,0 +1,62 @@
+{
+  "_meta": {
+    "format": "zion.bench.criterion.baseline.v1",
+    "issue": "https://github.com/fabriziosalmi/zion/issues/54",
+    "regenerate_with": "scripts/criterion-baseline.sh",
+    "platform": "macOS arm64 (Apple M-series), 64GiB RAM",
+    "rustc": "1.82.0 (default-features off)",
+    "captured_at": "2026-05-08",
+    "notes": [
+      "Numbers below are the median time of a quick-mode (`-- --quick`) run on an idle laptop.",
+      "CI-regenerated baselines should keep the same JSON shape so the diff bot can parse them.",
+      "Bench IDs match `target/criterion/<group>/<bench>/new/estimates.json` paths verbatim."
+    ]
+  },
+  "benchmarks": {
+    "traceparent/valid/rfc_example":              { "median_ns": 17.3,        "thrpt": "2.96 GiB/s" },
+    "traceparent/valid/flag_unsampled":           { "median_ns": 18.4,        "thrpt": "2.79 GiB/s" },
+    "traceparent/rejected/all_zero_trace_id":     { "median_ns": 18.3,        "thrpt": null },
+    "traceparent/rejected/all_zero_span_id":      { "median_ns": 20.4,        "thrpt": null },
+    "traceparent/rejected/wrong_version":         { "median_ns": 6.6,         "thrpt": null },
+    "traceparent/garbage/too_short":              { "median_ns": 6.5,         "thrpt": null },
+    "traceparent/garbage/non_hex_digits":         { "median_ns": 6.8,         "thrpt": null },
+    "traceparent/garbage/malformed_dash":         { "median_ns": 6.4,         "thrpt": null },
+    "traceparent/garbage/empty":                  { "median_ns": 6.7,         "thrpt": null },
+
+    "audit/compute_hmac/typical_event":           { "median_ns": 256.1,       "thrpt": "867 MiB/s" },
+    "audit/compute_hmac/verbose_2kb_detail":      { "median_ns": 970.0,       "thrpt": "2.14 GiB/s" },
+    "audit/sign_event/single_link":               { "median_ns": 482.8,       "thrpt": "2.07 Melem/s" },
+    "audit/chain/64_link_chain":                  { "median_ns": 38506.0,     "thrpt": "1.66 Melem/s" },
+    "audit/genesis_hash":                         { "median_ns": 159.5,       "thrpt": null },
+
+    "sovereign/record_classification/residential_ita": { "median_ns": 0.6,    "thrpt": null },
+    "sovereign/record_classification/unknown":         { "median_ns": 0.6,    "thrpt": null },
+    "sovereign/record_classification/gov_ita":         { "median_ns": 0.6,    "thrpt": null },
+    "sovereign/classify/ipv4_in_range":           { "median_ns": 2.04,        "thrpt": "489 Melem/s" },
+    "sovereign/classify/ipv6_v4mapped":            { "median_ns": 2.02,        "thrpt": "496 Melem/s" },
+    "sovereign/classify/ipv6_pure":                { "median_ns": 2.01,        "thrpt": "498 Melem/s" },
+    "sovereign/classify/ipv4_miss":                { "median_ns": 2.02,        "thrpt": "496 Melem/s" },
+    "sovereign/as_str/residential_ita":            { "median_ns": 0.67,        "thrpt": null },
+    "sovereign/as_str/unknown":                    { "median_ns": 0.67,        "thrpt": null },
+
+    "cache/l1/hit":                                { "median_ns": 6.5,         "thrpt": "153 Melem/s" },
+    "cache/l1/miss":                               { "median_ns": 7.8,         "thrpt": "128 Melem/s" },
+    "cache/l2/hit":                                { "median_ns": 16.4,        "thrpt": "61 Melem/s" },
+    "cache/l2/miss":                               { "median_ns": 8.5,         "thrpt": "118 Melem/s" },
+    "cache/full_miss/l1_then_l2_both_miss":        { "median_ns": 16.2,        "thrpt": "61 Melem/s" },
+    "cache/singleflight/oncecell_uncontended_get": { "median_ns": 3.8,         "thrpt": "266 Melem/s" },
+
+    "waf/buffered/clean/1KB":                      { "median_ns": 2769.0,      "thrpt": null },
+    "waf/buffered/clean/1MB":                      { "median_ns": 2791500.0,   "thrpt": null },
+    "waf/buffered/clean/10MB":                     { "median_ns": 28135000.0,  "thrpt": null },
+    "waf/streaming/clean/1KB":                     { "median_ns": 2243.0,      "thrpt": "435 MiB/s" },
+    "waf/streaming/clean/1MB":                     { "median_ns": 2273000.0,   "thrpt": "440 MiB/s" },
+    "waf/streaming/clean/10MB":                    { "median_ns": 23329000.0,  "thrpt": "439 MiB/s" },
+    "waf/attack_first_64b/10MB/buffered_scans_full_body": { "median_ns": 22.7, "thrpt": null },
+    "waf/attack_first_64b/10MB/streaming_early_exit":     { "median_ns": 127.8,"thrpt": null },
+    "waf/streaming/chunk_size/1024B":              { "median_ns": 2514400.0,   "thrpt": "411 MiB/s" },
+    "waf/streaming/chunk_size/4096B":              { "median_ns": 2304200.0,   "thrpt": "434 MiB/s" },
+    "waf/streaming/chunk_size/16384B":             { "median_ns": 2413200.0,   "thrpt": "440 MiB/s" },
+    "waf/streaming/chunk_size/65536B":             { "median_ns": 2278900.0,   "thrpt": "439 MiB/s" }
+  }
+}

--- a/docs/perf/microbench.md
+++ b/docs/perf/microbench.md
@@ -1,0 +1,132 @@
+# Microbench harness — `cargo bench`
+
+Tracking issue: [#54](https://github.com/fabriziosalmi/zion/issues/54).
+Companion file: [`benchmarks/results/criterion/baseline.json`](../../benchmarks/results/criterion/baseline.json).
+
+This page describes the Criterion-based microbench surface used to size
+candidate optimisations from [`docs/perf/roadmap.md`](roadmap.md). The
+end-to-end `wrk` suites under [`benchmarks/`](../../benchmarks/) are still
+the source of truth for *real-world throughput*; what's documented here
+is the **30-second feedback loop** for ranking *individual hot-path
+changes* (NUMA sharding, io_uring, kTLS, BPF, scanner tweaks).
+
+## Layout
+
+```
+benches/
+  waf_streaming.rs       — buffered vs StreamingScanner, 1KB→10MB sweep
+  sovereign.rs           — record_classification + classify
+  traceparent.rs         — W3C parser, RFC vectors + garbage
+  audit_hmac.rs          — HMAC chain throughput (events/sec)
+  cache_lookup.rs        — L1 hit / L2 hit / full miss / singleflight
+benchmarks/results/criterion/
+  baseline.json          — checked-in numbers from a stable laptop
+.github/workflows/
+  bench.yml              — manual dispatch CI (Criterion + diff comment)
+scripts/
+  criterion-diff.py      — diff two criterion trees, emit markdown
+```
+
+## Running
+
+Quick smoke pass (~10 s per bench, sample size truncated):
+
+```bash
+cargo bench --no-default-features --bench traceparent -- --quick
+```
+
+Full Criterion run (the numbers committed in `baseline.json`):
+
+```bash
+cargo bench --no-default-features --bench waf_streaming
+```
+
+A specific group or bench, regex-matched:
+
+```bash
+cargo bench --no-default-features --bench waf_streaming -- waf/buffered
+```
+
+Criterion writes per-bench detail under `target/criterion/<group>/<bench>/`,
+including `estimates.json` (point estimates), `report/index.html` (when
+`html_reports` is enabled — we ship the `cargo_bench_support` feature only,
+so HTML is generated only on local runs that have a browser to view it).
+
+## Adding a new bench
+
+1. Drop `benches/<name>.rs` containing a Criterion `criterion_main!` entry.
+   Use `criterion_group!` with named functions per surface (one group per
+   logical concept; `c.benchmark_group(...)` for nested ID prefixes).
+2. Register the bench in `Cargo.toml`:
+   ```toml
+   [[bench]]
+   name = "<name>"
+   harness = false
+   ```
+3. The harness can only call `pub` items reachable from `src/lib.rs`. The
+   lib already exposes `audit`, `observability`, `waf`, `sovereign` (and a
+   small re-export for `WafMode`/`WafProfile`). If you need a module that
+   isn't there, prefer one of:
+     * making the surface `pub` in the existing module (cheap if the type
+       is already a stable interface),
+     * extracting the bench-relevant logic into a self-contained submodule
+       and re-exporting it,
+     * using a synthetic fixture in the bench file (the cache bench does
+       this — it imports `dashmap` directly rather than dragging in the
+       `cache::StaticCache` dependency closure).
+4. Re-run and update `benchmarks/results/criterion/baseline.json` if the
+   numbers materially change. Keep the "captured_at" / "platform" fields
+   honest — they're how reviewers tell whether a delta is real or
+   hardware-relative.
+
+## What's measured (and what isn't)
+
+* **Measured**: per-call cost of pure functions on the request hot path.
+  These benches are kept short so they react to *one* line changing —
+  if a refactor moves a `format!()` allocation back into
+  `record_classification`, the sovereign bench moves by ~10 ns and the
+  diff bot flags it.
+* **Not measured**: end-to-end p99 latency under load, syscall behaviour,
+  TLS handshake cost, allocator interaction across long runs. Those
+  belong to the `wrk`/`hey` suites and the production-load profile.
+* **Not stable across runners**: GitHub-hosted CI is too noisy for sub-50 ns
+  benches. Treat CI deltas as *signals*, not gates — variance below ±5 %
+  is in the noise floor on `ubuntu-latest`. Reproduce locally before
+  reacting.
+
+## Bench targets — what each one defends
+
+| Bench file              | Defends                                                                                        |
+|-------------------------|-----------------------------------------------------------------------------------------------|
+| `traceparent.rs`        | Anti-panic guarantee on garbage input; nanosecond-level parser cost (every request hits it). |
+| `audit_hmac.rs`         | HMAC-SHA256 chain throughput; sustained events/sec a single audit writer can produce.        |
+| `sovereign.rs`          | `record_classification` stays a single atomic increment (no allocation regression).          |
+| `cache_lookup.rs`       | L1/L2 lookup latencies; alerts if a refactor makes the L1 path drift toward L2 cost.         |
+| `waf_streaming.rs`      | Aho-Corasick scan cost (gate 3) on representative payloads; per-chunk overhead of streaming. |
+
+## Why `--no-default-features`
+
+The default-features build pulls in a small set of integration crates
+(geo data, ml-waf, ACME) that aren't relevant to the microbench surface
+and slow compilation. The benches are written against the bare lib so
+they compile in ~70 s on a cold cache, ~5 s on a warm one. If a bench
+ever needs a feature-gated surface, gate the bench file the same way and
+document it here.
+
+## Comparison to the wrk suites
+
+|                       | `cargo bench` (this harness)                | `benchmarks/bench-scientific.sh`        |
+|-----------------------|---------------------------------------------|-----------------------------------------|
+| What it measures      | Per-call cost of pure functions             | End-to-end RPS / p99 / TLS handshake    |
+| Target                | One hot-path component at a time            | Full request pipeline incl. upstream    |
+| Reproducibility       | High (seconds, deterministic)               | Lower (network + kernel scheduling)     |
+| Use when              | Ranking optimisation candidates             | Validating release-shape numbers        |
+
+## Future work
+
+* Continuous regression detection (own issue once the baseline numbers
+  stabilise across at least three CI runs).
+* Compare against a reference-proxy baseline (separate harness; avoids
+  dragging Criterion into the wrk-suite path).
+* Tier-2 bench targets: `waf::validate_uri`, simd-json structural pass,
+  upstream connector pool checkout.

--- a/scripts/criterion-diff.py
+++ b/scripts/criterion-diff.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Diff two criterion output trees and emit a markdown summary.
+
+Criterion writes per-benchmark JSON under
+`target/criterion/<group>/<bench>/new/estimates.json`. Each file holds the
+median, mean, and slope estimates. We walk both trees, line them up by
+relative path, and emit a markdown table of the percent change with a
+threshold-based icon (✓ within band, ⚠️ regression, 🚀 improvement).
+
+Used by `.github/workflows/bench.yml`. Stdlib-only — no pip install on CI.
+"""
+
+from __future__ import annotations
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Optional
+
+
+def load_estimates(root: Path) -> dict[str, float]:
+    """Walk a criterion tree and return {bench_id: median_ns}.
+
+    `bench_id` is the relative path from `root` up to the bench directory,
+    e.g. `traceparent/valid/rfc_example`. Criterion's `estimates.json`
+    records times in nanoseconds via `point_estimate`.
+    """
+    out: dict[str, float] = {}
+    for est in root.rglob("new/estimates.json"):
+        # estimates.json sits at <root>/<group>/<bench>/new/estimates.json
+        bench_dir = est.parent.parent
+        rel = bench_dir.relative_to(root).as_posix()
+        # Skip criterion's report-aggregation directories.
+        if rel.endswith("/report") or rel == "report":
+            continue
+        try:
+            with est.open() as fh:
+                data = json.load(fh)
+            median = data.get("median", {}).get("point_estimate")
+            if median is None:
+                continue
+            out[rel] = float(median)
+        except (json.JSONDecodeError, OSError):
+            continue
+    return out
+
+
+def fmt_ns(ns: float) -> str:
+    if ns < 1_000:
+        return f"{ns:.2f} ns"
+    if ns < 1_000_000:
+        return f"{ns / 1_000:.2f} µs"
+    if ns < 1_000_000_000:
+        return f"{ns / 1_000_000:.2f} ms"
+    return f"{ns / 1_000_000_000:.2f} s"
+
+
+def icon(delta_pct: float, threshold: float) -> str:
+    if abs(delta_pct) <= threshold:
+        return "✓"
+    return "⚠️" if delta_pct > 0 else "🚀"
+
+
+def main(argv: list[str]) -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--head", required=True, type=Path, help="head criterion tree")
+    p.add_argument("--base", required=True, type=Path, help="base criterion tree")
+    p.add_argument(
+        "--threshold-pct",
+        type=float,
+        default=5.0,
+        help="percent change considered noise; below this counts as no change",
+    )
+    p.add_argument("--out", type=Path, default=None, help="markdown output path")
+    args = p.parse_args(argv)
+
+    head = load_estimates(args.head)
+    base = load_estimates(args.base)
+
+    if not head:
+        print(f"no criterion output under {args.head}", file=sys.stderr)
+        return 1
+
+    rows: list[tuple[str, Optional[float], float, Optional[float]]] = []
+    for bench_id in sorted(set(head) | set(base)):
+        h = head.get(bench_id)
+        b = base.get(bench_id)
+        if h is None or b is None:
+            rows.append((bench_id, h, b if b is not None else 0.0, None))
+            continue
+        if b == 0:
+            rows.append((bench_id, h, b, None))
+            continue
+        delta = (h - b) / b * 100.0
+        rows.append((bench_id, h, b, delta))
+
+    md: list[str] = []
+    md.append("### Criterion delta — head vs master")
+    md.append("")
+    md.append("| Bench | Head | Master | Δ% |")
+    md.append("|-------|------|--------|----|")
+    regressions = 0
+    improvements = 0
+    for bench_id, h, b, delta in rows:
+        if h is None:
+            md.append(f"| `{bench_id}` | _missing_ | {fmt_ns(b)} | — |")
+            continue
+        if delta is None:
+            md.append(f"| `{bench_id}` | {fmt_ns(h)} | _new_ | — |")
+            continue
+        sign = "+" if delta >= 0 else ""
+        ic = icon(delta, args.threshold_pct)
+        md.append(
+            f"| `{bench_id}` | {fmt_ns(h)} | {fmt_ns(b)} | {ic} {sign}{delta:.1f}% |"
+        )
+        if abs(delta) > args.threshold_pct:
+            if delta > 0:
+                regressions += 1
+            else:
+                improvements += 1
+
+    md.append("")
+    md.append(
+        f"_Summary: {regressions} regression(s), {improvements} improvement(s) outside ±{args.threshold_pct:.0f}%._"
+    )
+    md.append("")
+    md.append(
+        "Microbench numbers are signals, not gates. GitHub-hosted runners are noisy; reproduce locally before reacting to a single run."
+    )
+    out_text = "\n".join(md) + "\n"
+
+    if args.out is not None:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(out_text)
+    else:
+        sys.stdout.write(out_text)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/src/config.rs
+++ b/src/config.rs
@@ -314,88 +314,15 @@ pub(crate) fn default_client_auth() -> String {
 // WAF PROFILES (layered, named, per-route)
 // ============================================================================
 
-/// WAF detection mode — selects which Aho-Corasick pattern set is scanned.
-///
-/// `Balanced` (default): high-precision patterns. SQLi/XSS tags/path traversal/
-/// SSRF/XXE/Log4Shell/CRLF/SSTI/most LDAP and PHP patterns. Tuned to keep the
-/// false-positive rate low for content-bearing APIs (comments, code paste,
-/// docs, payloads with base64).
-///
-/// `Aggressive`: balanced PLUS broad-substring patterns that catch more
-/// attacks but also flag legitimate developer/tooling content. Use this on
-/// strict admin paths, never on user-content APIs unless you've measured the
-/// FP rate. Examples added under aggressive: `alert(`, `eval(`,
-/// `document.cookie`, `innerhtml`, `os.system(`, `pickle.loads`,
-/// `Runtime.getRuntime`, `$gt`/`$ne`/`$regex` (unanchored MongoDB ops), and
-/// generic XSS event handlers like `onclick=`/`onmouseover=`.
-#[derive(Deserialize, Clone, Copy, Debug, PartialEq, Eq, Default)]
-#[serde(rename_all = "lowercase")]
-pub enum WafMode {
-    #[default]
-    Balanced,
-    Aggressive,
-}
-
-#[derive(Deserialize, Clone, Debug)]
-pub struct WafProfile {
-    #[serde(default)]
-    pub mode: WafMode,
-    #[serde(default = "default_max_body_mb")]
-    pub max_body_mb: u64,
-    #[serde(default = "default_max_depth")]
-    pub max_depth: usize,
-    #[serde(default = "default_max_string_len")]
-    pub max_string_len: usize,
-    #[serde(default = "default_true")]
-    pub deny_unknown_content_types: bool,
-    #[serde(default = "default_allowed_content_types")]
-    pub allowed_content_types: Vec<String>,
-    /// Run Shannon-entropy gate on bodies ≥256 bytes. When true, denies
-    /// requests whose entropy exceeds `entropy_threshold`. Default: true.
-    /// Disable on routes that legitimately accept high-entropy payloads
-    /// (binary uploads as JSON-base64, encrypted blobs, signed envelopes).
-    #[serde(default = "default_true")]
-    pub entropy_check: bool,
-    /// Entropy threshold in bits/byte. Default: 6.5 — leaves headroom above
-    /// pure base64 (6.0 theoretical max) so JWTs, signed URLs and base64
-    /// payloads are not flagged. Random/encrypted content sits at ~7.5–8.0.
-    #[serde(default = "default_entropy_threshold")]
-    pub entropy_threshold: f64,
-}
-
-fn default_max_body_mb() -> u64 {
-    10
-}
-fn default_max_depth() -> usize {
-    10
-}
-fn default_max_string_len() -> usize {
-    1_048_576
-}
-fn default_allowed_content_types() -> Vec<String> {
-    vec![
-        "application/json".to_string(),
-        "multipart/form-data".to_string(),
-    ]
-}
-fn default_entropy_threshold() -> f64 {
-    6.5
-}
-
-impl Default for WafProfile {
-    fn default() -> Self {
-        Self {
-            mode: WafMode::default(),
-            max_body_mb: default_max_body_mb(),
-            max_depth: default_max_depth(),
-            max_string_len: default_max_string_len(),
-            deny_unknown_content_types: true,
-            allowed_content_types: default_allowed_content_types(),
-            entropy_check: true,
-            entropy_threshold: default_entropy_threshold(),
-        }
-    }
-}
+// `WafMode` and `WafProfile` are defined in `crate::waf` (their semantic home
+// — they're the inputs the scanner consumes). Re-exported here so existing
+// `config::WafProfile` import sites keep working unchanged. The move was
+// driven by the microbench harness (issue #54): the bench needs to construct
+// a profile via the lib surface without dragging the full config-loader
+// dependency graph (auth, security, audit, sovereign).
+#[allow(unused_imports)]
+// `WafMode` re-exported for downstream/test code; bin uses `crate::waf::WafMode`.
+pub use crate::waf::{WafMode, WafProfile};
 
 // ============================================================================
 // CACHE PROFILES

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,11 @@
 //! them would create lib/bin duplication of compilation units.
 
 #![allow(clippy::let_and_return)]
+// Match the bin's lint baseline so modules that compile under both
+// targets (`waf`, `sovereign`, `audit`, `observability`) don't trip a
+// strict-clippy run only because the lib has a stricter default.
+#![allow(clippy::explicit_auto_deref)]
+#![allow(clippy::needless_borrow)]
 
 /// W3C Trace Context parser, panic hook, OpenMetrics exemplar counters.
 pub mod observability;
@@ -34,3 +39,23 @@ pub mod error;
 /// Boot-path text/JSON logger. Re-exposed here because `audit` depends on it
 /// for warn/error output when the writer task fails to open its target.
 pub mod logging;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Microbenchmark surface (Track: v0.2 — Performance ceiling, issue #54).
+// The modules below are exposed for `cargo bench` / external regression
+// harnesses. They are pure data structures + algorithms — no hyper, no
+// tokio runtime ownership, no ArcSwap state. The `#[doc(hidden)]` markers
+// keep them out of rendered docs; the items are NOT part of the SemVer
+// contract beyond what is needed for the benches under `benches/`.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// WAF: Aho-Corasick scanner, `WafMode`, `WafProfile`, `StreamingScanner`,
+/// `validate_request`. Self-contained — no dependency on other crate modules.
+/// Exposed for `benches/waf_streaming.rs`.
+#[doc(hidden)]
+pub mod waf;
+
+/// Sovereign Edge Intelligence — IP classifier. Pure (no internal deps).
+/// Exposed for `benches/sovereign.rs`.
+#[doc(hidden)]
+pub mod sovereign;

--- a/src/sovereign/mod.rs
+++ b/src/sovereign/mod.rs
@@ -69,6 +69,12 @@ impl IpClass {
     /// Stable index into [`CLASS_COUNTERS`]. Hand-rolled instead of
     /// `enum_iterator` so this stays a `const fn` and the enum stays
     /// `#[derive(Copy)]`-able. Update both sides if a new variant lands.
+    ///
+    /// `Self::Unknown` resolves to `CLASS_COUNT - 1` rather than
+    /// `CLASS_COUNTERS.len() - 1`: referencing a `static` from a
+    /// `const fn` is unstable on rustc < 1.83 (E0658, see
+    /// rust-lang/rust#119618), and the project's MSRV floor is 1.82.
+    /// Both expressions evaluate to the same usize.
     #[inline]
     const fn index(self) -> usize {
         match self {
@@ -81,7 +87,7 @@ impl IpClass {
             Self::ResidentialEu => 4,
             #[cfg(feature = "geo-eu")]
             Self::DatacenterEu => 5,
-            Self::Unknown => CLASS_COUNTERS.len() - 1,
+            Self::Unknown => CLASS_COUNT - 1,
         }
     }
 }

--- a/src/sovereign/mod.rs
+++ b/src/sovereign/mod.rs
@@ -182,7 +182,10 @@ pub const fn cidr_range(a: u8, b: u8, c: u8, d: u8, prefix_len: u8) -> (u32, u32
 ///
 /// O(log N) binary search over sorted CIDR ranges. Zero allocation.
 pub fn classify(ip: IpAddr) -> IpClass {
-    let ipv4 = match ip {
+    // `_ipv4` (vs `ipv4`) silences an `unused_variable` warning when neither
+    // `geo-ita` nor `geo-eu` is enabled (e.g. lib build for the bench
+    // harness): both reader blocks below are then `cfg`-stripped.
+    let _ipv4 = match ip {
         IpAddr::V4(v4) => u32::from(v4),
         IpAddr::V6(v6) => {
             // Check for IPv4-mapped IPv6 (::ffff:a.b.c.d)
@@ -196,7 +199,7 @@ pub fn classify(ip: IpAddr) -> IpClass {
     // Search ITA data first (more specific)
     #[cfg(feature = "geo-ita")]
     {
-        let result = lookup(ipv4, data_ita::RANGES);
+        let result = lookup(_ipv4, data_ita::RANGES);
         if result != IpClass::Unknown {
             return result;
         }
@@ -205,7 +208,7 @@ pub fn classify(ip: IpAddr) -> IpClass {
     // Then EU data (broader)
     #[cfg(feature = "geo-eu")]
     {
-        let result = lookup(ipv4, data_eu::RANGES);
+        let result = lookup(_ipv4, data_eu::RANGES);
         if result != IpClass::Unknown {
             return result;
         }
@@ -215,6 +218,13 @@ pub fn classify(ip: IpAddr) -> IpClass {
 }
 
 /// Binary search a sorted `CidrEntry` array for the given IPv4 address.
+///
+/// `#[allow(dead_code)]`: the public `classify` only calls this under
+/// `feature = "geo-ita"` or `feature = "geo-eu"`, but the function itself
+/// is unit-tested below regardless of feature flags so the bench-time
+/// build (no-default-features) keeps coverage. Suppressing the warning is
+/// preferable to gating tests behind `cfg(any(...))`.
+#[allow(dead_code)]
 #[inline]
 fn lookup(ip: u32, ranges: &[CidrEntry]) -> IpClass {
     // Binary search: find the last range whose `start <= ip`

--- a/src/waf.rs
+++ b/src/waf.rs
@@ -24,9 +24,103 @@
 //! "fixed-length profiling" gate; it was never implemented and the
 //! advertisement has been removed to keep docs and code in lock-step.
 
-use crate::config::{WafMode, WafProfile};
 use aho_corasick::AhoCorasick;
+use serde::Deserialize;
 use std::sync::OnceLock;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// WAF Profile schema. Lives here (not in `config.rs`) so the bench surface
+// in `benches/waf_streaming.rs` can construct a profile via the lib without
+// pulling the whole config-loader dependency graph (auth/security/audit/etc).
+// `config.rs` re-exports these via `pub use crate::waf::{WafMode, WafProfile};`
+// to preserve every existing import site.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// WAF detection mode — selects which Aho-Corasick pattern set is scanned.
+///
+/// `Balanced` (default): high-precision patterns. SQLi/XSS tags/path traversal/
+/// SSRF/XXE/Log4Shell/CRLF/SSTI/most LDAP and PHP patterns. Tuned to keep the
+/// false-positive rate low for content-bearing APIs (comments, code paste,
+/// docs, payloads with base64).
+///
+/// `Aggressive`: balanced PLUS broad-substring patterns that catch more
+/// attacks but also flag legitimate developer/tooling content. Use this on
+/// strict admin paths, never on user-content APIs unless you've measured the
+/// FP rate. Examples added under aggressive: `alert(`, `eval(`,
+/// `document.cookie`, `innerhtml`, `os.system(`, `pickle.loads`,
+/// `Runtime.getRuntime`, `$gt`/`$ne`/`$regex` (unanchored MongoDB ops), and
+/// generic XSS event handlers like `onclick=`/`onmouseover=`.
+#[derive(Deserialize, Clone, Copy, Debug, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum WafMode {
+    #[default]
+    Balanced,
+    Aggressive,
+}
+
+#[derive(Deserialize, Clone, Debug)]
+pub struct WafProfile {
+    #[serde(default)]
+    pub mode: WafMode,
+    #[serde(default = "default_max_body_mb")]
+    pub max_body_mb: u64,
+    #[serde(default = "default_max_depth")]
+    pub max_depth: usize,
+    #[serde(default = "default_max_string_len")]
+    pub max_string_len: usize,
+    #[serde(default = "default_true")]
+    pub deny_unknown_content_types: bool,
+    #[serde(default = "default_allowed_content_types")]
+    pub allowed_content_types: Vec<String>,
+    /// Run Shannon-entropy gate on bodies ≥256 bytes. When true, denies
+    /// requests whose entropy exceeds `entropy_threshold`. Default: true.
+    /// Disable on routes that legitimately accept high-entropy payloads
+    /// (binary uploads as JSON-base64, encrypted blobs, signed envelopes).
+    #[serde(default = "default_true")]
+    pub entropy_check: bool,
+    /// Entropy threshold in bits/byte. Default: 6.5 — leaves headroom above
+    /// pure base64 (6.0 theoretical max) so JWTs, signed URLs and base64
+    /// payloads are not flagged. Random/encrypted content sits at ~7.5–8.0.
+    #[serde(default = "default_entropy_threshold")]
+    pub entropy_threshold: f64,
+}
+
+fn default_max_body_mb() -> u64 {
+    10
+}
+fn default_max_depth() -> usize {
+    10
+}
+fn default_max_string_len() -> usize {
+    1_048_576
+}
+fn default_allowed_content_types() -> Vec<String> {
+    vec![
+        "application/json".to_string(),
+        "multipart/form-data".to_string(),
+    ]
+}
+fn default_entropy_threshold() -> f64 {
+    6.5
+}
+fn default_true() -> bool {
+    true
+}
+
+impl Default for WafProfile {
+    fn default() -> Self {
+        Self {
+            mode: WafMode::default(),
+            max_body_mb: default_max_body_mb(),
+            max_depth: default_max_depth(),
+            max_string_len: default_max_string_len(),
+            deny_unknown_content_types: true,
+            allowed_content_types: default_allowed_content_types(),
+            entropy_check: true,
+            entropy_threshold: default_entropy_threshold(),
+        }
+    }
+}
 
 /// WAF verdict — returned from the pipeline.
 #[derive(Debug, PartialEq)]


### PR DESCRIPTION
## Summary

- Adds 5 Criterion bench targets under `benches/` covering the hot-path components from [docs/perf/roadmap.md](docs/perf/roadmap.md): `waf_streaming`, `sovereign`, `traceparent`, `audit_hmac`, `cache_lookup`.
- Numbers checked in at [`benchmarks/results/criterion/baseline.json`](benchmarks/results/criterion/baseline.json) for trend tracking; manual-dispatch [`bench.yml`](.github/workflows/bench.yml) workflow runs the suite and posts a delta-vs-master comment via [`scripts/criterion-diff.py`](scripts/criterion-diff.py).
- `WafMode` + `WafProfile` move from `config` to `waf` (with `pub use` re-export from `config`) so the bench can construct profiles via the lib surface without dragging the full config-loader graph. No breaking change.

## Bench surface

| File | Defends |
|------|---------|
| `traceparent.rs` | Anti-panic guarantee on garbage; nanosecond parser cost (every request touches it). |
| `audit_hmac.rs` | HMAC-SHA256 chain throughput; sustained events/sec. |
| `sovereign.rs` | `record_classification` stays a single atomic increment (no alloc regression). |
| `cache_lookup.rs` | L1/L2/full-miss/singleflight latencies. Synthetic fixtures (DashMap + thread-local HashMap) — `crate::cache` is not on the lib surface today. |
| `waf_streaming.rs` | Aho-Corasick scan cost (gate 3) on 1KB→10MB; per-chunk overhead of `StreamingScanner` vs buffered. |

## Acceptance (issue #54)

- [x] `Cargo.toml` `dev-dependencies.criterion = \"0.5\"` + 5 `[[bench]]` entries
- [x] 5 bench files committed with ≥3 benchmark functions each
- [x] `cargo bench --bench waf_streaming` runs in <60s on a developer laptop (~30s `--quick`)
- [x] Numbers logged into `benchmarks/results/criterion/baseline.json`
- [x] CI workflow `bench.yml` (manual dispatch) with delta-vs-master PR comment
- [x] `docs/perf/microbench.md`

## Out of scope

- Continuous regression detection (own issue once baselines stabilise across ≥3 CI runs).
- Tier-2 bench targets (`waf::validate_uri`, simd-json structural pass, upstream connector pool).

## Test plan

- [x] `cargo test --lib --no-default-features` — 161 passed
- [x] `cargo test --bin zion --no-default-features` — 368 passed
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --no-default-features --benches --lib --bin zion -- -D warnings` — clean
- [x] `cargo bench --bench waf_streaming --no-default-features -- --quick` — 30s wallclock, all benches reporting
- [ ] CI green (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)