### PR TITLE
chore(release): v0.3.2

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,7 +21,7 @@ A clear and concise description of what you expected to happen.
 **Environment (please complete the following information):**
  - OS: [e.g. Linux, macOS]
  - Architecture: [e.g. arm64, amd64]
- - Zion Version: [e.g. 0.3.1]
+ - Zion Version: [e.g. 0.3.2]
 
 **Additional context**
 Add any other context about the problem here (e.g. logs with `RUST_LOG=trace`, upstream backend type like Go/Node).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,49 @@ All notable changes to Zion Edge Gateway are documented here.
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-06-01
+
+Resilience and correctness, validated on a real two-node Proxmox e2e bench
+(real FQDN, real Let's Encrypt TLS 1.3). Adds adaptive self-heal so a recovered
+origin returns to service in ~1.4 s instead of up to 30 s, closes 24 data-plane
+findings from a live bug-hunt, and fixes a `/metrics` content-negotiation bug
+that made standard Prometheus unable to scrape.
+
+### Added
+
+- **Adaptive decorrelated-jitter origin recovery (#173)** — replaces the fixed
+  30 s upstream health-probe interval with a per-upstream decorrelated-jitter
+  backoff (AWS / Marc Brooker). A DOWN upstream is re-probed on a 100 ms→3 s
+  schedule, so a recovered origin returns to service in **~1.4 s instead of
+  ~30 s** (measured live on the e2e rig, ~21× faster), with jitter to avoid a
+  recovery thundering-herd across a co-dead pool or mesh replicas. HEALTHY
+  upstreams keep the unchanged 30 s steady cadence — zero happy-path
+  regression, identical steady-state origin load. Backoff state rides the
+  config-reload `Arc`-reuse so an in-progress walk survives reloads; the
+  request path is untouched (lock-free). `fastrand` promoted to a direct dep.
+
+### Fixed
+
+- **`/metrics` content-negotiation (#172)** — OpenMetrics exemplars were emitted
+  under the classic `text/plain; version=0.0.4` content-type, which standard
+  Prometheus rejects, making the target unscrapeable. `/metrics` now
+  content-negotiates on the `Accept` header: classic exposition (no exemplars,
+  no `# EOF`) by default, OpenMetrics only when the client asks for
+  `application/openmetrics-text`.
+- **24 data-plane findings from a live e2e bug-hunt (#171)** — request-path
+  hardening surfaced by real-traffic testing: catch-all-root + trailing-slash
+  routing, header-read / body-read / upstream timeouts (504/408), inbound
+  client-cert-fingerprint header strip, forwarding hygiene on the WebSocket
+  path, WAF whitespace/unicode/overlong-encoding evasion gates, cache GET-gating
+  + `Cache-Control` honoring, and security-header injection on all responses.
+
+### Validated
+
+- Two-node Proxmox e2e benchmark (`benches/e2e/`): Zion on **2 Skylake vCPU**
+  sustains **96 k req/s** cache+WAF+TLS and **43 k req/s** proxy+WAF+TLS at
+  ~40 MB RSS, and holds **flat RSS (OLS −26 MB/h, no leak)** under a
+  4.67 M-request mixed attack while serving 4.66 M legit cache-hits — 0 panics.
+
 ## [0.3.1] - 2026-06-01
 
 A focused patch on operability and documentation honesty. Makes the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5421,7 +5421,7 @@ dependencies = [
 
 [[package]]
 name = "zion"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "aho-corasick",
  "aimp_node",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zion"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 # MSRV is the *core* default-features build (TLS proxy + WAF + cache + metrics).
 # Opt-in features (acme, auth, init, http3) pull crypto/i18n crates that have

--- a/README.md
+++ b/README.md
@@ -364,12 +364,12 @@ commands. The short version:
 
 ```bash
 # Binary release (Sigstore-backed provenance via gh CLI)
-gh release download v0.3.1 -R fabriziosalmi/zion -p '*x86_64-unknown-linux-musl*' -p 'SHA256SUMS'
+gh release download v0.3.2 -R fabriziosalmi/zion -p '*x86_64-unknown-linux-musl*' -p 'SHA256SUMS'
 sha256sum --check --ignore-missing SHA256SUMS
-gh attestation verify zion-v0.3.1-x86_64-unknown-linux-musl.tar.gz --owner fabriziosalmi
+gh attestation verify zion-v0.3.2-x86_64-unknown-linux-musl.tar.gz --owner fabriziosalmi
 
 # Container image (cosign keyless)
-cosign verify ghcr.io/fabriziosalmi/zion:v0.3.1 \
+cosign verify ghcr.io/fabriziosalmi/zion:v0.3.2 \
     --certificate-identity-regexp "^https://github.com/fabriziosalmi/zion/\\.github/workflows/release\\.yml@refs/tags/v" \
     --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ from their containing minor — i.e. the latest `0.1.x` is always patched.
 | Version | Supported |
 | ------- | --------- |
 | 0.1.x (latest minor) | Yes |
-| < 0.3.1 | No |
+| < 0.3.2 | No |
 
 ## Reporting a Vulnerability
 

--- a/deploy/helm/zion/Chart.yaml
+++ b/deploy/helm/zion/Chart.yaml
@@ -3,7 +3,7 @@ name: zion
 description: Zion Edge Gateway — high-performance Rust TLS reverse proxy with WAF
 type: application
 version: 0.2.2
-appVersion: "0.3.1"
+appVersion: "0.3.2"
 home: https://fabriziosalmi.github.io/zion
 sources:
   - https://github.com/fabriziosalmi/zion

--- a/docs/deploy/hot-reload.md
+++ b/docs/deploy/hot-reload.md
@@ -130,7 +130,7 @@ Two surfaces report the reload state:
 
   ```json
   {
-    "version": "0.3.1",
+    "version": "0.3.2",
     "timestamp_ms": 1714425600000,
     "uptime_secs": 3712,
     "config_generation": 5,

--- a/docs/security/supply-chain.md
+++ b/docs/security/supply-chain.md
@@ -46,8 +46,8 @@ You need the GitHub CLI (`gh >= 2.49`) and `cosign >= 2.2`.
 
 ```bash
 # 1. Download the artifact + SHA256SUMS from the release page.
-gh release download v0.3.1 -R fabriziosalmi/zion \
-    -p 'zion-v0.3.1-x86_64-unknown-linux-musl.tar.gz' \
+gh release download v0.3.2 -R fabriziosalmi/zion \
+    -p 'zion-v0.3.2-x86_64-unknown-linux-musl.tar.gz' \
     -p 'SHA256SUMS' \
     -p 'zion-sbom.cdx.json'
 
@@ -55,7 +55,7 @@ gh release download v0.3.1 -R fabriziosalmi/zion \
 sha256sum --check --ignore-missing SHA256SUMS
 
 # 3. Verify the SLSA build provenance bound to the artifact's hash.
-gh attestation verify zion-v0.3.1-x86_64-unknown-linux-musl.tar.gz \
+gh attestation verify zion-v0.3.2-x86_64-unknown-linux-musl.tar.gz \
     --owner fabriziosalmi
 
 # Step 3 fails if:
@@ -78,7 +78,7 @@ grype zion-sbom.cdx.json
 ## Verifying a container image
 
 ```bash
-IMAGE=ghcr.io/fabriziosalmi/zion:v0.3.1
+IMAGE=ghcr.io/fabriziosalmi/zion:v0.3.2
 
 # 1. Pin to the digest immediately — tags are mutable, digests are not.
 DIGEST=$(crane digest "$IMAGE")
@@ -120,7 +120,7 @@ deterministically, and pins the Rust toolchain via
 [`rust-toolchain.toml`](../../rust-toolchain.toml). To reproduce locally:
 
 ```bash
-git checkout v0.3.1
+git checkout v0.3.2
 export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)
 # Linux musl example — matches the release artifact byte-for-byte
 # (modulo strip's stable behavior on your distro).


### PR DESCRIPTION
## v0.3.2

Resilience + correctness, validated on a real two-node Proxmox e2e bench (real FQDN, real Let's Encrypt TLS 1.3).

### Added
- **Adaptive decorrelated-jitter origin recovery (#173)** — fixed 30 s health-probe interval → per-upstream 100 ms→3 s decorrelated-jitter backoff. A recovered origin returns to service in **~1.4 s instead of ~30 s** (measured live, **~21×**), jitter avoids a recovery thundering-herd. Healthy cadence unchanged (30 s) → zero happy-path regression.

### Fixed
- **`/metrics` content-negotiation (#172)** — OpenMetrics exemplars under classic content-type broke standard Prometheus scraping; now negotiates on `Accept`.
- **24 data-plane findings from a live e2e bug-hunt (#171)** — request-path hardening (routing, timeouts, cert-fp strip, WAF evasion gates, cache gating, security headers).

### Validated (two-node Proxmox e2e, 2 Skylake vCPU)
- **96 k req/s** cache+WAF+TLS · **43 k req/s** proxy+WAF+TLS · RSS ~40 MB
- **flat RSS (OLS −26 MB/h)** under a 4.67 M-request mixed attack while serving 4.66 M legit cache-hits · 0 panics

Version SSOT bumped (Cargo.toml/lock, Helm appVersion, README, supply-chain, SECURITY, hot-reload, bug_report); `check-version-sync.sh` green. CHANGELOG updated. Merging triggers the `v0.3.2` tag → `release.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)