### PR TITLE
ci(dependabot): hold criterion <0.6 (MSRV 1.86)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,6 +49,11 @@ updates:
       # until MSRV-core moves to 1.85. Same posture as hyper-rustls above.
       - dependency-name: "dashmap"
         versions: [">=6.2.0"]
+      # criterion 0.8 raised its MSRV to rustc 1.86, well past the 1.82
+      # anchor. It's a dev/bench-only dependency with no runtime value, so
+      # hold at 0.5.x rather than relitigate MSRV for a benchmark harness.
+      - dependency-name: "criterion"
+        versions: [">=0.6.0"]
       # Pin major-version bumps for the cryptographic / network core — those
       # need a manual security review (release notes, advisory diff) before merge.
       - dependency-name: "rustls"


### PR DESCRIPTION
criterion 0.8 raised MSRV to rustc 1.86, past the 1.82 anchor (ADR-0007). Dev/bench-only dep — hold at 0.5.x. Closes #119 churn.