### PR TITLE
feat(health): adaptive decorrelated-jitter origin recovery (replace fixed 30s probe)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5435,6 +5435,7 @@ dependencies = [
  "criterion",
  "crossterm 0.28.1",
  "dashmap 6.1.0",
+ "fastrand",
  "fnv",
  "h3",
  "h3-quinn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,11 @@ memchr = "2"
 # FNV hash — ~2x faster than SipHash for short keys (SNI hostnames)
 fnv = "1"
 
+# Decorrelated-jitter RNG for the adaptive upstream-recovery backoff scheduler.
+# Already vendored transitively (via h3); promoted to a direct dep. Pure-Rust,
+# MSRV-1.82-clean, single-digit-ns thread-local Wyrand — never on the hot path.
+fastrand = "2"
+
 # Upstream TLS root CAs (embedded Mozilla bundle — deterministic, no system dep)
 webpki-roots = "0.26"
 

--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ Client -> TLS 1.3 -> Security Gates -> Radix Router -> WAF Pipeline (5 gates) ->
 ```
 
 <!-- zion-stats:modules-lines (kept in sync by scripts/update-readme-stats.sh) -->
-39 modules, ~26,700 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
+39 modules, ~26,900 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
 
 ## Benchmarking
 
@@ -335,7 +335,7 @@ Results saved to `benchmarks/bench-history.json` with automatic delta comparison
 ## Testing
 
 ```bash
-# Unit tests (576) <!-- zion-stats:test-count (kept in sync by scripts/update-readme-stats.sh) -->
+# Unit tests (580) <!-- zion-stats:test-count (kept in sync by scripts/update-readme-stats.sh) -->
 cargo test
 
 # Integration tests (19 -- requires running Zion + backend)

--- a/src/health.rs
+++ b/src/health.rs
@@ -14,10 +14,37 @@ use std::sync::Arc;
 /// Threshold for Gray Failures (2000 ms)
 const GRAY_FAILURE_THRESHOLD_US: u64 = 2_000_000;
 
+// ── Adaptive recovery (decorrelated-jitter backoff) ──────────────────────
+// When an upstream is DOWN we re-probe on a decorrelated-jitter schedule
+// (AWS / Marc Brooker) instead of the old fixed 30s interval, so a recovered
+// origin is picked back up in sub-second-to-few-seconds rather than up to 30s.
+// A HEALTHY upstream stays on the unchanged STEADY cadence — zero happy-path
+// regression. See main.rs prober loop. State lives as two atomics below so it
+// rides reload.rs's Arc-reuse merge for free.
+
+/// Min/base DOWN re-probe delay and the floor of every decorrelated draw —
+/// never probe a recovering origin faster than this (protects a struggling one).
+pub const PROBE_BASE_US: u64 = 100_000; // 100 ms
+/// Ceiling for a DOWN upstream's re-probe delay (a long outage is still
+/// detected within this bound; ~10× the old dead-origin poll rate).
+pub const PROBE_CAP_US: u64 = 3_000_000; // 3 s
+/// Decorrelated-jitter growth multiplier (E[next] = 2 × prev).
+pub const PROBE_MULT: u64 = 3;
+/// Steady re-probe cadence for HEALTHY upstreams — deliberately unchanged from
+/// the historical fixed interval so steady-state origin probe load is identical.
+pub const STEADY_US: u64 = 30_000_000; // 30 s
+
 /// Per-upstream health state.
 pub struct UpstreamHealth {
     pub healthy: AtomicBool,
     pub latency_us: std::sync::atomic::AtomicU64,
+    /// Current decorrelated-jitter DOWN delay (µs); reset to `PROBE_BASE_US`
+    /// the moment a probe succeeds. Prober-private — the request path never
+    /// reads it, so `select_best_upstream`/`is_healthy` stay lock-free.
+    pub backoff_us: std::sync::atomic::AtomicU64,
+    /// Absolute monotonic deadline (µs since the prober's base `Instant`) of the
+    /// next probe. `0` == due immediately (fresh boot / freshly added upstream).
+    pub next_probe_at_us: std::sync::atomic::AtomicU64,
 }
 
 impl UpstreamHealth {
@@ -40,6 +67,50 @@ impl UpstreamHealth {
             }
         }
     }
