### PR TITLE
fix(release): pre-build the PGO workload backend (fix flaky release build)

### DIFF
--- a/scripts/pgo-collect.sh
+++ b/scripts/pgo-collect.sh
@@ -48,23 +48,35 @@ echo "  duration  : ${WORKLOAD_SECONDS}s × 3 endpoints"
 # ── 1. Backend ────────────────────────────────────────────────────────
 # The Go test-server is shipped in-tree under benchmarks/backend/. Go is
 # preinstalled on ubuntu-latest; on macOS the runner has it too.
+# Declared up-front (empty) so the EXIT trap is safe under `set -u` even
+# if we bail out before Zion starts.
+ZION_PID=""
+
+# Build the backend *synchronously* first, then run the compiled binary.
+# `go run … &` backgrounds the compile + module-fetch, which on a cold
+# runner can outlast the readiness wait and lose the race ("backend never
+# became ready"). A pre-built binary starts effectively instantly, and a
+# build failure surfaces here instead of as a silent timeout.
+echo "[1/5] building backend"
+BACKEND_BIN="$(mktemp -t pgo-backend-XXXXXX)"
+( cd benchmarks/backend && go build -o "$BACKEND_BIN" test-server.go )
 echo "[1/5] starting backend on :$BACKEND_PORT"
-cd benchmarks/backend
-go run test-server.go > /tmp/pgo-backend.log 2>&1 &
+"$BACKEND_BIN" > /tmp/pgo-backend.log 2>&1 &
 BACKEND_PID=$!
-cd "$OLDPWD"
 
 cleanup() {
   set +e
   kill "$BACKEND_PID" 2>/dev/null || true
-  kill "$ZION_PID" 2>/dev/null || true
+  [ -n "${ZION_PID:-}" ] && kill "$ZION_PID" 2>/dev/null || true
   wait "$BACKEND_PID" 2>/dev/null || true
-  wait "$ZION_PID" 2>/dev/null || true
+  [ -n "${ZION_PID:-}" ] && wait "$ZION_PID" 2>/dev/null || true
+  rm -f "$BACKEND_BIN" 2>/dev/null || true
 }
 trap cleanup EXIT
 
-# Wait for backend ready (max 10 s).
-for _ in $(seq 1 20); do
+# Wait for backend ready (the binary is already built, so this only covers
+# process startup + port bind, but keep margin for slow CI).
+for _ in $(seq 1 40); do
   if curl -fsS "http://127.0.0.1:${BACKEND_PORT}/api/v1/data" >/dev/null 2>&1; then
     break
   fi


### PR DESCRIPTION
The **v0.3.0 release build** failed reproducibly at the PGO leg — `backend never became ready` — which gates `publish-release`, so **no release was cut**.

## Cause
`pgo-collect.sh` ran the Go test-server as `go run test-server.go &`. `go run` backgrounds the **compile + module fetch**; on a cold runner that outlasts the 10 s readiness wait, so the probe hits a port nothing is bound to yet and the job aborts. (Today's transient network blips made the compile slower, but the race is latent.)

## Fix
- **Build the backend synchronously** (`go build -o … test-server.go`), then run the compiled binary → instant startup; a real build failure now surfaces here instead of as a silent timeout.
- Declare `ZION_PID=""` up-front so the EXIT trap doesn't trip `set -u` (`ZION_PID: unbound variable`) when we bail before Zion starts; clean up the backend binary; bump the readiness margin.

Verified locally: `go build` produces a backend that binds `:9090` and serves `/api/v1/data`.

After merge: re-tag `v0.3.0` at the new master tip (version unchanged; the release was never published, so the re-tag is clean) → `release.yml` re-runs and publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)