### PR TITLE
ci(supply-chain): install cargo-audit/cargo-vet as prebuilt binaries

### DIFF
--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -50,11 +50,14 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          shared-key: audit
+      # Prebuilt binary, not `cargo install` from source: building the tool
+      # on the self-hosted runners is the flaky step ("could not parse/
+      # generate dep info … .d: No such file" — a /tmp race during the
+      # install build). A downloaded binary sidesteps it and is faster.
       - name: Install cargo-audit
-        run: cargo install --locked cargo-audit
+        uses: taiki-e/install-action@873c7452cadb7c034694a1282227095d93fbdf92 # v2.79.14
+        with:
+          tool: cargo-audit
       - name: Run cargo-audit
         # Fail on any unfixed advisory + any yanked crate.
         run: cargo audit --deny warnings --deny unmaintained --deny unsound --deny yanked
@@ -94,11 +97,12 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          shared-key: vet
+      # Prebuilt binary (see cargo-audit note) — avoids the flaky
+      # source-build of the tool on the self-hosted runners.
       - name: Install cargo-vet
-        run: cargo install --locked cargo-vet
+        uses: taiki-e/install-action@873c7452cadb7c034694a1282227095d93fbdf92 # v2.79.14
+        with:
+          tool: cargo-vet
       - name: Run cargo-vet
         run: cargo vet --locked
 


### PR DESCRIPTION
## Why

`cargo install --locked cargo-{audit,vet}` builds the tool **from source** on the self-hosted runners, and that build is intermittently flaky:

```
error: could not parse/generate dep info at: /tmp/cargo-installXXX/release/deps/rustls-….d
Caused by: No such file or directory (os error 2)
```

A `/tmp` race during the install build. It blocked the required `cargo-audit` and `cargo-vet` checks on **nearly every PR today** (#146, #149, #152, #153) and only cleared on manual re-run — pure wasted cycles.

## Fix

Install both as **prebuilt binaries** via `taiki-e/install-action` (SHA-pinned). No compilation → no `/tmp` race, and the jobs run in seconds instead of minutes. Removed the now-pointless `Swatinem/rust-cache` on these two jobs. `RUSTUP_TOOLCHAIN=stable` + the stable toolchain stay (cargo-vet still calls `cargo metadata`).

This PR's own `cargo-audit` / `cargo-vet` runs validate the change end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)