### PR TITLE
feat: runtime resource introspection (process RSS + open-fd gauges)

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ Client -> TLS 1.3 -> Security Gates -> Radix Router -> WAF Pipeline (5 gates) ->
 ```
 
 <!-- zion-stats:modules-lines (kept in sync by scripts/update-readme-stats.sh) -->
-39 modules, ~25,800 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
+39 modules, ~26,000 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
 
 ## Benchmarking
 
@@ -335,7 +335,7 @@ Results saved to `benchmarks/bench-history.json` with automatic delta comparison
 ## Testing
 
 ```bash
-# Unit tests (565) <!-- zion-stats:test-count (kept in sync by scripts/update-readme-stats.sh) -->
+# Unit tests (567) <!-- zion-stats:test-count (kept in sync by scripts/update-readme-stats.sh) -->
 cargo test
 
 # Integration tests (19 -- requires running Zion + backend)

--- a/docs/deploy/observability.md
+++ b/docs/deploy/observability.md
@@ -34,6 +34,18 @@ These endpoints are handled before rate limiting and routing, ensuring they alwa
 
 All counters are lock-free atomic `u64` values. Incrementing a counter costs ~2ns (single `fetch_add` with `Relaxed` ordering).
 
+### Runtime Resource Gauges
+
+`/metrics` also exposes process self-introspection gauges, so you can watch the daemon's own footprint live — and catch a slow leak (for example ~1 MB per 1000 connections) by its RSS slope, without restarting under a profiler.
+
+| Metric | Type | Description |
+|---|---|---|
+| `zion_active_connections` | gauge | Currently active TLS connections |
+| `zion_process_resident_memory_bytes` | gauge | Resident set size of the Zion process, in bytes (Linux `/proc/self/status` `VmRSS`; `0` on other platforms) |
+| `zion_process_open_fds` | gauge | Open file descriptors held by the process (Linux `/proc/self/fd`; `0` on other platforms) |
+
+The two `process_*` gauges are sampled from `/proc/self` **once per scrape** — the `/metrics` render is cached for one second, so the two small file reads never run on the hot connection path. The same values are surfaced in `/_zion/snapshot.json` and the `zion top` TUI ("rss" / "open fds" rows). They are Linux-only; on macOS/Windows they render as `0` so one dashboard works across hosts. Run `zion doctor` to confirm the host actually exposes `/proc/self/status` — a hardened container runtime that masks `/proc` will report `0` here, and the check warns you up front.
+
 ### Prometheus Scrape Config
 
 ```yaml
@@ -63,6 +75,14 @@ zion_cache_hits / (zion_cache_hits + zion_cache_misses)
 
 # TLS handshake failure rate
 rate(zion_tls_handshake_errors[5m])
+
+# Memory-leak slope: RSS growth rate over 30m. A sustained positive
+# slope under flat request traffic is the silent-leak signal.
+deriv(zion_process_resident_memory_bytes[30m])
+
+# File-descriptor leak: open fds climbing without bound (alert if it
+# approaches the `zion doctor` fd soft limit).
+zion_process_open_fds
 ```
 
 ## X-Request-ID

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -88,6 +88,7 @@ pub fn run() -> i32 {
 fn collect_checks(p: &crate::bootstrap::Platform) -> Vec<Check> {
     vec![
         check_fd_limit(),
+        check_memory_introspection(),
         check_privileged_port_80(),
         check_privileged_port_443(),
         check_somaxconn(),
@@ -138,6 +139,49 @@ fn check_fd_limit() -> Check {
     #[cfg(not(unix))]
     {
         Check::skip("fd limit", "non-unix platform")
+    }
+}
+
+/// Memory-introspection readiness. The daemon populates the
+/// `zion_process_resident_memory_bytes` gauge by reading `/proc/self/status`
+/// (`VmRSS`); this preflight confirms that source is actually readable on
+/// the deployment host and reports the current resident set size. In a
+/// hardened container that masks `/proc`, this warns up front that the RSS
+/// gauge will read 0 — so an operator doesn't discover a blind metric only
+/// while chasing a leak in production.
+fn check_memory_introspection() -> Check {
+    #[cfg(target_os = "linux")]
+    {
+        match std::fs::read_to_string("/proc/self/status") {
+            Ok(status) => match status
+                .lines()
+                .find(|l| l.starts_with("VmRSS:"))
+                .and_then(|l| l.split_whitespace().nth(1))
+                .and_then(|n| n.parse::<u64>().ok())
+            {
+                Some(kib) => Check::ok(
+                    "memory introspection",
+                    format!("VmRSS readable ({} MB) — /metrics RSS gauge active", kib / 1024),
+                ),
+                None => Check::warn(
+                    "memory introspection",
+                    "/proc/self/status exposes no VmRSS line",
+                    "the zion_process_resident_memory_bytes gauge will report 0 here",
+                ),
+            },
+            Err(e) => Check::warn(
+                "memory introspection",
+                format!("/proc/self/status unreadable: {e}"),
+                "unmask /proc so the RSS / open-fd gauges can populate (some hardened container runtimes mask it)",
+            ),
+        }
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        Check::skip(
+            "memory introspection",
+            "RSS / open-fd gauges are Linux-only (sourced from /proc/self)",
+        )
     }
 }
 
@@ -559,9 +603,9 @@ mod tests {
     fn collect_checks_returns_all_categories() {
         let p = synth_platform();
         let checks = collect_checks(&p);
-        // Seven canonical checks: fd, port80, port443, somaxconn, kernel,
-        // hwcrypto, aes-cal.
-        assert_eq!(checks.len(), 7);
+        // Eight canonical checks: fd, memory-introspection, port80, port443,
+        // somaxconn, kernel, hwcrypto, aes-cal.
+        assert_eq!(checks.len(), 8);
         for c in &checks {
             assert!(!c.name.is_empty());
             assert!(!c.detail.is_empty(), "empty detail in {}", c.name);

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1303,4 +1303,44 @@ mod tests {
         assert!(out.contains("zion_upstream_duration_seconds_bucket"));
         assert!(out.contains("zion_tls_handshake_duration_seconds_bucket"));
     }
+
+    #[test]
+    fn render_always_emits_resource_gauges() {
+        // The gauge lines must be present on every platform (value 0 off
+        // Linux) so dashboards can scrape the same names everywhere.
+        let m = Metrics::new();
+        let out = String::from_utf8(m.render().to_vec()).unwrap();
+        assert!(out.contains("# TYPE zion_process_resident_memory_bytes gauge"));
+        assert!(out.contains("zion_process_resident_memory_bytes "));
+        assert!(out.contains("# TYPE zion_process_open_fds gauge"));
+        assert!(out.contains("zion_process_open_fds "));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn resource_sampler_populates_on_linux() {
+        let m = Metrics::new();
+        assert_eq!(m.process_resident_memory_bytes.load(Relaxed), 0);
+        assert_eq!(m.process_open_fds.load(Relaxed), 0);
+        m.sample_resource_gauges();
+        // The test process has resident memory and at least the stdio fds.
+        assert!(
+            m.process_resident_memory_bytes.load(Relaxed) > 0,
+            "VmRSS should be readable from /proc/self/status on Linux"
+        );
+        assert!(
+            m.process_open_fds.load(Relaxed) > 0,
+            "open-fd count should be at least the stdio descriptors"
+        );
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    #[test]
+    fn resource_sampler_is_noop_off_linux() {
+        // /proc does not exist; the fallback leaves both gauges at 0.
+        let m = Metrics::new();
+        m.sample_resource_gauges();
+        assert_eq!(m.process_resident_memory_bytes.load(Relaxed), 0);
+        assert_eq!(m.process_open_fds.load(Relaxed), 0);
+    }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -446,6 +446,20 @@ pub struct Metrics {
     // Gauges
     pub active_connections: AtomicI64,
 
+    // ── Runtime resource gauges (process self-introspection) ─────────
+    // Sampled from `/proc/self` once per `/metrics` scrape (and per JSON
+    // snapshot) — never on the hot connection path. Linux-only; both
+    // stay 0 on other platforms. The point is leak detection *without a
+    // restart*: a steadily climbing RSS or fd count under flat traffic
+    // is exactly the "silent 1 MB / 1000-connection leak" signal an
+    // operator needs to see live on a dashboard.
+    /// Resident set size of this process, in bytes (`/proc/self/status`
+    /// `VmRSS`). 0 on non-Linux platforms.
+    pub process_resident_memory_bytes: AtomicU64,
+    /// Open file descriptors held by this process (`/proc/self/fd`
+    /// entry count). 0 on non-Linux platforms.
+    pub process_open_fds: AtomicU64,
+
     // Histograms
     pub request_duration: LatencyHistogram,
     pub upstream_duration: LatencyHistogram,
@@ -487,6 +501,8 @@ impl Metrics {
             acme_renewals_total: AtomicU64::new(0),
             acme_renewal_failures_total: AtomicU64::new(0),
             active_connections: AtomicI64::new(0),
+            process_resident_memory_bytes: AtomicU64::new(0),
+            process_open_fds: AtomicU64::new(0),
             request_duration: LatencyHistogram::new(),
             upstream_duration: LatencyHistogram::new(),
             tls_handshake_duration: LatencyHistogram::new(),
@@ -512,6 +528,45 @@ impl Metrics {
         }
     }
 
+    /// Refresh the process-level resource gauges from `/proc/self`.
+    ///
+    /// Cheap and lock-free: one `read_to_string` of the small
+    /// `/proc/self/status` file plus a `read_dir` count of
+    /// `/proc/self/fd`. Called once per `/metrics` scrape and per JSON
+    /// snapshot — never on the hot connection path, so the two reads add
+    /// no per-request cost. No-op (gauges stay 0) on non-Linux platforms,
+    /// where `/proc` does not exist.
+    #[cfg(target_os = "linux")]
+    pub fn sample_resource_gauges(&self) {
+        // `/proc/self/status` exposes `VmRSS:\t<N> kB` — the resident set
+        // size directly in kibibytes. This is the same file bpf_demux.rs
+        // already reads for capability probing, so no new syscall surface.
+        if let Ok(status) = std::fs::read_to_string("/proc/self/status") {
+            if let Some(kib) = status
+                .lines()
+                .find(|l| l.starts_with("VmRSS:"))
+                .and_then(|l| l.split_whitespace().nth(1))
+                .and_then(|n| n.parse::<u64>().ok())
+            {
+                self.process_resident_memory_bytes
+                    .store(kib.saturating_mul(1024), Relaxed);
+            }
+        }
+        // `/proc/self/fd` has one entry per open descriptor. `read_dir`
+        // itself opens one transient fd that is counted here and released
+        // when the iterator drops, so the value carries a constant +1 —
+        // harmless for the leak-slope signal we care about.
+        if let Ok(entries) = std::fs::read_dir("/proc/self/fd") {
+            self.process_open_fds.store(entries.count() as u64, Relaxed);
+        }
+    }
+
+    /// Non-Linux fallback: `/proc` is Linux-specific, so the gauges stay
+    /// at 0. Kept as a method (rather than `cfg`-erasing the call sites)
+    /// so the render and snapshot paths compile unchanged everywhere.
+    #[cfg(not(target_os = "linux"))]
+    pub fn sample_resource_gauges(&self) {}
+
     /// Render Prometheus text exposition format. Lock-free cached.
     pub fn render(&self) -> bytes::Bytes {
         let now_sec = std::time::SystemTime::now()
@@ -524,6 +579,12 @@ impl Metrics {
         if cached.0 == now_sec {
             return cached.1.clone();
         }
+
+        // Cache miss (at most once per wall-clock second): refresh the
+        // process-resource gauges so the values we render below are live.
+        // The 1-second render cache above is what throttles the two
+        // `/proc/self` reads — they never run on the per-request path.
+        self.sample_resource_gauges();
 
         // Preallocate estimated capacity to avoid reallocations
         let mut out = bytes::BytesMut::with_capacity(4096);
@@ -686,6 +747,33 @@ impl Metrics {
         out.extend_from_slice(
             itoa_buf
                 .format(self.active_connections.load(Relaxed))
+                .as_bytes(),
+        );
+        out.extend_from_slice(b"\n");
+
+        // ── Runtime resource gauges (process self-introspection) ──
+        // Linux-only; render as 0 elsewhere so dashboards can `grep` the
+        // same metric names regardless of the host the build runs on.
+        out.extend_from_slice(
+            b"# HELP zion_process_resident_memory_bytes Resident set size of the Zion process in bytes (Linux /proc/self/status VmRSS; 0 elsewhere).\n\
+                                # TYPE zion_process_resident_memory_bytes gauge\n\
+                                zion_process_resident_memory_bytes ",
+        );
+        out.extend_from_slice(
+            itoa_buf
+                .format(self.process_resident_memory_bytes.load(Relaxed))
+                .as_bytes(),
+        );
+        out.extend_from_slice(b"\n");
+
+        out.extend_from_slice(
+            b"# HELP zion_process_open_fds Open file descriptors held by the Zion process (Linux /proc/self/fd; 0 elsewhere).\n\
+                                # TYPE zion_process_open_fds gauge\n\
+                                zion_process_open_fds ",
+        );
+        out.extend_from_slice(
+            itoa_buf
+                .format(self.process_open_fds.load(Relaxed))
                 .as_bytes(),
         );
         out.extend_from_slice(b"\n");

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -989,6 +989,10 @@ pub fn snapshot_json(
     use serde_json::json;
 
     let m = &METRICS;
+    // Refresh the process-resource gauges so `zion top` shows live RSS and
+    // fd counts. The snapshot is already built fresh on every poll (no
+    // caching), so sampling here keeps the JSON consistent with that intent.
+    m.sample_resource_gauges();
     let now_ms = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
@@ -1045,6 +1049,11 @@ pub fn snapshot_json(
             "cache_misses": m.cache_misses.load(Relaxed),
             "websocket_upgrades": m.websocket_upgrades.load(Relaxed),
             "active_connections": m.active_connections.load(Relaxed),
+            // Process self-introspection (Linux /proc/self; 0 elsewhere).
+            // RSS in bytes alongside the box total at platform.ram_mb, so
+            // `zion top` can show "of N MB total, the daemon holds X".
+            "process_resident_memory_bytes": m.process_resident_memory_bytes.load(Relaxed),
+            "process_open_fds": m.process_open_fds.load(Relaxed),
             "connections_total": m.connections_total.load(Relaxed),
             "tls_handshake_errors": m.tls_handshake_errors.load(Relaxed),
             "request_p50_us": m.request_duration.quantile_us(0.50),

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -98,6 +98,13 @@ struct MetricsSnap {
     #[allow(dead_code)]
     websocket_upgrades: u64,
     active_connections: i64,
+    // Process self-introspection. `#[serde(default)]` so a newer `zion top`
+    // polling an older daemon that predates these fields still parses (and
+    // shows 0) instead of failing the whole snapshot decode.
+    #[serde(default)]
+    process_resident_memory_bytes: u64,
+    #[serde(default)]
+    process_open_fds: u64,
     connections_total: u64,
     tls_handshake_errors: u64,
     request_p50_us: u64,
@@ -476,6 +483,11 @@ fn draw_traffic(f: &mut Frame, area: Rect, app: &App, snap: &Snapshot) {
         kv("active conn", &snap.metrics.active_connections.to_string()),
         kv("total conn", &fmt_int(snap.metrics.connections_total)),
         kv("tls errors", &fmt_int(snap.metrics.tls_handshake_errors)),
+        kv(
+            "rss",
+            &fmt_bytes(snap.metrics.process_resident_memory_bytes),
+        ),
+        kv("open fds", &fmt_int(snap.metrics.process_open_fds)),
     ];
     let p = Paragraph::new(lines).block(panel(" traffic "));
     f.render_widget(p, area);
@@ -756,6 +768,26 @@ fn fmt_int(mut n: u64) -> String {
     out.chars().rev().collect()
 }
 
+/// Human-readable byte size for the resource panel (RSS). Mirrors the
+/// boot-banner formatter in bootstrap.rs; kept local so the TUI owns its
+/// own display helpers alongside `fmt_int`/`fmt_us`.
+fn fmt_bytes(n: u64) -> String {
+    const K: u64 = 1024;
+    const M: u64 = K * K;
+    const G: u64 = K * M;
+    if n == 0 {
+        "—".to_string()
+    } else if n >= G {
+        format!("{:.1} GB", n as f64 / G as f64)
+    } else if n >= M {
+        format!("{} MB", n / M)
+    } else if n >= K {
+        format!("{} KB", n / K)
+    } else {
+        format!("{n} B")
+    }
+}
+
 fn fmt_us(us: u64) -> String {
     if us == 0 {
         return "—".to_string();
@@ -960,7 +992,9 @@ mod tests {
             "worker_threads":3,"conn_limit":10000},
           "metrics":{"requests_total":10,"requests_2xx":9,"requests_4xx":1,"requests_5xx":0,
             "waf_denied":0,"rate_limited":0,"cache_hits":5,"cache_misses":5,
-            "websocket_upgrades":0,"active_connections":2,"connections_total":7,"tls_handshake_errors":0,
+            "websocket_upgrades":0,"active_connections":2,
+            "process_resident_memory_bytes":47185920,"process_open_fds":128,
+            "connections_total":7,"tls_handshake_errors":0,
             "request_p50_us":1000,"request_p95_us":4000,"request_p99_us":8000,
             "upstream_p50_us":900,"upstream_p95_us":3000,"upstream_p99_us":6000,
             "tls_p50_us":500,"tls_p95_us":900},
@@ -969,7 +1003,33 @@ mod tests {
         let s: Snapshot = serde_json::from_str(json).unwrap();
         assert_eq!(s.platform.tier, "A");
         assert_eq!(s.metrics.requests_total, 10);
+        assert_eq!(s.metrics.process_resident_memory_bytes, 47_185_920);
+        assert_eq!(s.metrics.process_open_fds, 128);
         assert_eq!(s.upstreams.len(), 1);
         assert!(s.upstreams[0].healthy);
+    }
+
+    #[test]
+    fn snapshot_tolerates_missing_resource_fields() {
+        // A `zion top` polling an older daemon predating the resource
+        // gauges must still decode the snapshot (fields default to 0).
+        let json = r#"{
+          "version":"0.1.0","timestamp_ms":0,"uptime_secs":1,
+          "platform":{"os":"linux","arch":"x86_64","cores":1,"ram_mb":1024,
+            "tier":"C","tier_score":10,"projected_kreqs_cached":1,"projected_kreqs_dynamic":1,
+            "has_aes_ni":true,"has_sha256":true,"has_avx2":false,"has_neon":false,
+            "has_so_reuseport":true,"has_tcp_fastopen":false,"has_tcp_quickack":false,
+            "worker_threads":1,"conn_limit":1000},
+          "metrics":{"requests_total":0,"requests_2xx":0,"requests_4xx":0,"requests_5xx":0,
+            "waf_denied":0,"rate_limited":0,"cache_hits":0,"cache_misses":0,
+            "websocket_upgrades":0,"active_connections":0,"connections_total":0,"tls_handshake_errors":0,
+            "request_p50_us":0,"request_p95_us":0,"request_p99_us":0,
+            "upstream_p50_us":0,"upstream_p95_us":0,"upstream_p99_us":0,
+            "tls_p50_us":0,"tls_p95_us":0},
+          "upstreams":[]
+        }"#;
+        let s: Snapshot = serde_json::from_str(json).unwrap();
+        assert_eq!(s.metrics.process_resident_memory_bytes, 0);
+        assert_eq!(s.metrics.process_open_fds, 0);
     }
 }


### PR DESCRIPTION
## Why

Answers the bluntest question you can ask a production proxy:

> *"If tomorrow Zion had a silent memory leak under load — ~1 MB per 1000 connections — do you have the introspection to debug it in production **without shutting it down**?"*

Until now the metrics surface tracked `active_connections` and latency histograms but **no process-level resource posture**, so a slow leak was invisible without attaching a profiler or restarting. This PR makes the daemon's own footprint observable, live.

## What

Two new gauges, sampled from `/proc/self` **once per `/metrics` scrape** (the render is already cached for 1s, so the two small file reads never touch the hot connection path):

| Metric | Source |
|---|---|
| `zion_process_resident_memory_bytes` | `/proc/self/status` `VmRSS` |
| `zion_process_open_fds` | entry count of `/proc/self/fd` |

Surfaced on three operator-facing planes:
- **`/metrics`** — Prometheus gauges (commit 1)
- **`/_zion/snapshot.json` + `zion top`** — new "rss" / "open fds" rows; `#[serde(default)]` so a newer `zion top` tolerates an older daemon (commit 2)
- **`zion doctor`** — a preflight that confirms `/proc/self/status` is readable on the host, warning up front when a hardened container masks `/proc` and the gauge would read 0 (commit 3)

Plus cfg-aware tests (commit 4) and Grafana leak-detection queries in the docs (commit 5).

## Design notes
- **No new dependencies, no `unsafe`** — reuses the exact `/proc/self` read pattern `bpf_demux.rs` already ships.
- **Linux-only with graceful fallback** — both gauges render as `0` on macOS/Windows so one dashboard works across hosts.
- **Off the hot path** — sampling is gated by the existing 1-second render cache.

## Deliberately deferred (out of scope, noted for honesty)
- `tokio_runtime_active_tasks` — needs the `tokio_unstable` cfg across every target triple; opts into an unstable API. Separate PR.
- mimalloc heap stats — the allocator is pulled `default-features = false`, so the stats APIs aren't compiled in. Separate PR.

Each commit compiles, passes `cargo test`, and is clean under `clippy -D warnings` + `rustfmt` independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
