### PR TITLE
chore(release): v0.3.1

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,7 +21,7 @@ A clear and concise description of what you expected to happen.
 **Environment (please complete the following information):**
  - OS: [e.g. Linux, macOS]
  - Architecture: [e.g. arm64, amd64]
- - Zion Version: [e.g. 0.3.0]
+ - Zion Version: [e.g. 0.3.1]
 
 **Additional context**
 Add any other context about the problem here (e.g. logs with `RUST_LOG=trace`, upstream backend type like Go/Node).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,45 @@ All notable changes to Zion Edge Gateway are documented here.
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-06-01
+
+A focused patch on operability and documentation honesty. Makes the
+daemon's own resource footprint observable in production — the answer to
+"can you debug a silent memory leak without restarting?" — and corrects
+three FIPS-guide claims about tooling that did not exist.
+
+### Added
+
+- **Runtime resource introspection (#163)** — two new `/metrics` gauges,
+  `zion_process_resident_memory_bytes` (RSS via `/proc/self/status`
+  `VmRSS`) and `zion_process_open_fds` (`/proc/self/fd` entry count),
+  sampled **once per scrape** off the hot connection path — the existing
+  1-second render cache throttles the two `/proc/self` reads, so there is
+  no per-request cost. Surfaced on three operator planes: `/metrics`,
+  `/_zion/snapshot.json`, and the `zion top` TUI (new "rss" / "open fds"
+  rows, version-skew tolerant via `#[serde(default)]`). A steadily
+  climbing RSS or fd count under flat traffic is now visible on a
+  dashboard within one scrape cycle, no restart required. Linux-only;
+  both gauges render as `0` on other platforms so a single dashboard
+  works across hosts. No new dependencies, no `unsafe`. New Grafana
+  leak-detection queries in
+  [`docs/deploy/observability.md`](docs/deploy/observability.md).
+- **`zion doctor` memory-introspection check (#163)** — a preflight that
+  confirms `/proc/self/status` is readable on the host and reports the
+  current RSS, warning up front when a hardened container runtime masks
+  `/proc` (where the gauges would otherwise silently read `0`).
+
+### Fixed
+
+- **FIPS guide referenced tooling that does not exist (#164)** — the guide
+  promised a `scripts/fips-self-check.sh` helper, a `ci.yml` `flavor=fips`
+  job, and a `release.yml` `-fips` artifact, none of which the repo ships.
+  Rewrote [`docs/security/fips.md`](docs/security/fips.md) to the honest
+  posture: a FIPS build is a manual `cargo build --features fips` today,
+  carries no SLSA provenance attestation (unlike the default release
+  binaries), and its chain of custody is the operator's to establish.
+  CI/release wiring is noted as future work.
+
 ## [0.3.0] - 2026-05-30
 
 The first tagged release since v0.2.2. Completes the **v0.3 — Compliance

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5421,7 +5421,7 @@ dependencies = [
 
 [[package]]
 name = "zion"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "aho-corasick",
  "aimp_node",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zion"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 # MSRV is the *core* default-features build (TLS proxy + WAF + cache + metrics).
 # Opt-in features (acme, auth, init, http3) pull crypto/i18n crates that have

--- a/README.md
+++ b/README.md
@@ -364,12 +364,12 @@ commands. The short version:
 
 ```bash
 # Binary release (Sigstore-backed provenance via gh CLI)
-gh release download v0.3.0 -R fabriziosalmi/zion -p '*x86_64-unknown-linux-musl*' -p 'SHA256SUMS'
+gh release download v0.3.1 -R fabriziosalmi/zion -p '*x86_64-unknown-linux-musl*' -p 'SHA256SUMS'
 sha256sum --check --ignore-missing SHA256SUMS
-gh attestation verify zion-v0.3.0-x86_64-unknown-linux-musl.tar.gz --owner fabriziosalmi
+gh attestation verify zion-v0.3.1-x86_64-unknown-linux-musl.tar.gz --owner fabriziosalmi
 
 # Container image (cosign keyless)
-cosign verify ghcr.io/fabriziosalmi/zion:v0.3.0 \
+cosign verify ghcr.io/fabriziosalmi/zion:v0.3.1 \
     --certificate-identity-regexp "^https://github.com/fabriziosalmi/zion/\\.github/workflows/release\\.yml@refs/tags/v" \
     --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ from their containing minor — i.e. the latest `0.1.x` is always patched.
 | Version | Supported |
 | ------- | --------- |
 | 0.1.x (latest minor) | Yes |
-| < 0.3.0 | No |
+| < 0.3.1 | No |
 
 ## Reporting a Vulnerability
 

--- a/deploy/helm/zion/Chart.yaml
+++ b/deploy/helm/zion/Chart.yaml
@@ -3,7 +3,7 @@ name: zion
 description: Zion Edge Gateway — high-performance Rust TLS reverse proxy with WAF
 type: application
 version: 0.2.2
-appVersion: "0.3.0"
+appVersion: "0.3.1"
 home: https://fabriziosalmi.github.io/zion
 sources:
   - https://github.com/fabriziosalmi/zion

--- a/docs/deploy/hot-reload.md
+++ b/docs/deploy/hot-reload.md
@@ -130,7 +130,7 @@ Two surfaces report the reload state:
 
   ```json
   {
-    "version": "0.3.0",
+    "version": "0.3.1",
     "timestamp_ms": 1714425600000,
     "uptime_secs": 3712,
     "config_generation": 5,

--- a/docs/security/supply-chain.md
+++ b/docs/security/supply-chain.md
@@ -46,8 +46,8 @@ You need the GitHub CLI (`gh >= 2.49`) and `cosign >= 2.2`.
 
 ```bash
 # 1. Download the artifact + SHA256SUMS from the release page.
-gh release download v0.3.0 -R fabriziosalmi/zion \
-    -p 'zion-v0.3.0-x86_64-unknown-linux-musl.tar.gz' \
+gh release download v0.3.1 -R fabriziosalmi/zion \
+    -p 'zion-v0.3.1-x86_64-unknown-linux-musl.tar.gz' \
     -p 'SHA256SUMS' \
     -p 'zion-sbom.cdx.json'
 
@@ -55,7 +55,7 @@ gh release download v0.3.0 -R fabriziosalmi/zion \
 sha256sum --check --ignore-missing SHA256SUMS
 
 # 3. Verify the SLSA build provenance bound to the artifact's hash.
-gh attestation verify zion-v0.3.0-x86_64-unknown-linux-musl.tar.gz \
+gh attestation verify zion-v0.3.1-x86_64-unknown-linux-musl.tar.gz \
     --owner fabriziosalmi
 
 # Step 3 fails if:
@@ -78,7 +78,7 @@ grype zion-sbom.cdx.json
 ## Verifying a container image
 
 ```bash
-IMAGE=ghcr.io/fabriziosalmi/zion:v0.3.0
+IMAGE=ghcr.io/fabriziosalmi/zion:v0.3.1
 
 # 1. Pin to the digest immediately — tags are mutable, digests are not.
 DIGEST=$(crane digest "$IMAGE")
@@ -120,7 +120,7 @@ deterministically, and pins the Rust toolchain via
 [`rust-toolchain.toml`](../../rust-toolchain.toml). To reproduce locally:
 
 ```bash
-git checkout v0.3.0
+git checkout v0.3.1
 export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)
 # Linux musl example — matches the release artifact byte-for-byte
 # (modulo strip's stable behavior on your distro).


### PR DESCRIPTION
Patch release cutting **v0.3.1** — bundles the two merged PRs into a tagged release.

## Contents
- **#163** — runtime resource introspection: `zion_process_resident_memory_bytes` + `zion_process_open_fds` gauges on `/metrics`, `/_zion/snapshot.json` and `zion top`, plus a `zion doctor` memory-introspection preflight. Off the hot path, Linux-only with 0 fallback, no new deps.
- **#164** — honest rewrite of the FIPS guide (removed three claims about tooling that does not exist).

## Mechanics
- `scripts/bump-version.sh 0.3.1` → Cargo.toml/lock, Helm `appVersion`, SECURITY.md, hot-reload.md, supply-chain.md, bug_report.md, README version strings.
- `CHANGELOG.md`: `[Unreleased]` → `[0.3.1] - 2026-06-01`.
- `check-version-sync.sh` green.

On merge, the squash commit is tagged `v0.3.1` to trigger the release pipeline (7-target cross-compile + signed multi-arch image + SLSA provenance + SBOM).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
