### PR TITLE
chore(release): v0.3.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,7 +21,7 @@ A clear and concise description of what you expected to happen.
 **Environment (please complete the following information):**
  - OS: [e.g. Linux, macOS]
  - Architecture: [e.g. arm64, amd64]
- - Zion Version: [e.g. 0.2.3]
+ - Zion Version: [e.g. 0.3.0]
 
 **Additional context**
 Add any other context about the problem here (e.g. logs with `RUST_LOG=trace`, upstream backend type like Go/Node).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,47 @@ All notable changes to Zion Edge Gateway are documented here.
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-05-30
+
+The first tagged release since v0.2.2. Completes the **v0.3 — Compliance
+frontier** milestone (BoGo TLS conformance in CI) and ships the
+**Sovereign Edge** origin tagging (IT/EU, IPv4 + IPv6) plus the first
+**anti-DDoS admission levers** (per-IP concurrent-connection limit,
+tag-driven enforcement). The full OpenTelemetry stack moved to 0.32 and
+the CI / supply-chain were hardened. Supersedes the unreleased 0.2.3 line.
+
 ### Added
 
+- **BoGo TLS conformance suite in CI (#56)**
+  ([`.github/workflows/tls-conformance.yml`](.github/workflows/tls-conformance.yml)).
+  Runs BoringSSL's BoGo suite (~600 cases) against the exact `rustls` +
+  `aws-lc-rs` versions zion pins — version-locked, so a future
+  `Cargo.lock` bump that regresses conformance goes red on the bumping
+  PR. Closes the v0.3 milestone. Corrected the long-standing doc/issue
+  myth that BoGo could be pointed at zion's `:443` (it drives a *shim*).
+- **Sovereign Edge — IT/EU origin tagging, IPv4 + IPv6 (#147)**
+  (`--features geo-ita` / `geo-eu`). Classifies the client IP via an
+  O(log N) binary search over baked CIDR tables (a `u32` table + a
+  parallel `u128` table for IPv6) — no GeoIP DB, no syscall, one atomic.
+  `geo-eu` is a hybrid model: every EU-27 RIPE allocation is the
+  `Eu` baseline, curated EU ASN sets override it with gov/residential/
+  datacenter roles. Answers "% EU vs non-EU traffic" out of the box via
+  `zion_sovereign_classifications_total{class}`. Dataset auto-refreshes
+  weekly (`sovereign-data.yml`, RIPE NCC + Team Cymru).
+- **Per-IP concurrent-connection limit (#155)** —
+  `server.max_connections_per_ip` (0 = off). Caps how many sockets one
+  source IP may hold open at once, enforced at accept *before* the TLS
+  handshake (the resource a slow/backed flood drains). RAII release,
+  zero overhead when disabled, hot-reloadable. Metric
+  `zion_connections_rejected_per_ip`.
+- **Tag-driven enforcement (#150)** — `[sovereign.enforce]` promotes the
+  origin tag / AIMP mesh score from a *signal* to an opt-in `403` deny.
+  `deny = ["unknown"]` on a `geo-eu` build blocks every non-EU source
+  while the EU classes pass (sovereign allowlist by complement), or deny
+  above a mesh-reputation threshold. Off by default; local WAF /
+  rate-limit / auth stay authoritative. Metric
+  `zion_enforcement_denied_total{reason}`. A README "Sovereign edge &
+  DDoS resistance" section maps the layered defence.
 - **ACME issue → renew → revoke soak in CI (#59)**
   ([`.github/workflows/acme-soak.yml`](.github/workflows/acme-soak.yml),
   [`src/acme.rs`](src/acme.rs)). New `acme-soak` weekly + on-demand
@@ -216,6 +255,20 @@ All notable changes to Zion Edge Gateway are documented here.
 
 ### Changed
 
+- **OpenTelemetry stack migrated 0.27 → 0.32 (#145)** — adapted
+  `src/observability.rs` to the post-0.28 SDK API (`SdkTracerProvider`,
+  `with_batch_exporter` without a runtime arg, `Resource::builder`,
+  semconv `attribute::`). All target versions are MSRV 1.75. The
+  cargo-vet baseline was regenerated for the new transitive crates
+  (prost 0.14, tonic 0.14, …).
+- **CI hardening.** `cargo-audit` / `cargo-vet` now install as **prebuilt
+  binaries** (`taiki-e/install-action`) instead of building from source,
+  eliminating an intermittent self-hosted-runner build flake (#154).
+  Three high-volume workflows (supply-chain, CodeQL, DCO) moved to
+  self-hosted runners (#144); `supply-chain.yml` forces
+  `RUSTUP_TOOLCHAIN=stable` so the repo's pinned 1.88.0 toolchain can't
+  break the audit jobs (#146).
+- **Security:** `tar` 0.4.45 → 0.4.46 (Dependabot rust-security group).
 - **`cargo-vet` promoted to a required CI gate** — `supply-chain/`
   baseline committed via `cargo vet init`, with audit imports from
   Mozilla, Google, Embark, Bytecode Alliance, ISRG, and Zcash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1233,7 +1233,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1978,7 +1978,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3492,7 +3492,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3560,7 +3560,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4059,9 +4059,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.45"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",
@@ -4954,7 +4954,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -5421,7 +5421,7 @@ dependencies = [
 
 [[package]]
 name = "zion"
-version = "0.2.3"
+version = "0.3.0"
 dependencies = [
  "aho-corasick",
  "aimp_node",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zion"
-version = "0.2.3"
+version = "0.3.0"
 edition = "2021"
 # MSRV is the *core* default-features build (TLS proxy + WAF + cache + metrics).
 # Opt-in features (acme, auth, init, http3) pull crypto/i18n crates that have

--- a/README.md
+++ b/README.md
@@ -364,12 +364,12 @@ commands. The short version:
 
 ```bash
 # Binary release (Sigstore-backed provenance via gh CLI)
-gh release download v0.2.3 -R fabriziosalmi/zion -p '*x86_64-unknown-linux-musl*' -p 'SHA256SUMS'
+gh release download v0.3.0 -R fabriziosalmi/zion -p '*x86_64-unknown-linux-musl*' -p 'SHA256SUMS'
 sha256sum --check --ignore-missing SHA256SUMS
-gh attestation verify zion-v0.2.3-x86_64-unknown-linux-musl.tar.gz --owner fabriziosalmi
+gh attestation verify zion-v0.3.0-x86_64-unknown-linux-musl.tar.gz --owner fabriziosalmi
 
 # Container image (cosign keyless)
-cosign verify ghcr.io/fabriziosalmi/zion:v0.2.3 \
+cosign verify ghcr.io/fabriziosalmi/zion:v0.3.0 \
     --certificate-identity-regexp "^https://github.com/fabriziosalmi/zion/\\.github/workflows/release\\.yml@refs/tags/v" \
     --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ from their containing minor — i.e. the latest `0.1.x` is always patched.
 | Version | Supported |
 | ------- | --------- |
 | 0.1.x (latest minor) | Yes |
-| < 0.2.3 | No |
+| < 0.3.0 | No |
 
 ## Reporting a Vulnerability
 

--- a/deploy/helm/zion/Chart.yaml
+++ b/deploy/helm/zion/Chart.yaml
@@ -3,7 +3,7 @@ name: zion
 description: Zion Edge Gateway — high-performance Rust TLS reverse proxy with WAF
 type: application
 version: 0.2.2
-appVersion: "0.2.3"
+appVersion: "0.3.0"
 home: https://fabriziosalmi.github.io/zion
 sources:
   - https://github.com/fabriziosalmi/zion

--- a/docs/deploy/hot-reload.md
+++ b/docs/deploy/hot-reload.md
@@ -130,7 +130,7 @@ Two surfaces report the reload state:
 
   ```json
   {
-    "version": "0.2.3",
+    "version": "0.3.0",
     "timestamp_ms": 1714425600000,
     "uptime_secs": 3712,
     "config_generation": 5,

--- a/docs/security/supply-chain.md
+++ b/docs/security/supply-chain.md
@@ -46,8 +46,8 @@ You need the GitHub CLI (`gh >= 2.49`) and `cosign >= 2.2`.
 
 ```bash
 # 1. Download the artifact + SHA256SUMS from the release page.
-gh release download v0.2.3 -R fabriziosalmi/zion \
-    -p 'zion-v0.2.3-x86_64-unknown-linux-musl.tar.gz' \
+gh release download v0.3.0 -R fabriziosalmi/zion \
+    -p 'zion-v0.3.0-x86_64-unknown-linux-musl.tar.gz' \
     -p 'SHA256SUMS' \
     -p 'zion-sbom.cdx.json'
 
@@ -55,7 +55,7 @@ gh release download v0.2.3 -R fabriziosalmi/zion \
 sha256sum --check --ignore-missing SHA256SUMS
 
 # 3. Verify the SLSA build provenance bound to the artifact's hash.
-gh attestation verify zion-v0.2.3-x86_64-unknown-linux-musl.tar.gz \
+gh attestation verify zion-v0.3.0-x86_64-unknown-linux-musl.tar.gz \
     --owner fabriziosalmi
 
 # Step 3 fails if:
@@ -78,7 +78,7 @@ grype zion-sbom.cdx.json
 ## Verifying a container image
 
 ```bash
-IMAGE=ghcr.io/fabriziosalmi/zion:v0.2.3
+IMAGE=ghcr.io/fabriziosalmi/zion:v0.3.0
 
 # 1. Pin to the digest immediately — tags are mutable, digests are not.
 DIGEST=$(crane digest "$IMAGE")
@@ -120,7 +120,7 @@ deterministically, and pins the Rust toolchain via
 [`rust-toolchain.toml`](../../rust-toolchain.toml). To reproduce locally:
 
 ```bash
-git checkout v0.2.3
+git checkout v0.3.0
 export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)
 # Linux musl example — matches the release artifact byte-for-byte
 # (modulo strip's stable behavior on your distro).

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -1215,7 +1215,7 @@ version = "0.6.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.tar]]
-version = "0.4.45"
+version = "0.4.46"
 criteria = "safe-to-deploy"
 
 [[exemptions.thiserror]]


### PR DESCRIPTION
First tagged release since **v0.2.2** (31 commits).

## Highlights
- ✅ **v0.3 — Compliance frontier milestone complete**: BoGo TLS conformance suite in CI (#56), version-locked to zion's rustls pin.
- 🇪🇺 **Sovereign Edge** — IT/EU origin tagging, **IPv4 + IPv6** (#147). O(log N), no GeoIP DB. `% EU vs non-EU` via `zion_sovereign_classifications_total{class}`.
- 🛡️ **First anti-DDoS admission levers**: per-IP concurrent-connection limit (#155) + tag-driven enforcement (#150, `[sovereign.enforce]`).
- 📊 **OpenTelemetry 0.27 → 0.32** (#145).
- 🔧 **CI / supply-chain hardening**: prebuilt cargo-audit/vet (#154), self-hosted runners (#144), RUSTUP_TOOLCHAIN fix (#146).
- 🔒 Security: `tar` 0.4.45 → 0.4.46 (**folds in #156**).

## Mechanics
- `scripts/bump-version.sh 0.3.0` → version SSOT across Cargo.toml/lock, Helm Chart, SECURITY.md, hot-reload.md, bug_report.md, supply-chain.md, README. `check-version-sync` green.
- cargo-vet baseline regenerated for `tar` 0.4.46.
- CHANGELOG `[Unreleased]` → `[0.3.0]`.

## After merge
Tag `v0.3.0` on the merge commit → `release.yml` runs (PGO build, SBOM, cosign/SLSA, GitHub release).

Closes #156.

🤖 Generated with [Claude Code](https://claude.com/claude-code)