+
+    /// Construct a fresh upstream entry: healthy, unknown latency, backoff at
+    /// the base, due to probe immediately.
+    pub fn new_healthy() -> Self {
+        UpstreamHealth {
+            healthy: AtomicBool::new(true),
+            latency_us: std::sync::atomic::AtomicU64::new(0),
+            backoff_us: std::sync::atomic::AtomicU64::new(PROBE_BASE_US),
+            next_probe_at_us: std::sync::atomic::AtomicU64::new(0),
+        }
+    }
+
+    /// Advance the probe schedule after a probe completes. `now_us` is
+    /// `base.elapsed().as_micros()` from the prober's monotonic base `Instant`.
+    /// A success resets the backoff to base and re-probes on the STEADY cadence;
+    /// a failure draws the next decorrelated-jitter delay and grows the backoff.
+    pub fn reschedule(&self, healthy: bool, now_us: u64) {
+        let delay = if healthy {
+            self.backoff_us.store(PROBE_BASE_US, Relaxed);
+            STEADY_US
+        } else {
+            let prev = self.backoff_us.load(Relaxed);
+            let next = next_down_delay(prev);
+            self.backoff_us.store(next, Relaxed);
+            next
+        };
+        self.next_probe_at_us
+            .store(now_us.saturating_add(delay), Relaxed);
+    }
+}
+
+/// Decorrelated jitter: `min(CAP, rand_in(BASE..=prev*MULT))`. The `BASE` floor
+/// guarantees we never hammer a recovering origin faster than 100ms; the draw
+/// stays fully decorrelated step-to-step so a pool that died together (or
+/// future mesh replicas) desynchronise their recovery probes instead of
+/// stampeding back in lockstep. Pure arithmetic + one `fastrand` draw —
+/// nowhere near the request hot path.
+#[inline]
+pub fn next_down_delay(prev_us: u64) -> u64 {
+    // BASE <= CAP always (compile-time consts), so clamp cannot panic.
+    let ceil = prev_us
+        .saturating_mul(PROBE_MULT)
+        .clamp(PROBE_BASE_US, PROBE_CAP_US);
+    fastrand::u64(PROBE_BASE_US..=ceil).min(PROBE_CAP_US)
 }
 
 /// Shared health state — keyed by upstream URL.
@@ -128,6 +199,7 @@ mod tests {
             Arc::new(UpstreamHealth {
                 healthy: AtomicBool::new(true),
                 latency_us: std::sync::atomic::AtomicU64::new(0),
+                ..UpstreamHealth::new_healthy()
             }),
         );
         let hm: HealthMap = Arc::new(map);
@@ -142,6 +214,7 @@ mod tests {
             Arc::new(UpstreamHealth {
                 healthy: AtomicBool::new(false),
                 latency_us: std::sync::atomic::AtomicU64::new(0),
+                ..UpstreamHealth::new_healthy()
             }),
         );
         let hm: HealthMap = Arc::new(map);
@@ -156,6 +229,7 @@ mod tests {
             Arc::new(UpstreamHealth {
                 healthy: AtomicBool::new(true),
                 latency_us: std::sync::atomic::AtomicU64::new(0),
+                ..UpstreamHealth::new_healthy()
             }),
         );
         let hm: HealthMap = Arc::new(map);
