### PR TITLE
fix: correct stale io_uring "multishot" → "single-shot" accept claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ cargo build --release --features http3           # + HTTP/3 QUIC listener
 cargo build --release --features otel            # + OpenTelemetry tracing + OTLP export
 cargo build --release --features fips            # + FIPS 140-3 build (aws-lc-rs validated backend)
 cargo build --release --features geo-ita         # + Italian ASN/gov/ISP ranges (sovereign edge)
-cargo build --release --features io-uring-accept # Linux 5.19+: multishot accept
+cargo build --release --features io-uring-accept # Linux 5.19+: single-shot accept
 ```
 
 Stack flavors for a "max" build:

--- a/benchmarks/generate-scientific-report.py
+++ b/benchmarks/generate-scientific-report.py
@@ -282,7 +282,7 @@ def create_pdf(data, rdir, pngs, outpath):
     Story.append(Paragraph("6. Statistical Jitter and Deviation Profiling", styles['SectionLabel']))
     Story.append(Paragraph(
         "Measuring the Coefficient of Variation (CV%) isolates instances where a proxy struggles to share threads under contention, causing unpredictable micro-stalls. "
-        "A CV% > 15% denotes profound instability. Thanks to the io_uring multishot accept queues (on Linux) and fully deterministic state machines, "
+        "A CV% > 15% denotes profound instability. Thanks to the io_uring single-shot accept loop (on Linux) and fully deterministic state machines, "
         "Zion minimizes jitter even when deeply parsing WAF rules, demonstrating remarkably flat standard variation across test iterations.", styles['NormalText']))
     Story.append(Spacer(1, 0.1 * inch))
     Story.append(RLImage(pngs[3], width=6.5*inch, height=3.0*inch))

--- a/benchmarks/results/generate_report.py
+++ b/benchmarks/results/generate_report.py
@@ -355,7 +355,7 @@ def build():
         "Zero-regex WAF: Aho-Corasick O(N) single-pass over 70+ patterns, SIMD pre-filter bypass "
         "for clean traffic, entropy analysis for obfuscated payloads",
         "Hardware-aware bootstrap: CPU affinity pinning, L1d cache sizing, AES-NI/NEON detection, "
-        "SO_REUSEPORT, TCP_FASTOPEN, io_uring multishot accept",
+        "SO_REUSEPORT, TCP_FASTOPEN, io_uring single-shot accept",
         "Graceful shutdown: 30s connection drain via semaphore-based tracking",
         "Request coalescing (singleflight): prevents thundering herd on cache cold starts",
     ]

--- a/docs/benchmarks/optimization.md
+++ b/docs/benchmarks/optimization.md
@@ -101,7 +101,7 @@ Changes made to improve throughput and latency, with rationale. Throughput claim
 | `TCP_CORK` | Batches writes on listener; combined with NODELAY on accept |
 | `SO_BUSY_POLL` (50us) | Spin-poll NIC queue before sleeping; trades CPU for latency |
 | Listen backlog 1024 | Prevents SYN drops under burst load |
-| io_uring multishot accept | Feature-gated: one syscall for N connections |
+| io_uring single-shot accept | Feature-gated: dedicated accept thread, one SQE re-submitted per connection |
 
 ## Proxy
 

--- a/docs/config/http3.md
+++ b/docs/config/http3.md
@@ -51,7 +51,7 @@ When certificates are hot-reloaded, both the TCP TLS acceptor **and** the QUIC c
 
 - HTTP/3 uses the same upstream connection pool (HTTP/1.1 to backend)
 - WebSocket upgrade is not supported over HTTP/3 (protocol limitation)
-- `io_uring` multishot accept applies to TCP only (QUIC uses standard UDP recv)
+- `io_uring` single-shot accept applies to TCP only (QUIC uses standard UDP recv)
 
 ## Dependencies
 

--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -20,7 +20,7 @@ src/
 ├── auth.rs        # JWT/OIDC validation gate (feature: --features auth)
 ├── acme.rs        # ACME HTTP-01 auto-renewal (feature: --features acme)
 ├── quic.rs        # HTTP/3 QUIC listener (feature: --features http3)
-├── uring.rs       # io_uring multishot accept (feature: --features io-uring-accept)
+├── uring.rs       # io_uring single-shot accept (feature: --features io-uring-accept)
 ├── bootstrap.rs   # Platform detection (CPU, RAM, L1d cache, AES-NI/NEON, kernel features) + AES-GCM calibration
 ├── net.rs         # Socket tuning (SO_REUSEPORT, TCP_FASTOPEN, TCP_QUICKACK, TCP_DEFER_ACCEPT, TCP_CORK, SO_BUSY_POLL)
 ├── doctor.rs      # `zion doctor` environment diagnostic
@@ -147,7 +147,7 @@ Client
 | `OnceLock` for WAF scanners + WS TLS | One Aho-Corasick automaton per WAF mode (balanced + aggressive); root cert store for upstream WS TLS — both built once on first hit, reused for process lifetime |
 | Stack buffers for request ID + traceparent | Zero heap allocation on per-request headers |
 | `Arc<AutoBuilder>` for HTTP builder | Per-connection clone is ref-count bump, not deep copy |
-| io_uring multishot accept (Linux) | Batches N connections per syscall |
+| io_uring single-shot accept (Linux) | Dedicated accept thread; one SQE re-submitted per connection |
 | `SO_BUSY_POLL` (Linux) | Spin-poll NIC queue 50us for lower p99 latency |
 | Semaphore for connection limit | Bound from detected RAM: `(RAM_MB / 4) * 1024 / 50`, clamped 1k-100k |
 
@@ -162,7 +162,7 @@ Zion uses Tokio's multi-threaded runtime. Worker count is set to available CPU c
 | ACME auto-renewal | `--features acme` | HTTP-01 challenge, auto-renew via Let's Encrypt |
 | JWT/OIDC auth | `--features auth` | Per-route JWT validation (HMAC, RSA, ECDSA, JWKS) |
 | HTTP/3 QUIC | `--features http3` | UDP listener on same port, Alt-Svc advertisement |
-| io_uring accept | `--features io-uring-accept` | Linux 5.19+, multishot accept batching |
+| io_uring accept | `--features io-uring-accept` | Linux 5.19+, single-shot accept on a dedicated thread |
 
 Build with multiple features:
 ```bash

