### PR TITLE
ci(supply-chain): force RUSTUP_TOOLCHAIN=stable for audit jobs

### DIFF
--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -30,6 +30,17 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  # The repo's `rust-toolchain.toml` pins `channel = "1.88.0"` with
+  # `profile = "minimal"`. Some self-hosted runners have that 1.88.0
+  # toolchain installed *without* the `cargo` component, so the in-repo
+  # override makes `cargo install`/`cargo vet` fail with "the 'cargo'
+  # binary … is not applicable to the '1.88.0' toolchain". These audit
+  # tools don't need the pinned compiler — they analyse Cargo.lock and the
+  # vet baseline — so we force `stable` (installed by dtolnay/rust-toolchain
+  # below) and bypass the override. RUSTUP_TOOLCHAIN has the highest
+  # precedence, above rust-toolchain.toml. GitHub-hosted CI is unaffected
+  # because a fresh runner auto-syncs a complete 1.88.0.
+  RUSTUP_TOOLCHAIN: stable
 
 jobs:
   # ── 1. RustSec advisories — scheduled + on-PR. ────────────────────────────
@@ -104,8 +115,15 @@ jobs:
           shared-key: geiger
       - name: Install build deps
         run: |
-          sudo apt-get update
-          sudo apt-get install -y cmake pkg-config build-essential libssl-dev
+          # Self-hosted runners typically have these pre-installed and may
+          # lack passwordless sudo, so only reach for apt when something is
+          # actually missing — and don't hard-fail the step if sudo is
+          # unavailable (the later cargo step surfaces any real gap).
+          if ! command -v cmake >/dev/null || ! command -v pkg-config >/dev/null; then
+            sudo apt-get update && \
+            sudo apt-get install -y cmake pkg-config build-essential libssl-dev || \
+            echo "::warning::could not apt-get build deps; relying on pre-installed toolchain"
+          fi
       - name: Install cargo-geiger
         run: cargo install --locked cargo-geiger
       - name: Geiger report
@@ -132,8 +150,15 @@ jobs:
           shared-key: sbom
       - name: Install build deps
         run: |
-          sudo apt-get update
-          sudo apt-get install -y cmake pkg-config build-essential libssl-dev
+          # Self-hosted runners typically have these pre-installed and may
+          # lack passwordless sudo, so only reach for apt when something is
+          # actually missing — and don't hard-fail the step if sudo is
+          # unavailable (the later cargo step surfaces any real gap).
+          if ! command -v cmake >/dev/null || ! command -v pkg-config >/dev/null; then
+            sudo apt-get update && \
+            sudo apt-get install -y cmake pkg-config build-essential libssl-dev || \
+            echo "::warning::could not apt-get build deps; relying on pre-installed toolchain"
+          fi
       - name: Install cargo-cyclonedx
         run: cargo install --locked cargo-cyclonedx
       - name: Generate SBOM (JSON, all features)


### PR DESCRIPTION
## Root cause

The repo's [`rust-toolchain.toml`](rust-toolchain.toml) pins `channel = "1.88.0"` with `profile = "minimal"` and `components = ["rustfmt", "clippy", "rust-src"]`. Several self-hosted runners have that `1.88.0` toolchain installed **without the `cargo` component**, and the in-repo override outranks the `rustup default stable` that `dtolnay/rust-toolchain` sets. So every `cargo install` / `cargo vet` step fails with:

```
error: the 'cargo' binary, normally provided by the 'cargo' component,
is not applicable to the '1.88.0-x86_64-unknown-linux-gnu' toolchain
```

…**non-deterministically**, depending on which runner picks the job. Observed failing on `vmi3020113-contabo-zion-4` (the homelab runner's 1.88.0 actually *has* cargo) — i.e. it's per-runner toolchain state, **not** a single bad box, so runner-pinning is not the fix. Because `cargo-audit` and `cargo-vet` are **required** checks, this blocked every PR (including the OTel migration #145). GitHub-hosted CI (`check`/`clippy`/`msrv`) is unaffected because a fresh runner auto-syncs a complete 1.88.0.

## Fix

Set `RUSTUP_TOOLCHAIN: stable` at the workflow level. These audit tools analyse `Cargo.lock` and the cargo-vet baseline — they don't need the pinned compiler — and `RUSTUP_TOOLCHAIN` has **higher precedence than `rust-toolchain.toml`**, so they run on the stable toolchain dtolnay installs regardless of the runner's 1.88.0 state.

Also harden the geiger/sbom build-dep step: only `apt-get` when `cmake`/`pkg-config` is missing, and warn instead of hard-failing when the runner lacks passwordless sudo.

Keeps the generic `[self-hosted, Linux, X64]` label — no runner pinning — so #144's load distribution stands.

## Runner hygiene (done out-of-band)
On `runner-02-homelab`: installed `cmake` and granted the runner user passwordless sudo for `apt-get`. The contabo runners' minimal `1.88.0` (missing `cargo`) is sidestepped by the `RUSTUP_TOOLCHAIN` fix; adding the `cargo` component there is optional follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)