### PR TITLE
fix(docker): copy benches/ into the real-source build stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,8 +60,11 @@ RUN mkdir -p src benches && \
     rm -rf src benches target/release/zion target/release/zion.d \
            target/release/deps/zion-* target/release/build/zion-*
 
-# Real source.
+# Real source. `benches/` is copied too: the manifest declares `[[bench]]`
+# targets, and Cargo won't parse it if their files are absent (the binary
+# build below doesn't compile benches, so this only satisfies the parse).
 COPY src/ src/
+COPY benches/ benches/
 COPY .cargo/ .cargo/
 RUN cargo build --release --locked && \
     strip target/release/zion && \


### PR DESCRIPTION
Fourth and final v0.3.0 release-pipeline fix — completes the container image.

The previous fix stubbed bench files only in the **dep-cache** stage; the **real application build** (`COPY src/ src/` → `cargo build --release`) still lacked `benches/`, so it hit the same `can't find audit_hmac bench` manifest-parse error in the cross-arch builder stage.

**Fix:** `COPY benches/ benches/` into the real-source stage (benches are real source; the binary build doesn't compile them, so this only satisfies Cargo's manifest parse). Dep-cache stub stays.

**Validated locally:** `docker build --target builder` completes (EXIT 0) — past the bench parse, full compile.

After merge: final re-tag `v0.3.0` → container (cosign-signed GHCR) completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)