--- a/docs/perf/roadmap.md
+++ b/docs/perf/roadmap.md
@@ -121,7 +121,7 @@ hardware.
 ### io_uring read/write vectored, splice/sendfile (estimate: 1–2% on large payloads)
 
 [`src/uring.rs`](../../src/uring.rs) currently uses io_uring only for
-multishot accept. Read/write vectored would reduce syscall count for
+single-shot accept. Read/write vectored would reduce syscall count for
 large bodies; `splice` / `sendfile` would zero-copy cacheable static
 responses from the file system to the socket.
 

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -888,7 +888,7 @@ fn upgrade_hint(p: &Platform) -> String {
 
     // ── 2. Build flags — biggest perf win first, then UX ──
     if cfg!(target_os = "linux") && !cfg!(feature = "io-uring-accept") {
-        return "linux + multi-core — rebuild with `--features io-uring-accept` for multishot accept (kernel 5.19+)."
+        return "linux + multi-core — rebuild with `--features io-uring-accept` for a dedicated io_uring accept thread (kernel 5.19+)."
             .to_string();
     }
     if !cfg!(feature = "tui") {

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -207,7 +207,7 @@ fn check_somaxconn() -> Check {
     }
 }
 
-/// Kernel version — io_uring multishot accept needs 5.19+. We don't fail
+/// Kernel version — io_uring accept needs 5.19+. We don't fail
 /// on this; we just nudge the user toward a feature flag they may not
 /// know about.
 fn check_kernel_version() -> Check {
@@ -226,19 +226,19 @@ fn check_kernel_version() -> Check {
         let major: u32 = parts.next().and_then(|s| s.parse().ok()).unwrap_or(0);
         let minor: u32 = parts.next().and_then(|s| s.parse().ok()).unwrap_or(0);
         let detail = format!("{major}.{minor}");
-        let supports_io_uring_multishot = major > 5 || (major == 5 && minor >= 19);
-        if supports_io_uring_multishot {
+        let supports_io_uring_accept = major > 5 || (major == 5 && minor >= 19);
+        if supports_io_uring_accept {
             Check::ok(
                 "kernel version",
                 format!(
-                    "{detail} (io_uring multishot supported — try `--features io-uring-accept`)"
+                    "{detail} (io_uring accept supported — try `--features io-uring-accept`)"
                 ),
             )
         } else if major >= 5 {
             Check::warn(
                 "kernel version",
                 detail,
-                "for io_uring multishot accept, upgrade to 5.19+",
+                "for io_uring accept, upgrade to 5.19+",
             )
         } else {
             Check::warn(

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -230,9 +230,7 @@ fn check_kernel_version() -> Check {
         if supports_io_uring_accept {
             Check::ok(
                 "kernel version",
-                format!(
-                    "{detail} (io_uring accept supported — try `--features io-uring-accept`)"
-                ),
+                format!("{detail} (io_uring accept supported — try `--features io-uring-accept`)"),
             )
         } else if major >= 5 {
             Check::warn(

--- a/src/listener.rs
+++ b/src/listener.rs
@@ -15,7 +15,7 @@
 //! in `zion.toml` never strands Zion offline.
 //!
 //! Out of scope for Phase 1.5:
-//!   * io_uring multishot accept (`--features io-uring-accept`): the
+//!   * io_uring single-shot accept (`--features io-uring-accept`): the
 //!     uring task is bound to the listener's file descriptor at spawn
 //!     time and cannot be re-pointed without tearing it down. The
 //!     supervisor logs a WARN and skips the rebind in that build flavour.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1070,7 +1070,7 @@ async fn async_main(platform: &'static bootstrap::Platform) -> error::ZionResult
         .map_err(|e| error::ZionError::Listener(format!("HTTPS bind {https_addr}: {e}")))?;
     eprintln!("  listening HTTPS on {https_addr}");
 
-    // io_uring multishot accept on Linux (one syscall for N connections).
+    // io_uring single-shot accept on Linux (dedicated thread, one SQE re-submitted per connection).
     // The uring task is bound to the listener's fd at spawn time and the
     // listener supervisor explicitly does NOT manage HTTPS rebind in this
     // build flavour — that limitation is documented in `listener.rs`.
@@ -1080,7 +1080,7 @@ async fn async_main(platform: &'static bootstrap::Platform) -> error::ZionResult
     let https_initial: Option<(SocketAddr, tokio::net::TcpListener)> = {
         use std::os::unix::io::AsRawFd;
         let fd = https_listener.as_raw_fd();
-        eprintln!("  io_uring multishot accept enabled");
+        eprintln!("  io_uring single-shot accept enabled");
         let uring_rx = uring::spawn_uring_accept(fd, 4096);
         // Spawn the accept loop ourselves; pass `https_initial = None`
         // to the supervisor so it tracks no HTTPS slot.

--- a/src/uring.rs
+++ b/src/uring.rs
@@ -36,7 +36,7 @@ mod inner {
         pub addr: SocketAddr,
     }
 
-    /// Run io_uring multishot accept in a dedicated thread.
+    /// Run io_uring single-shot accept in a dedicated thread.
     /// Sends accepted connections to the returned channel.
     ///
     /// The listener_fd must be a bound, listening, non-blocking TCP socket.


### PR DESCRIPTION
## What

v0.2.2 reverted the io_uring accept loop from multishot (`opcode::AcceptMulti`) to single-shot (`opcode::Accept` re-submitted per CQE) to close the TFO/DEFER_ACCEPT × multishot ENOTSOCK race. That revert updated `src/uring.rs`'s module doc and the README feature list, but left **~15 stale "multishot" references** across the tree — several user-facing.

This sweeps `multishot → single-shot` and rewrites the "one syscall for N connections" / "batches N connections per syscall" phrasing (which described the *old* multishot shape) to the accurate single-shot model: **a dedicated accept thread, one SQE re-submitted per connection**.

## Scope (12 files, 19/19)

- **User-facing fixes**: `src/main.rs` boot log (`io_uring multishot accept enabled`), `src/doctor.rs` kernel-version hint + local var name, `src/bootstrap.rs` upgrade hint
- **Comments**: `uring.rs` fn doc (it contradicted its own module doc), `listener.rs`, `main.rs`
- **Docs**: `guide/architecture.md` (×3), `config/http3.md`, `benchmarks/optimization.md`, `perf/roadmap.md`, `README.md`
- **Bench copy**: `benchmarks/generate-scientific-report.py`, `benchmarks/results/generate_report.py`

No behaviour change — comments, doc text, and message strings only.

## Left untouched (intentional)

- **CHANGELOG + `uring.rs:12-21` historical rationale** — they correctly describe the *removed* `AcceptMulti` behaviour, not the current state.
- **The advertised "kernel 5.19+" floor** — single-shot `opcode::Accept` predates 5.19 (5.19 was the `AcceptMulti` requirement), so the floor in `doctor.rs`/`bootstrap.rs`/README is arguably now too strict. Revisiting it needs verification of the project's actually-tested floor → flagged for a follow-up, not changed here.

## Verification

- Pre-commit: `cargo check` + `cargo test` green (169 + 378 + 6 tests).
- Linux `io-uring-accept`-gated edits (boot log, doctor, uring) are compile-checked by CI `clippy (io-uring-rw)` + the Linux all-features test job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
