### PR TITLE
feat(edge): per-IP concurrent-connection limit (anti-DDoS lever)

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Payload x concurrency grid -- measures end-to-end TLS throughput. These numbers 
 - Server header stripped, hop-by-hop headers stripped (RFC 7230)
 - URI length limit (8 KB path+query), method whitelist (7 methods)
 - Per-IP rate limiting (lock-free atomic, configurable window)
+- Per-IP concurrent-connection cap (`max_connections_per_ip`, enforced at accept; 0 = off)
 - CORS with FNV O(1) origin lookup, case-insensitive (RFC 6454)
 - TLS handshake timeout (10s), connection timeout (1h for H2/WS/SSE)
 - Header bomb prevention (64 headers, 16 KB buffer)
@@ -164,9 +165,9 @@ leave on under load. Defence is layered, outside-in:
 |---|---|---|
 | **L3/4 — NIC** | XDP eBPF LPM-trie source drop (`--features xdp`); blocked IPs never reach the TLS handshake. AIMP-synced blocklist feeds the trie. | ✅ shipping |
 | **L7 — pre-routing** | Zero-cost edge gates before any work: URI-length cap, method whitelist, XFF-spoof-resistant client-IP resolution (no rate-limit bypass via forged `X-Forwarded-For`). | ✅ shipping |
-| **L7 — admission** | Per-IP rate limiter — lock-free fixed-window counter (packed window+count in one atomic), `429` over budget. | ✅ shipping |
+| **L7 — admission** | Per-IP **rate** limiter (lock-free fixed-window, `429` over budget) **and** per-IP **concurrent-connection** cap (`max_connections_per_ip`, enforced at accept before the TLS handshake) — the connection-exhaustion lever a slow/backed flood actually hits. Global ceiling = the platform connection semaphore. | ✅ shipping |
 | **L7 — inspection** | WAF: zero-regex Aho-Corasick O(N) single-pass, Shannon entropy, simd-json structural limits, 5 gates. | ✅ shipping |
