### PR TITLE
ci(deps): consolidate workflow + docker bumps (actions group, codeql, configure-pages, setup-node, build-push-action, rust 1.95, distroless)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -51,13 +51,13 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@0daab03d71ff584ef619d027a3fd9146679c5d84 # v3
+        uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v3
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
           queries: security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@0daab03d71ff584ef619d027a3fd9146679c5d84 # v3
+        uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v3
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,7 +34,7 @@ jobs:
           cache-dependency-path: docs/package-lock.json
 
       - name: Setup Pages
-        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20
           cache: npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -497,7 +497,7 @@ jobs:
 
       - name: Build & push (linux/amd64,arm64)
         id: push
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
+      - uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: scorecard.sarif
           results_format: sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -64,6 +64,6 @@ jobs:
           publish_results: true
 
       - name: Upload scorecard SARIF
-        uses: github/codeql-action/upload-sarif@0daab03d71ff584ef619d027a3fd9146679c5d84 # v3
+        uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v3
         with:
           sarif_file: scorecard.sarif

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -64,7 +64,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       # The cargo-deny action does the install + cache for us, with the
       # check name driving deny.toml's section filter.
-      - uses: EmbarkStudios/cargo-deny-action@91bf2b620e09e18d6eb78b92e7861937469acedb # v2
+      - uses: EmbarkStudios/cargo-deny-action@a531616d8ce3b9177443e48a1159bc945a099823 # v2
         with:
           command: check ${{ matrix.checks }}
           arguments: --all-features

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,7 @@ RUN mkdir -p /out/var/lib/zion && \
 # `nonroot` (UID 65532). For a fully static binary use a separate target
 # (linux-musl) and ship via gcr.io/distroless/static — that path is taken
 # by the CI release workflow when building from the precompiled musl artifact.
-FROM gcr.io/distroless/cc-debian12:nonroot@sha256:e2d29aec8061843706b7e484c444f78fafb05bfe47745505252b1769a05d14f1 AS runtime
+FROM gcr.io/distroless/cc-debian12:nonroot@sha256:bd2899c12b335c827750ccf2359879eab09c09b206023dcebea408947d54127c AS runtime
 
 # Re-declare so labels can interpolate it.
 ARG SOURCE_DATE_EPOCH=0

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@
 # Pinned to match rust-toolchain.toml. MSRV (Cargo.toml rust-version=1.82)
 # only applies to the no-default-features build; this image bakes a full
 # default-features binary so we need the same compiler we ship with.
-FROM --platform=$BUILDPLATFORM rust:1.88-bookworm@sha256:af306cfa71d987911a781c37b59d7d67d934f49684058f96cf72079c3626bfe0 AS builder
+FROM --platform=$BUILDPLATFORM rust:1.95-bookworm@sha256:adab7941580c74513aa3347f2d2a1f975498280743d29ec62978ba12e3540d3a AS builder
 
 # Build arg flowed through by `docker buildx build --platform=...`.
 # Lets us cross-compile on the native runner architecture.


### PR DESCRIPTION
Consolidates the stale workflow/docker Dependabot PRs into one branch off current master (none touch `Cargo.lock`, so no MSRV/lockfile impact). Cherry-picked verbatim from each Dependabot commit.

## Bumps
- **actions group** (#102): `ossf/scorecard-action` v2.4.0→v2.4.3, `EmbarkStudios/cargo-deny-action` SHA bump (v2)
- `actions/configure-pages` v5→v6 (#36)
- `actions/setup-node` v4→v6.4.0 (#35)
- `docker/build-push-action` v6→v7.1.0 (#37)
- `github/codeql-action` SHA bump (#34) — required CodeQL check validates the pin
- `Dockerfile` builder `rust` 1.88→1.95-bookworm (#31) — build image only; MSRV gate is separate and unchanged
- `distroless/cc-debian12` runtime digest bump (#108)

## Supersedes
#102, #34, #36, #35, #37, #31, #108 — close on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)