### PR TITLE
feat(edge): tag-driven enforcement — origin tag / mesh score → opt-in deny (#150)

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ Results saved to `benchmarks/bench-history.json` with automatic delta comparison
 ## Testing
 
 ```bash
-# Unit tests (561) <!-- zion-stats:test-count (kept in sync by scripts/update-readme-stats.sh) -->
+# Unit tests (565) <!-- zion-stats:test-count (kept in sync by scripts/update-readme-stats.sh) -->
 cargo test
 
 # Integration tests (19 -- requires running Zion + backend)

--- a/README.md
+++ b/README.md
@@ -169,17 +169,15 @@ leave on under load. Defence is layered, outside-in:
 | **L7 — inspection** | WAF: zero-regex Aho-Corasick O(N) single-pass, Shannon entropy, simd-json structural limits, 5 gates. | ✅ shipping |
 | **Origin tagging** | IT/EU range classification (`--features geo-ita` / `geo-eu`), **IPv4 + IPv6** — O(log N) binary search over baked CIDR data + one atomic, **no GeoIP DB, no syscall**. Class lands on the request (`extensions`), a metric, and an optional log. Answers "% EU vs non-EU traffic" out of the box (see [observability](https://fabriziosalmi.github.io/zion/guide/observability)). | ✅ shipping |
 | **Fleet signal** | AIMP serverless mesh (`--features sovereign-aimp`): Ed25519-signed UDP gossip of blocks + IP-reputation, source-bound revocation, no central control plane. Reputation rides to the upstream as `X-Zion-Mesh-Score`. | ✅ shipping (advisory) |
+| **Tag-driven enforcement** | `[sovereign.enforce]` (`#150`) promotes the origin tag / mesh score from *signal* to an opt-in `403` deny — e.g. `deny = ["unknown"]` blocks every non-EU source while EU classes pass (sovereign allowlist by complement), or deny above an AIMP reputation threshold. Off by default; local WAF / rate-limit / auth stay authoritative. Counted in `zion_enforcement_denied_total{reason}`. | ✅ shipping |
 
-**On the roadmap — the levers still to build** (tracked; PRs welcome):
+**On the roadmap — the lever still to build** (tracked; PRs welcome):
 
-- **Tag-driven enforcement** ([#150](https://github.com/fabriziosalmi/zion/issues/150)) —
-  today the origin tag and mesh score are *signals* (metric / header /
-  request extension). Wiring them as *active* admission knobs — e.g.
-  tighter rate-limit or tarpit for non-EU or low-reputation sources,
-  allowlist your sovereign ranges — is the next lever.
 - **L7 tarpit / slow-drip** ([#151](https://github.com/fabriziosalmi/zion/issues/151)) —
-  hold flagged connections instead of a clean `429`, so a backed
-  attacker pays wall-clock and socket budget.
+  hold flagged connections (those an enforcement policy or a rate/conn
+  breach marks) instead of a clean `429`, so a backed attacker pays
+  wall-clock and socket budget. Bounded by a hard concurrency ceiling
+  (the per-IP connection-limit primitive) so it can't self-DoS.
 
 The design rule: tagging and reputation never *silently* gate — the
 operator opts a signal into enforcement explicitly, and the local
@@ -311,7 +309,7 @@ Client -> TLS 1.3 -> Security Gates -> Radix Router -> WAF Pipeline (5 gates) ->
 ```
 
 <!-- zion-stats:modules-lines (kept in sync by scripts/update-readme-stats.sh) -->
-39 modules, ~25,600 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
+39 modules, ~25,800 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
 
 ## Benchmarking
 

--- a/docs/guide/observability.md
+++ b/docs/guide/observability.md
@@ -95,6 +95,21 @@ table and a parallel `u128` table; IPv4-mapped IPv6 folds onto the v4
 path). `unknown` therefore means an IP in no dataset — genuinely non-EU
 on the `geo-eu` build, or unclassified-by-ASN on `geo-ita`.
 
+**Tag-driven enforcement (`[sovereign.enforce]`).** By default the class
+is a pure *signal*. The operator can opt a class (or an AIMP
+mesh-reputation threshold) into a hard `403` deny — e.g. `deny =
+["unknown"]` on a `geo-eu` build blocks every non-EU source while the EU
+classes pass (the sovereign allowlist *by complement*). Denials are
+counted, split by reason:
+
+```
+zion_enforcement_denied_total{reason="class"}       1043
+zion_enforcement_denied_total{reason="mesh_score"}    77
+```
+
+The local WAF / rate-limiter / auth gates stay authoritative — enforcement
+only *adds* a deny on top, and is off until configured.
+
 ## Access log
 
 Every successful request emits one structured `tracing::info!`

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -213,6 +213,15 @@ pub(crate) async fn process_request(
             let ip_class = sovereign::classify(client_ip);
             sovereign::record_classification(ip_class);
             req.extensions_mut().insert(ip_class);
+            // Tag-driven enforcement (#150): deny classes the operator
+            // opted in. Off by default; the local WAF / rate-limit / auth
+            // gates stay authoritative — this only adds a deny on top.
+            if cfg.enforce.denies_class(ip_class.as_str()) {
+                metrics::METRICS
+                    .enforcement_denied_class
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                return Ok(empty_response(StatusCode::FORBIDDEN));
+            }
             if cfg.sovereign_log_classification && ip_class != sovereign::IpClass::Unknown {
                 tracing::info!(
                     target: "sovereign",
@@ -246,6 +255,18 @@ pub(crate) async fn process_request(
             metrics::METRICS
                 .mesh_score_lookups
                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            // Tag-driven enforcement (#150): deny low-reputation sources
+            // when the operator set a threshold. Promotes the mesh score
+            // from advisory header to optional hard gate (ADR-0008). The
+            // policy lives under the geo-gated `[sovereign]` block, so this
+            // deny is only compiled when geo is on too.
+            #[cfg(any(feature = "geo-ita", feature = "geo-eu"))]
+            if cfg.enforce.denies_score(rep.score) {
+                metrics::METRICS
+                    .enforcement_denied_mesh_score
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                return Ok(empty_response(StatusCode::FORBIDDEN));
+            }
             // 3 decimals so log/grep humans see a stable string;
             // upstreams parse as f32 and tolerate any precision.
             let formatted = format!("{:.3}", rep.score);

--- a/src/main.rs
+++ b/src/main.rs
@@ -203,6 +203,12 @@ pub(crate) struct ResolvedAppConfig {
     /// Max concurrent connections per source IP. 0 = disabled. Read at
     /// accept, so a hot-reload retunes the cap without dropping live conns.
     pub(crate) max_connections_per_ip: u32,
+    /// Resolved tag-driven enforcement policy (`[sovereign.enforce]`, #150).
+    /// Lives under the geo-gated `[sovereign]` block (class deny needs the
+    /// dataset). Disabled by default. Mesh-score deny additionally needs
+    /// `--features sovereign-aimp`.
+    #[cfg(any(feature = "geo-ita", feature = "geo-eu"))]
+    pub(crate) enforce: sovereign::EnforcePolicy,
     /// Pre-parsed listen address for plain HTTP. `None` if the config
     /// string is malformed; the listener supervisor logs the parse error
     /// at reload time and keeps the previously-bound listener.
@@ -240,6 +246,8 @@ impl ResolvedAppConfig {
             rate_limit_rps: 0,
             rate_limit_window: 1,
             max_connections_per_ip: 0,
+            #[cfg(any(feature = "geo-ita", feature = "geo-eu"))]
+            enforce: sovereign::EnforcePolicy::default(),
             listen_http: None,
             listen_https: None,
             #[cfg(any(feature = "geo-ita", feature = "geo-eu"))]
@@ -350,6 +358,28 @@ impl ResolvedAppConfig {
             (sov.enabled, sov.log_classification)
         };
 
+        // Resolve the tag-driven enforcement policy (#150) and warn on any
+        // deny label that matches no known IpClass — a typo would silently
+        // never fire, which is exactly the failure an operator can't see.
+        #[cfg(any(feature = "geo-ita", feature = "geo-eu"))]
+        let enforce = {
+            let policy = sovereign::EnforcePolicy::from_config(&config.sovereign.enforce);
+            if config.sovereign.enforce.enabled {
+                let unknown = policy.unknown_deny_labels();
+                if !unknown.is_empty() {
+                    logging::warn(
+                        "sovereign",
+                        &format!(
+                            "[sovereign.enforce] deny lists unknown class label(s) {:?} — they will never match (known: {:?})",
+                            unknown,
+                            sovereign::known_class_labels(),
+                        ),
+                    );
+                }
+            }
+            policy
+        };
+
         Ok(Self {
             router,
             health_map,
@@ -358,6 +388,8 @@ impl ResolvedAppConfig {
             rate_limit_rps: config.server.rate_limit_rps,
             rate_limit_window: config.server.rate_limit_window_secs,
             max_connections_per_ip: config.server.max_connections_per_ip,
+            #[cfg(any(feature = "geo-ita", feature = "geo-eu"))]
+            enforce,
             listen_http,
             listen_https,
             #[cfg(any(feature = "geo-ita", feature = "geo-eu"))]

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -403,6 +403,12 @@ pub struct Metrics {
     /// Connections closed at accept because the source IP was already at
     /// its `max_connections_per_ip` concurrent cap (anti-DDoS lever).
     pub connections_rejected_per_ip: AtomicU64,
+    /// Requests denied (403) by tag-driven enforcement because the origin
+    /// class is on the `[sovereign.enforce] deny` list (#150).
+    pub enforcement_denied_class: AtomicU64,
+    /// Requests denied (403) by tag-driven enforcement because the AIMP
+    /// mesh reputation score exceeded `mesh_score_deny_above` (#150).
+    pub enforcement_denied_mesh_score: AtomicU64,
 
     // ── Mesh observability (issue #69) ──────────────────────────────
     // Always-on counters (zero on builds without `--features
@@ -467,6 +473,8 @@ impl Metrics {
             connections_total: AtomicU64::new(0),
             tls_handshake_errors: AtomicU64::new(0),
             connections_rejected_per_ip: AtomicU64::new(0),
+            enforcement_denied_class: AtomicU64::new(0),
+            enforcement_denied_mesh_score: AtomicU64::new(0),
             mesh_claims_emitted: AtomicU64::new(0),
             mesh_claims_received: AtomicU64::new(0),
             mesh_claims_dropped_signature: AtomicU64::new(0),
@@ -648,6 +656,24 @@ impl Metrics {
         out.extend_from_slice(
             itoa_buf
                 .format(self.connections_rejected_per_ip.load(Relaxed))
+                .as_bytes(),
+        );
+        out.extend_from_slice(b"\n");
+
+        out.extend_from_slice(
+            b"# HELP zion_enforcement_denied_total Requests denied (403) by tag-driven enforcement.\n\
+                                # TYPE zion_enforcement_denied_total counter\n\
+                                zion_enforcement_denied_total{reason=\"class\"} ",
+        );
+        out.extend_from_slice(
+            itoa_buf
+                .format(self.enforcement_denied_class.load(Relaxed))
+                .as_bytes(),
+        );
+        out.extend_from_slice(b"\nzion_enforcement_denied_total{reason=\"mesh_score\"} ");
+        out.extend_from_slice(
+            itoa_buf
+                .format(self.enforcement_denied_mesh_score.load(Relaxed))
                 .as_bytes(),
         );
         out.extend_from_slice(b"\n");

--- a/src/sovereign/mod.rs
+++ b/src/sovereign/mod.rs
@@ -342,6 +342,109 @@ pub struct SovereignConfig {
     /// Log IP classification in structured request logs.
     #[serde(default = "default_true")]
     pub log_classification: bool,
+
+    /// Tag-driven enforcement policy (`[sovereign.enforce]`, issue #150).
+    /// Off by default — classification stays a pure signal unless the
+    /// operator opts a class (or a mesh-reputation threshold) into a
+    /// hard deny.
+    #[serde(default)]
+    pub enforce: EnforceConfig,
+}
+
+/// `[sovereign.enforce]` — promotes the origin tag / mesh-reputation
+/// score from *signal* to an opt-in admission gate (issue #150). Disabled
+/// by default. The local WAF / rate-limiter / auth gates stay
+/// authoritative; this only adds a deny on top.
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct EnforceConfig {
+    /// Master switch. Default: false (signals-only).
+    #[serde(default)]
+    pub enabled: bool,
+    /// `IpClass` labels (as in [`IpClass::as_str`], e.g. `"unknown"`,
+    /// `"datacenter_eu"`) whose requests are denied with `403`. On a
+    /// `geo-eu` build, `["unknown"]` denies every non-EU source while the
+    /// EU classes pass — the sovereign allowlist *by complement*.
+    #[serde(default)]
+    pub deny: Vec<String>,
+    /// Deny (`403`) when the AIMP mesh reputation score for the source
+    /// exceeds this threshold. `0.0` = off (default). Promotes the mesh
+    /// score from advisory header to optional hard gate (ADR-0008
+    /// high-confidence path). Requires `--features sovereign-aimp`.
+    #[serde(default)]
+    pub mesh_score_deny_above: f32,
+}
+
+impl Default for EnforceConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            deny: Vec::new(),
+            mesh_score_deny_above: 0.0,
+        }
+    }
+}
+
+/// Resolved, hot-path form of [`EnforceConfig`]: deny labels lowercased
+/// into a set for O(1) membership. Pure decision methods so the policy is
+/// unit-testable without a live request.
+#[derive(Debug, Clone, Default)]
+pub struct EnforcePolicy {
+    pub enabled: bool,
+    deny: std::collections::HashSet<String>,
+    mesh_score_deny_above: f32,
+}
+
+impl EnforcePolicy {
+    pub fn from_config(c: &EnforceConfig) -> Self {
+        Self {
+            enabled: c.enabled,
+            deny: c.deny.iter().map(|s| s.to_ascii_lowercase()).collect(),
+            mesh_score_deny_above: c.mesh_score_deny_above,
+        }
+    }
+
+    /// True if a request from `class_label` should be denied (`403`).
+    #[inline]
+    pub fn denies_class(&self, class_label: &str) -> bool {
+        self.enabled && self.deny.contains(class_label)
+    }
+
+    /// True if a source with mesh reputation `score` should be denied.
+    #[inline]
+    #[allow(dead_code)] // only reached on `--features sovereign-aimp`
+    pub fn denies_score(&self, score: f32) -> bool {
+        self.enabled && self.mesh_score_deny_above > 0.0 && score > self.mesh_score_deny_above
+    }
+
+    /// Deny labels that don't match any known `IpClass` — surfaced at
+    /// config-load so a typo (`"datacentre_eu"`) doesn't silently no-op.
+    pub fn unknown_deny_labels(&self) -> Vec<&str> {
+        let known = known_class_labels();
+        self.deny
+            .iter()
+            .filter(|l| !known.contains(&l.as_str()))
+            .map(|s| s.as_str())
+            .collect()
+    }
+}
+
+/// Every `IpClass` label valid in the current build (the EU labels exist
+/// only under `--features geo-eu`). Used to validate enforcement config.
+pub fn known_class_labels() -> &'static [&'static str] {
+    &[
+        "gov_ita",
+        "residential_ita",
+        "datacenter_ita",
+        #[cfg(feature = "geo-eu")]
+        "eu",
+        #[cfg(feature = "geo-eu")]
+        "gov_eu",
+        #[cfg(feature = "geo-eu")]
+        "residential_eu",
+        #[cfg(feature = "geo-eu")]
+        "datacenter_eu",
+        "unknown",
+    ]
 }
 
 impl Default for SovereignConfig {
@@ -352,6 +455,7 @@ impl Default for SovereignConfig {
             signals: false,
             signal_listen: "0.0.0.0:9443".to_string(),
             log_classification: true,
+            enforce: EnforceConfig::default(),
         }
     }
 }
@@ -483,6 +587,63 @@ mod tests {
         assert_eq!(IpClass::GovEu.as_str(), "gov_eu");
         assert_eq!(IpClass::ResidentialEu.as_str(), "residential_eu");
         assert_eq!(IpClass::DatacenterEu.as_str(), "datacenter_eu");
+    }
+
+    // ── Tag-driven enforcement policy (issue #150) ───────────────────
+    #[test]
+    fn enforce_disabled_denies_nothing() {
+        let p = EnforcePolicy::from_config(&EnforceConfig {
+            enabled: false,
+            deny: vec!["unknown".into()],
+            mesh_score_deny_above: 0.5,
+        });
+        assert!(!p.denies_class("unknown"));
+        assert!(!p.denies_score(0.99));
+    }
+
+    #[test]
+    fn enforce_denies_listed_class_case_insensitively() {
+        let p = EnforcePolicy::from_config(&EnforceConfig {
+            enabled: true,
+            deny: vec!["Unknown".into(), "DATACENTER_EU".into()],
+            mesh_score_deny_above: 0.0,
+        });
+        assert!(p.denies_class("unknown"));
+        assert!(p.denies_class("datacenter_eu"));
+        // A class not on the list passes (the sovereign-allowlist-by-complement).
+        assert!(!p.denies_class("residential_eu"));
+        assert!(!p.denies_class("gov_ita"));
+    }
+
+    #[test]
+    fn enforce_score_threshold_is_strict_and_off_at_zero() {
+        let off = EnforcePolicy::from_config(&EnforceConfig {
+            enabled: true,
+            deny: vec![],
+            mesh_score_deny_above: 0.0, // 0 = disabled
+        });
+        assert!(!off.denies_score(1.0));
+
+        let p = EnforcePolicy::from_config(&EnforceConfig {
+            enabled: true,
+            deny: vec![],
+            mesh_score_deny_above: 0.9,
+        });
+        assert!(p.denies_score(0.91));
+        assert!(!p.denies_score(0.9)); // strict `>`, equal does not deny
+        assert!(!p.denies_score(0.5));
+    }
+
+    #[test]
+    fn enforce_flags_typoed_deny_labels() {
+        let p = EnforcePolicy::from_config(&EnforceConfig {
+            enabled: true,
+            deny: vec!["unknown".into(), "datacentre_eu".into()], // British typo
+            mesh_score_deny_above: 0.0,
+        });
+        let unknown = p.unknown_deny_labels();
+        assert!(unknown.contains(&"datacentre_eu"));
+        assert!(!unknown.contains(&"unknown"));
     }
 
     #[cfg(feature = "geo-eu")]

--- a/zion.example.toml
+++ b/zion.example.toml
@@ -39,6 +39,28 @@ listen_https = "0.0.0.0:443"
 # Invalid values fall back to "append" with a startup warning.
 # xff_mode = "append"
 
+# ── Sovereign edge: IT/EU origin tagging (build with --features geo-ita
+# / geo-eu). Classifies the client IP (IPv4+IPv6) and exposes
+# `zion_sovereign_classifications_total{class}` → "% EU vs non-EU".
+# [sovereign]
+# enabled = true
+# log_classification = false   # also emit a per-request `sovereign` log line
+#
+# Tag-driven enforcement (#150) — promotes the origin tag / mesh score
+# from a *signal* to an opt-in admission DENY. Off by default. The local
+# WAF / rate-limit / auth gates stay authoritative; this only adds a deny.
+# [sovereign.enforce]
+# enabled = true
+# # IpClass labels to deny with 403. On a geo-eu build `["unknown"]` blocks
+# # every non-EU source while the EU classes pass — the sovereign allowlist
+# # by complement. Labels: eu, gov_eu, residential_eu, datacenter_eu,
+# # gov_ita, residential_ita, datacenter_ita, unknown.
+# deny = ["unknown"]
+# # Deny when the AIMP mesh reputation score exceeds this (0 = off).
+# # Requires --features sovereign-aimp. Counted in
+# # `zion_enforcement_denied_total{reason="class"|"mesh_score"}`.
+# mesh_score_deny_above = 0.9
+
 [tls]
 cert_path = "/etc/ssl/zion/tls.crt"
 key_path = "/etc/ssl/zion/tls.key"


### PR DESCRIPTION
**Sprint B / Phase 1.** Closes the "tag exists but nothing acts on it" gap from #147: promotes the sovereign origin tag (and AIMP mesh-reputation score) from a pure *signal* to an opt-in admission **deny**.

## Model
`[sovereign.enforce]` (off by default):
```toml
[sovereign.enforce]
enabled = true
deny = ["unknown"]            # IpClass labels → 403. On geo-eu, "unknown" = non-EU.
mesh_score_deny_above = 0.9   # 403 if AIMP reputation > threshold (0 = off; needs sovereign-aimp)
```
On a `geo-eu` build, `deny = ["unknown"]` blocks every non-EU source while the EU classes pass — **the sovereign allowlist by complement**. The local WAF / rate-limiter / auth stay authoritative; this only *adds* a 403.

## Implementation
- `EnforceConfig` → resolved `EnforcePolicy` (deny labels lowercased into a set; pure `denies_class` / `denies_score` methods, unit-tested).
- Enforced in `dispatch`: class-deny inside the existing geo block (after classification), mesh-score-deny inside the AIMP block (after the reputation lookup). **No reordering, no rate-limiter surgery.**
- Config-load **warns on typo'd deny labels** (`known_class_labels()`) so a mistake doesn't silently never-fire.
- Metric `zion_enforcement_denied_total{reason="class"|"mesh_score"}`.
- Cfg: under the geo-gated `[sovereign]` block; mesh-score deny additionally needs `--features sovereign-aimp`. Compiles clean on **default / geo-eu / sovereign-aimp(no geo) / all-features** (clippy `-D warnings`).

## Deferred (honest follow-up)
Per-class `rate` throttle and per-class `max_conn` override — they need a class-aware rate-limiter (reordering classify before the always-on rate gate) and accept-path rework. Separate PR.

Closes #150. Next (Phase 2): #151 L7 tarpit, which consumes this flagging + the #155 bounded-concurrency primitive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)