-| **Origin tagging** | IT/EU range classification (`--features geo-ita` / `geo-eu`) — O(log N) binary search over baked CIDR data + one atomic, **no GeoIP DB, no syscall**. Class lands on the request (`extensions`), a metric, and an optional log. Answers "% EU vs non-EU traffic" out of the box (see [observability](https://fabriziosalmi.github.io/zion/guide/observability)). | ✅ shipping (IPv4) |
+| **Origin tagging** | IT/EU range classification (`--features geo-ita` / `geo-eu`), **IPv4 + IPv6** — O(log N) binary search over baked CIDR data + one atomic, **no GeoIP DB, no syscall**. Class lands on the request (`extensions`), a metric, and an optional log. Answers "% EU vs non-EU traffic" out of the box (see [observability](https://fabriziosalmi.github.io/zion/guide/observability)). | ✅ shipping |
 | **Fleet signal** | AIMP serverless mesh (`--features sovereign-aimp`): Ed25519-signed UDP gossip of blocks + IP-reputation, source-bound revocation, no central control plane. Reputation rides to the upstream as `X-Zion-Mesh-Score`. | ✅ shipping (advisory) |
 
 **On the roadmap — the levers still to build** (tracked; PRs welcome):
@@ -310,7 +311,7 @@ Client -> TLS 1.3 -> Security Gates -> Radix Router -> WAF Pipeline (5 gates) ->
 ```
 
 <!-- zion-stats:modules-lines (kept in sync by scripts/update-readme-stats.sh) -->
-38 modules, ~25,400 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
+39 modules, ~25,600 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
 
 ## Benchmarking
 
@@ -336,7 +337,7 @@ Results saved to `benchmarks/bench-history.json` with automatic delta comparison
 ## Testing
 
 ```bash
-# Unit tests (557) <!-- zion-stats:test-count (kept in sync by scripts/update-readme-stats.sh) -->
+# Unit tests (561) <!-- zion-stats:test-count (kept in sync by scripts/update-readme-stats.sh) -->
 cargo test
 
 # Integration tests (19 -- requires running Zion + backend)

--- a/src/config.rs
+++ b/src/config.rs
@@ -146,6 +146,13 @@ pub struct ServerConfig {
     /// Rate limit window in seconds. Default: 1.
     #[serde(default = "default_rate_window")]
     pub rate_limit_window_secs: u64,
+    /// Max *concurrent* connections from a single source IP. 0 = unlimited
+    /// (default). This is the connection-exhaustion lever: rate_limit_rps
+    /// caps request frequency, this caps how many sockets one source can
+    /// hold open at once — the resource a slow/backed flood actually
+    /// drains. The global ceiling is the platform connection semaphore.
+    #[serde(default)]
+    pub max_connections_per_ip: u32,
     /// Log format: "text" (default) or "json".
     #[serde(default = "default_log_format")]
     pub log_format: String,

--- a/src/connlimit.rs
+++ b/src/connlimit.rs
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Per-IP concurrent-connection limiter — the connection-exhaustion lever.
+//!
+//! `rate_limit_rps` (see `security.rs`) caps how *often* a source may make
+//! requests; this caps how many connections a single source IP may hold
+//! open at the *same time*. That's the resource a slow / backed flood
+//! actually exhausts — sockets and handshake state, not request frequency.
+//! Enforced at accept, before the TLS handshake, so a rejected connection
+//! costs one map probe and an immediate close.
+//!
+//! Cost model mirrors the rate limiter: a `DashMap<IpAddr, u32>` shard
+//! lookup + increment on admit, decrement on drop (RAII). When the cap is
+//! 0 (disabled, the default) `try_acquire` short-circuits before touching
+//! the map — genuinely zero overhead.
+
+use dashmap::DashMap;
+use std::net::IpAddr;
+use std::sync::Arc;
+
+/// Tracks live concurrent connections per source IP. Lives in `AppState`
+/// across hot-reloads (it counts sockets, not config); the *cap* is read
+/// from the config snapshot at each accept, so changing the limit takes
+/// effect on new connections without disturbing live ones.
+#[derive(Default)]
+pub struct PerIpConnLimiter {
+    counts: DashMap<IpAddr, u32>,
+}
+
+impl PerIpConnLimiter {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Try to admit a new connection from `ip` under `cap`
+    /// (`0` = unlimited). Returns a [`ConnSlot`] guard that releases the
+    /// slot when dropped, or `None` if `ip` already holds `cap` concurrent
+    /// connections (caller should close the socket).
+    pub fn try_acquire(self: &Arc<Self>, ip: IpAddr, cap: u32) -> Option<ConnSlot> {
+        if cap == 0 {
+            // Disabled — don't even touch the map.
+            return Some(ConnSlot { limiter: None, ip });
+        }
+        // `entry` holds the shard write-lock for this key only while we
+        // read-and-bump — no other lock is taken inside, so no deadlock.
+        let mut count = self.counts.entry(ip).or_insert(0);
+        if *count >= cap {
+            return None;
+        }
+        *count += 1;
+        Some(ConnSlot {
+            limiter: Some(self.clone()),
+            ip,
+        })
+    }
+
+    /// Current number of distinct source IPs with at least one live
+    /// connection. For metrics / introspection.
+    #[allow(dead_code)]
+    pub fn tracked_ips(&self) -> usize {
+        self.counts.len()
+    }
+
+    fn release(&self, ip: IpAddr) {
+        // Decrement under the entry guard, then drop it before any
+        // `remove_if` (which needs the same shard lock — holding both
+        // would deadlock).
+        let now_zero = match self.counts.get_mut(&ip) {
+            Some(mut count) => {
+                *count = count.saturating_sub(1);
+                *count == 0
+            }
+            None => false,
+        };
+        if now_zero {
+            // Re-check under the removal path so we never evict an entry a
+            // concurrent `try_acquire` just bumped back above zero.
+            self.counts.remove_if(&ip, |_, &v| v == 0);
+        }
+    }
+}
+
+/// RAII slot: while held, one connection from `ip` is counted against the
+/// per-IP cap. Dropped when the connection task ends (including on panic /
+/// early return), releasing the slot.
+pub struct ConnSlot {
+    limiter: Option<Arc<PerIpConnLimiter>>,
+    ip: IpAddr,
+}
+
+impl Drop for ConnSlot {
+    fn drop(&mut self) {
+        if let Some(limiter) = &self.limiter {
+            limiter.release(self.ip);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ip(s: &str) -> IpAddr {
+        s.parse().unwrap()
+    }
+
+    #[test]
+    fn cap_zero_is_unlimited_and_untracked() {
+        let l = Arc::new(PerIpConnLimiter::new());
+        let a = ip("1.2.3.4");
+        let _g1 = l.try_acquire(a, 0).unwrap();
+        let _g2 = l.try_acquire(a, 0).unwrap();
+        // Disabled cap must not allocate map entries.
+        assert_eq!(l.tracked_ips(), 0);
+    }
+
+    #[test]
+    fn enforces_cap_per_ip() {
+        let l = Arc::new(PerIpConnLimiter::new());
+        let a = ip("1.2.3.4");
+        let g1 = l.try_acquire(a, 2);
+        let g2 = l.try_acquire(a, 2);
+        assert!(g1.is_some() && g2.is_some());
+        // Third concurrent connection from the same IP is rejected.
+        assert!(l.try_acquire(a, 2).is_none());
+        // A different IP is unaffected.
+        assert!(l.try_acquire(ip("5.6.7.8"), 2).is_some());
+    }
+
+    #[test]
+    fn slot_release_frees_capacity() {
+        let l = Arc::new(PerIpConnLimiter::new());
+        let a = ip("1.2.3.4");
+        let g1 = l.try_acquire(a, 1).unwrap();
+        assert!(l.try_acquire(a, 1).is_none());
+        drop(g1);
+        // Slot freed → a new connection is admitted again, and the entry
+        // is reclaimed when the count hits zero.
+        let g2 = l.try_acquire(a, 1);
+        assert!(g2.is_some());
+        drop(g2);
+        assert_eq!(l.tracked_ips(), 0);
+    }
+
+    #[test]
+    fn ipv6_is_tracked_independently() {
+        let l = Arc::new(PerIpConnLimiter::new());
+        let v6 = ip("2001:db8::1");
+        let _g = l.try_acquire(v6, 1).unwrap();
+        assert!(l.try_acquire(v6, 1).is_none());
+        assert!(l.try_acquire(ip("2001:db8::2"), 1).is_some());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,6 +48,7 @@ mod bootstrap;
 mod cache;
 mod cli;
 mod config;
+mod connlimit;
 mod doctor;
 mod error;
 mod health;
@@ -199,6 +200,9 @@ pub(crate) struct ResolvedAppConfig {
     pub(crate) rate_limit_rps: u32,
     /// Rate limiter window in seconds.
     pub(crate) rate_limit_window: u64,
+    /// Max concurrent connections per source IP. 0 = disabled. Read at
+    /// accept, so a hot-reload retunes the cap without dropping live conns.
+    pub(crate) max_connections_per_ip: u32,
     /// Pre-parsed listen address for plain HTTP. `None` if the config
     /// string is malformed; the listener supervisor logs the parse error
     /// at reload time and keeps the previously-bound listener.
@@ -235,6 +239,7 @@ impl ResolvedAppConfig {
             xff_mode: proxy::XffMode::Append,
             rate_limit_rps: 0,
             rate_limit_window: 1,
+            max_connections_per_ip: 0,
             listen_http: None,
             listen_https: None,
             #[cfg(any(feature = "geo-ita", feature = "geo-eu"))]
@@ -352,6 +357,7 @@ impl ResolvedAppConfig {
             xff_mode,
             rate_limit_rps: config.server.rate_limit_rps,
             rate_limit_window: config.server.rate_limit_window_secs,
+            max_connections_per_ip: config.server.max_connections_per_ip,
             listen_http,
             listen_https,
             #[cfg(any(feature = "geo-ita", feature = "geo-eu"))]
@@ -394,6 +400,11 @@ struct AppState {
     /// calling thread's current node — same-socket workers stay
     /// cache-local, cross-socket fallback scans on get-miss.
     rate_map: Arc<numa::NumaAwareMap<std::net::IpAddr, RateEntry>>,
+    /// Per-IP concurrent-connection limiter. Like `rate_map`, persists
+    /// across config reloads (it tracks live sockets, not config); the cap
+    /// is read from the config snapshot at accept time. The global ceiling
+    /// stays the `conn_limit` semaphore above.
+    conn_per_ip: Arc<connlimit::PerIpConnLimiter>,
     /// Singleflight: coalesce concurrent cache misses for the same key.
     /// First request fetches from upstream and inserts a `watch::Sender<bool>`;
     /// subsequent requests subscribe and await `true`. Watch (vs Notify) is
@@ -849,6 +860,7 @@ async fn async_main(platform: &'static bootstrap::Platform) -> error::ZionResult
         conn_limit: Arc::new(Semaphore::new(platform.conn_limit)),
         acme_challenges: acme::new_challenge_store(),
         rate_map: Arc::new(numa::NumaAwareMap::new()),
+        conn_per_ip: Arc::new(connlimit::PerIpConnLimiter::new()),
         inflight: numa::NumaAwareMap::new(),
         audit: audit_handle,
         redact: compiled_redact,
@@ -1363,10 +1375,28 @@ fn spawn_https_handler(
     remote_addr: SocketAddr,
     state: Arc<AppState>,
 ) {
-    // Connection limit — fast atomic check, no Arc clone.
+    // Global connection ceiling — fast atomic check, no Arc clone.
     let permit = match state.conn_limit.clone().try_acquire_owned() {
         Ok(p) => p,
         Err(_) => {
+            drop(tcp_stream);
+            return;
+        }
+    };
+
+    // Per-IP concurrent-connection cap (anti-DDoS, issue #150 lever). Read
+    // the cap from the live config snapshot so a hot-reload retunes it.
+    // `cap == 0` short-circuits inside `try_acquire` (zero overhead). A
+    // rejected source is closed immediately, before the TLS handshake.
+    let ip_slot = match state
+        .conn_per_ip
+        .try_acquire(remote_addr.ip(), state.config.load().max_connections_per_ip)
+    {
+        Some(slot) => slot,
+        None => {
+            metrics::METRICS
+                .connections_rejected_per_ip
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             drop(tcp_stream);
             return;
         }
@@ -1377,6 +1407,9 @@ fn spawn_https_handler(
 
     tokio::spawn(async move {
         let _permit = permit;
+        // Held for the connection's lifetime; releases the per-IP slot on
+        // drop (including early return / panic during the handshake).
+        let _ip_slot = ip_slot;
         let _conn_guard = metrics::ConnectionGuard::new();
         let _ = tcp_stream.set_nodelay(true);
         net::tune_accepted(&tcp_stream);

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -400,6 +400,9 @@ pub struct Metrics {
     pub websocket_upgrades: AtomicU64,
     pub connections_total: AtomicU64,
     pub tls_handshake_errors: AtomicU64,
+    /// Connections closed at accept because the source IP was already at
+    /// its `max_connections_per_ip` concurrent cap (anti-DDoS lever).
+    pub connections_rejected_per_ip: AtomicU64,
 
     // ── Mesh observability (issue #69) ──────────────────────────────
     // Always-on counters (zero on builds without `--features
@@ -463,6 +466,7 @@ impl Metrics {
             websocket_upgrades: AtomicU64::new(0),
             connections_total: AtomicU64::new(0),
             tls_handshake_errors: AtomicU64::new(0),
+            connections_rejected_per_ip: AtomicU64::new(0),
             mesh_claims_emitted: AtomicU64::new(0),
             mesh_claims_received: AtomicU64::new(0),
             mesh_claims_dropped_signature: AtomicU64::new(0),
@@ -632,6 +636,18 @@ impl Metrics {
         out.extend_from_slice(
             itoa_buf
                 .format(self.tls_handshake_errors.load(Relaxed))
+                .as_bytes(),
+        );
+        out.extend_from_slice(b"\n");
+
+        out.extend_from_slice(
+            b"# HELP zion_connections_rejected_per_ip Connections closed at accept for exceeding max_connections_per_ip.\n\
+                                # TYPE zion_connections_rejected_per_ip counter\n\
+                                zion_connections_rejected_per_ip ",
+        );
+        out.extend_from_slice(
+            itoa_buf
+                .format(self.connections_rejected_per_ip.load(Relaxed))
                 .as_bytes(),
         );
         out.extend_from_slice(b"\n");

--- a/zion.example.toml
+++ b/zion.example.toml
@@ -17,6 +17,13 @@ listen_https = "0.0.0.0:443"
 # rate_limit_rps = 1000
 # rate_limit_window_secs = 1
 
+# Per-IP concurrent-connection cap. 0 = disabled (default). Caps how many
+# sockets a single source IP may hold open at once (enforced at accept,
+# before the TLS handshake) — the resource a slow/backed flood drains.
+# Complements rate_limit_rps (which caps request frequency, not sockets).
+# rejected connections are counted in `zion_connections_rejected_per_ip`.
+# max_connections_per_ip = 256
+
 # Trusted proxy CIDR ranges. When the TCP peer matches one of these,
 # the real client IP is extracted from X-Forwarded-For using the
 # rightmost-untrusted-hop algorithm. Leave empty when Zion is the front


### PR DESCRIPTION
Per-IP **concurrent-connection** limit — caps how many sockets a single source IP may hold open at once, enforced at accept before the TLS handshake. `rate_limit_rps` caps request *frequency*; this caps *concurrency*, the resource a slow/backed flood actually exhausts.

- `connlimit::PerIpConnLimiter` — `DashMap<IpAddr, u32>` + RAII `ConnSlot` guard (releases on drop, incl. early-return/panic). `cap == 0` (default) short-circuits before touching the map → zero overhead. Lives in `AppState` across reloads; cap read from the config snapshot per accept → hot-reload retunes it without dropping live conns.
- Enforced in `spawn_https_handler` after the global permit, before the handshake; rejected source closed in one map probe. Metric `zion_connections_rejected_per_ip`.
- Config `server.max_connections_per_ip` (0 = off), documented in `zion.example.toml`.
- Tests: cap enforcement, release frees + reclaims the entry, cap=0 untracked, v4/v6 independent.

HTTP/:80 (redirect/ACME, no TLS cost) intentionally not gated here. Global total stays the platform connection semaphore.