@@ -175,6 +249,7 @@ mod tests {
             Arc::new(UpstreamHealth {
                 healthy: AtomicBool::new(true),
                 latency_us: std::sync::atomic::AtomicU64::new(3_000_000), // > 2000ms
+                ..UpstreamHealth::new_healthy()
             }),
         );
         map.insert(
@@ -182,6 +257,7 @@ mod tests {
             Arc::new(UpstreamHealth {
                 healthy: AtomicBool::new(true),
                 latency_us: std::sync::atomic::AtomicU64::new(50_000), // 50ms
+                ..UpstreamHealth::new_healthy()
             }),
         );
 
@@ -200,10 +276,74 @@ mod tests {
         let up = UpstreamHealth {
             healthy: AtomicBool::new(true),
             latency_us: std::sync::atomic::AtomicU64::new(0),
+            ..UpstreamHealth::new_healthy()
         };
         up.update_latency(100);
         assert_eq!(up.latency_us.load(Relaxed), 100); // initial
         up.update_latency(900);
         assert_eq!(up.latency_us.load(Relaxed), 200); // (900 + 7*100) / 8 = 200
+    }
+
+    // ── Adaptive recovery backoff ────────────────────────────────────────
+
+    #[test]
+    fn next_down_delay_respects_floor_and_cap() {
+        // The decorrelated draw must always land within [BASE, CAP] for any
+        // prior value — fastrand is real, but the ENVELOPE is deterministic.
+        for &prev in &[0u64, PROBE_BASE_US, 1_000_000, PROBE_CAP_US, u64::MAX] {
+            for _ in 0..1000 {
+                let d = next_down_delay(prev);
+                assert!(
+                    (PROBE_BASE_US..=PROBE_CAP_US).contains(&d),
+                    "delay {d} out of [{PROBE_BASE_US}, {PROBE_CAP_US}] for prev={prev}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn next_down_delay_saturates_at_cap_no_overflow() {
+        // prev*MULT must not overflow (saturating_mul) and the draw stays bounded
+        // even at u64::MAX — guards the 1.82 build against UB-free overflow panics.
+        for _ in 0..1000 {
+            let d = next_down_delay(u64::MAX);
+            assert!((PROBE_BASE_US..=PROBE_CAP_US).contains(&d));
+        }
+    }
+
+    #[test]
+    fn reschedule_success_resets_backoff_and_uses_steady() {
+        let up = UpstreamHealth::new_healthy();
+        up.backoff_us.store(2_000_000, Relaxed); // pretend mid-walk
+        up.reschedule(true, 1_000_000);
+        assert_eq!(
+            up.backoff_us.load(Relaxed),
+            PROBE_BASE_US,
+            "success resets backoff"
+        );
+        assert_eq!(
+            up.next_probe_at_us.load(Relaxed),
+            1_000_000 + STEADY_US,
+            "healthy upstream re-probes on the STEADY cadence"
+        );
+    }
+
+    #[test]
+    fn reschedule_failure_advances_within_bounds() {
+        let up = UpstreamHealth::new_healthy();
+        let mut now = 0u64;
+        for _ in 0..50 {
+            up.reschedule(false, now);
+            let delay = up.next_probe_at_us.load(Relaxed) - now;
+            assert!(
+                (PROBE_BASE_US..=PROBE_CAP_US).contains(&delay),
+                "DOWN re-probe delay {delay} out of [{PROBE_BASE_US}, {PROBE_CAP_US}]"
+            );
+            assert!(
+                up.backoff_us.load(Relaxed) <= PROBE_CAP_US,
+                "backoff never exceeds cap"
+            );
+            now += delay;
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -285,12 +285,8 @@ impl ResolvedAppConfig {
                 continue;
             };
             for url in urls {
-                map.entry(url.clone()).or_insert_with(|| {
-                    Arc::new(health::UpstreamHealth {
-                        healthy: std::sync::atomic::AtomicBool::new(true),
-                        latency_us: std::sync::atomic::AtomicU64::new(0),
-                    })
-                });
+                map.entry(url.clone())
+                    .or_insert_with(|| Arc::new(health::UpstreamHealth::new_healthy()));
             }
         }
         let health_map = Arc::new(map);
@@ -1003,15 +999,30 @@ async fn async_main(platform: &'static bootstrap::Platform) -> error::ZionResult
             // 1. HTTPS upstreams get TLS pre-warming (connections stay in pool)
             // 2. HTTP/2 multiplexing for HTTPS health probes
             let client = health_http_client;
+            // Monotonic base for every adaptive probe deadline (immune to NTP
+            // jumps — all scheduling is in µs-since-base, never wall-clock).
+            let base = tokio::time::Instant::now();
+            const MIN_TICK_US: u64 = 10_000;
             loop {
-                let mut upstreams_to_check: Vec<(String, Arc<health::UpstreamHealth>)> = Vec::new();
+                let now_us = base.elapsed().as_micros() as u64;
+                // Probe only upstreams whose adaptive deadline is due: a HEALTHY
+                // upstream every STEADY_US (unchanged 30s), a DOWN one on the
+                // decorrelated-jitter backoff schedule — fast self-heal without
+                // a recovery thundering-herd.
+                let mut due: Vec<(String, Arc<health::UpstreamHealth>)> = Vec::new();
                 for (url, up) in hm.iter() {
-                    upstreams_to_check.push((url.to_string(), Arc::clone(up)));
+                    if up
+                        .next_probe_at_us
+                        .load(std::sync::atomic::Ordering::Relaxed)
+                        <= now_us
+                    {
+                        due.push((url.to_string(), Arc::clone(up)));
+                    }
                 }
 
                 let mut join_set = tokio::task::JoinSet::new();
 
-                for (url, up) in upstreams_to_check {
+                for (url, up) in due {
                     let client_clone = client.clone();
                     join_set.spawn(async move {
                         use http_body_util::BodyExt;
@@ -1056,11 +1067,19 @@ async fn async_main(platform: &'static bootstrap::Platform) -> error::ZionResult
                         let was_healthy = up
                             .healthy
                             .swap(healthy, std::sync::atomic::Ordering::Relaxed);
+                        // Advance the adaptive probe schedule: a success resets
+                        // the backoff to base and returns to the STEADY cadence;
+                        // a failure draws the next decorrelated-jitter delay.
+                        up.reschedule(healthy, base.elapsed().as_micros() as u64);
                         if was_healthy && !healthy {
+                            let next_ms = up
+                                .backoff_us
+                                .load(std::sync::atomic::Ordering::Relaxed)
+                                / 1000;
                             logging::warn(
                                 "health",
                                 &format!(
-                                    "upstream {url} is DOWN — requests to this upstream will return 503 until it recovers"
+                                    "upstream {url} is DOWN — 503 until it recovers; adaptive re-probe in ~{next_ms}ms"
                                 ),
                             );
                         } else if !was_healthy && healthy {
@@ -1072,7 +1091,20 @@ async fn async_main(platform: &'static bootstrap::Platform) -> error::ZionResult
                     });
                 }
                 while join_set.join_next().await.is_some() {}
-                tokio::time::sleep(std::time::Duration::from_secs(30)).await;
+
+                // Sleep until the earliest upstream is next due, floored so an
+                // all-due-now state cannot busy-spin.
+                let now2 = base.elapsed().as_micros() as u64;
+                let next_due = hm
+                    .values()
+                    .map(|u| {
+                        u.next_probe_at_us
+                            .load(std::sync::atomic::Ordering::Relaxed)
+                    })
+                    .min()
+                    .unwrap_or_else(|| now2 + health::STEADY_US);
+                let sleep_us = next_due.saturating_sub(now2).max(MIN_TICK_US);
+                tokio::time::sleep(std::time::Duration::from_micros(sleep_us)).await;
             }
         });
     }

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -298,6 +298,11 @@ mod tests {
         let old_health = Arc::new(health::UpstreamHealth {
             healthy: std::sync::atomic::AtomicBool::new(false),
             latency_us: std::sync::atomic::AtomicU64::new(42_000),
+            // Sentinel mid-backoff-walk value — must survive the reload via
+            // Arc reuse, else a future refactor could silently reset an
+            // in-progress recovery backoff on every config reload.
+            backoff_us: std::sync::atomic::AtomicU64::new(700_000),
+            next_probe_at_us: std::sync::atomic::AtomicU64::new(0),
         });
         let mut old_map = fnv::FnvHashMap::default();
         old_map.insert(url.clone(), old_health.clone());
@@ -338,6 +343,9 @@ mod tests {
         // The carried state survives.
         assert!(!merged_arc.healthy.load(Ordering::Relaxed));
         assert_eq!(merged_arc.latency_us.load(Ordering::Relaxed), 42_000);
+        // The adaptive-recovery backoff walk also survives the reload (rides
+        // the same Arc) — pins the "reload must not reset in-progress backoff".
+        assert_eq!(merged_arc.backoff_us.load(Ordering::Relaxed), 700_000);
     }
 
     #[test]
@@ -349,6 +357,8 @@ mod tests {
             Arc::new(health::UpstreamHealth {
                 healthy: std::sync::atomic::AtomicBool::new(false),
                 latency_us: std::sync::atomic::AtomicU64::new(99),
+                backoff_us: std::sync::atomic::AtomicU64::new(123_456),
+                next_probe_at_us: std::sync::atomic::AtomicU64::new(0),
             }),
         );
         let previous = ResolvedAppConfig::test_with_health(Arc::new(old_map));
@@ -381,6 +391,13 @@ mod tests {
             .expect("new upstream must be tracked");
         assert!(billing.healthy.load(Ordering::Relaxed));
         assert_eq!(billing.latency_us.load(Ordering::Relaxed), 0);
+        // Fresh upstream starts on the default adaptive schedule (base backoff,
+        // due immediately) — NOT the old upstream's sentinel.
+        assert_eq!(
+            billing.backoff_us.load(Ordering::Relaxed),
+            health::PROBE_BASE_US
+        );
+        assert_eq!(billing.next_probe_at_us.load(Ordering::Relaxed), 0);
     }
 
     #[test]


### PR DESCRIPTION
## What

Replace Zion's hardcoded **30 s** health-probe interval with a per-upstream **decorrelated-jitter backoff** (AWS / Marc Brooker, *Exponential Backoff And Jitter*).

A **DOWN** upstream is now re-probed on a `100 ms → 3 s` schedule, so a recovered origin is picked back up in **sub-second-to-few-seconds instead of up to 30 s**. The jitter desynchronises recovery probes across a co-dead pool (and future mesh replicas) — anti thundering-herd. **HEALTHY** upstreams keep the unchanged **30 s** steady cadence → zero happy-path regression, byte-identical steady-state origin probe load.

This was surfaced live during e2e testing: a reboot left Zion serving 503 for ~30 s after the origin had already recovered in ~200 ms. Fits the project's resilience thesis — *fast self-heal*.

## Method

`next = min(CAP, rand_in(BASE ..= prev × MULT))` per failed probe; a success resets to `BASE` and returns to the steady cadence.

| param | value | role |
|---|---|---|
| `PROBE_BASE_US` | 100 ms | floor — never hammer a recovering origin faster |
| `PROBE_CAP_US` | 3 s | ceiling for a DOWN re-probe (~10× the old dead-origin rate) |
| `PROBE_MULT` | 3 | decorrelated growth (E[next] = 2×prev) |
| `STEADY_US` | 30 s | **unchanged** healthy cadence |

Decorrelated jitter chosen over full/equal: keeps a guaranteed `base` floor yet stays fully decorrelated step-to-step (equal jitter's fixed lower bound would partially synchronise the n-th retry across instances).

## Changes

- **`src/health.rs`**: two prober-private atomics on `UpstreamHealth` (`backoff_us`, `next_probe_at_us`), `new_healthy()`, `reschedule()`, pure `next_down_delay()`. Request path (`select_best_upstream`/`is_healthy`) **untouched** — still reads only `healthy`+`latency_us`, lock-free.
- **`src/main.rs`**: prober loop reworked into a single-task **min-deadline scheduler** (no per-upstream tasks); fixed 30 s sleep deleted; DOWN log line records the next adaptive delay.
- **`src/reload.rs`**: backoff state rides the existing **Arc-reuse merge**, so an in-progress backoff walk survives config reload (pinned by extended tests).
- **`Cargo.toml`**: `fastrand` promoted to a direct dep (already vendored via `h3`; pure-Rust, MSRV-1.82-clean; never on the hot path).

## Tests

- `next_down_delay` envelope (floor/cap, no overflow at `u64::MAX`).
- `reschedule` success-resets-to-steady / failure-advances-within-bounds.
- reload Arc-reuse: in-progress backoff **survives** reload; fresh upstream gets defaults.
- `cargo check` ✓ · 177 lib tests ✓ · `clippy -D warnings` ✓ · `rustfmt` ✓.

## Thundering herd

Mitigated for the **prober** and **cross-replica** paths via decorrelated jitter. The **request path** needs no mitigation here: while DOWN, dispatch serves 503 **locally** without contacting the origin, so a recovering origin receives zero real traffic during backoff. A request-path half-open admission breaker is a genuine **v0.4 mesh** follow-up.

## Deferred (follow-ups)

`[health]` config block (steady/min/max/jitter knobs); recovery metrics (`zion_upstream_recovery_seconds` histogram); request-path half-open breaker.

**Known pre-existing limitation (unchanged here):** the prober captures the health map at boot, so reload-*added*/*removed* upstreams aren't (de)probed until restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)