### PR TITLE
ci: route supply-chain, codeql, dco to self-hosted runners

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,7 +28,7 @@ concurrency:
 jobs:
   analyze:
     name: CodeQL (${{ matrix.language }})
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 60
     permissions:
       actions: read

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   dco-check:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     permissions:
       contents: read
     steps:

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -35,7 +35,7 @@ jobs:
   # ── 1. RustSec advisories — scheduled + on-PR. ────────────────────────────
   audit:
     name: cargo-audit (advisories)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -51,7 +51,7 @@ jobs:
   # ── 2. cargo-deny: advisories+licenses+bans+sources, all in one. ──────────
   deny:
     name: cargo-deny (${{ matrix.checks }})
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     strategy:
       fail-fast: false
       matrix:
@@ -79,7 +79,7 @@ jobs:
   # cargo-vet baseline" for the standing operator workflow.
   vet:
     name: cargo-vet
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -94,7 +94,7 @@ jobs:
   # ── 4. cargo-geiger — quantify unsafe surface (informational signal). ────
   geiger:
     name: cargo-geiger (unsafe surface)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     continue-on-error: true   # geiger is a *report*, not a gate
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -120,7 +120,7 @@ jobs:
   # ── 5. CycloneDX SBOM — on master + release tags. Attached to releases. ──
   sbom:
     name: SBOM (CycloneDX)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     if: github.event_name != 'pull_request'
     permissions:
       contents: read


### PR DESCRIPTION
**Conversione dei 3 workflow più carichi del repo a `runs-on: [self-hosted, Linux, X64]`:**

| Workflow | Run / mese | Era | Adesso |
|---|---:|---|---|
| `supply-chain.yml` | 343 | ubuntu-latest | `[self-hosted, Linux, X64]` |
| `codeql.yml` | 313 | ubuntu-latest | `[self-hosted, Linux, X64]` |
| `dco.yml` | 265 | ubuntu-latest | `[self-hosted, Linux, X64]` |
| **Totale** | **~920** | | |

## Setup runner per questo repo
- ✅ `runner-02-homelab` (CT 101 su opti7, homelab) registrato e attivo (servizio systemd).
- ⚠️ `vmi3020113` Contabo **non è registrato** su questo repo (lo è solo su `proxxx`).
- Conseguenza: tutti i ~920 run/mese **atterreranno su runner-02** dopo il merge. Niente load balancing finché non aggiungiamo Contabo. Per registrare anche Contabo: dovrai farlo sul VPS (non ho accesso).

## Workflow esclusi (per ora)
- `ci.yml` ha `runs-on: ${{ matrix.os }}` → richiede valutazione separata (matrix potrebbe avere altri OS).
- `integration.yml`, `version-sync.yml`, `readme-stats-sync.yml` → estendiamo dopo conferma che i top-3 girano stabili.

## Cosa monitorare dopo il merge
- `gh run list --repo fabriziosalmi/zion --workflow supply-chain.yml --limit 3` → verifica runner.
- Eventuali fail per dipendenze mancanti (apt packages, sudo NOPASSWD, rust toolchain). Il CT 101 ha già git, curl, jq, docker; rust/cargo viene installato dai workflow stessi via setup-rust action.

Validato in precedenza su `proxxx/docs.yml` (build su runner-02-homelab, deploy su Contabo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)