### PR TITLE
docs(readme): refresh perf to honest v0.3.2 numbers + fix bench harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 [![License](https://img.shields.io/github/license/fabriziosalmi/zion)](https://github.com/fabriziosalmi/zion/blob/master/LICENSE)
 
 <!-- Capabilities -->
-[![Performance](https://img.shields.io/badge/Performance-233k%20req%2Fs-success?style=flat&color=brightgreen)](https://github.com/fabriziosalmi/zion/tree/master/benchmarks)
+[![Performance](https://img.shields.io/badge/TLS_proxy-107k%20req%2Fs%20%C2%B7%20cache%20222k%20(M4)-success?style=flat&color=brightgreen)](https://github.com/fabriziosalmi/zion/tree/master/benchmarks)
 [![WAF](https://img.shields.io/badge/WAF-Zero%20Regex-orange)](https://github.com/fabriziosalmi/zion/blob/master/src/waf.rs)
 
 <p align="center">
@@ -28,56 +28,48 @@ High-performance TLS reverse proxy with built-in WAF, written in Rust.
 
 ## Performance
 
-### Native Benchmark (Apple M4, Rust backend, 5 runs x 10s, c=100)
+### Native Benchmark (Apple M4, v0.3.2, Rust backend, 5×10s, c=100, wrk)
 
-| Endpoint | Median req/s | Best Run | CV% | Errors |
-|----------|-------------|----------|-----|--------|
-| HTML SSR 5KB | **233,170** | 235,370 | 1.1% | 0 |
-| CSS 3KB (cached) | **209,573** | 215,408 | 3.4% | 0 |
-| Cache Hit JS 4KB (RAM) | **195,318** | 207,521 | 7.1% | 0 |
-| TLS Proxy API GET 1KB | **106,505** | 107,189 | 2.1% | 0 |
-| WAF POST JSON | **103,206** | 103,547 | 0.5% | 0 |
-| JS 4KB (no cache) | **102,892** | 104,135 | 1.3% | 0 |
-| PNG 8KB (no cache) | **99,496** | 101,290 | 1.7% | 0 |
-| WOFF2 16KB (no cache) | **83,870** | 86,242 | 2.5% | 0 |
-| SQLi blocked | Yes (400) | -- | -- | -- |
-| XSS blocked | Yes (400) | -- | -- | -- |
+End-to-end TLS 1.3 over loopback to a zero-overhead hyper backend. Median of 5
+runs; **0 errors (all 2xx) on every row**.
 
-**Peak**: 233K req/s HTML (TLS 1.3 e2e) -- 210K cache hit -- 107K API proxy -- 103K WAF POST (CV 0.5%)
+| Endpoint | Path | Median req/s | CV% |
+|---|---|--:|--:|
+| TLS proxy — JS 4KB | `/_next/static/chunk.js` | **108,055** | 1.3% |
+| TLS proxy — API GET 1KB | `/api/v1/data` | **107,220** | 8.3% |
+| TLS proxy — PNG 8KB | `/_next/static/hero.png` | **104,851** | 0.7% |
+| TLS proxy — HTML SSR 5KB | `/` | **102,658** | 2.8% |
+| TLS proxy — WOFF2 16KB | `/_next/static/font.woff2` | **92,748** | 0.8% |
+| TLS + **WAF** — POST JSON | `/api/v1/data` | **101,295** | 3.7% |
+| TLS + **cache hit** — JS 4KB (RAM) | `/_next/static/chunk.js` | **190,532** | 2.2% |
+| TLS + **cache hit** — CSS 3KB (RAM) | `/_next/static/style.css` | **222,410** | 1.9% |
+| **WAF** — SQLi / XSS | — | blocked (400) | — |
 
-Reproduce: `bash benchmarks/bench-native.sh`
+**Reliable baseline**: ~**100–108k req/s** end-to-end TLS proxy to a live upstream
+(92k for 16 KB bodies), ~**101k** with the WAF scanning every request, and
+**190–222k** for cache hits served from RAM — all at **zero errors**. Peak
+(cache, CSS): **222k req/s**. (Reference: the bare hyper backend tops out at
+~255k req/s, so the proxy path costs ~2.4× for TLS termination + relay.)
 
-### Fair Comparison with nginx (Docker, 1 CPU, 256 MB)
+Reproduce: `bash benchmarks/certs/generate.sh && bash benchmarks/bench-native.sh`
 
-| Endpoint | nginx 1.27 | Zion TLS | Zion WAF | Zion Full | Best Delta | Errors |
-|---|---|---|---|---|---|---|
-| API GET (1KB) | 29,404 | 27,517 | 27,438 | 27,537 | -6.3% | 0 |
-| HTML (5KB) | 25,657 | 52,581 | 53,016 | 53,368 | **+108.0%** | 0 |
-| JS (4KB) | 23,152 | 18,165 | 18,037 | 32,366 | **+39.8%** | 0 |
-| PNG (8KB) | 17,409 | 13,411 | 14,345 | 24,770 | **+42.3%** | 0 |
-| WAF POST | 27,772 | 26,173 | 25,653 | 26,909 | -3.1% | 0 |
-| CSS cached | 27,436 | 16,800 | 14,949 | 25,111 | -8.5% | 0 |
+> **Corrected number.** Earlier READMEs headlined "HTML SSR 5KB — 233k req/s".
+> That was an artifact: before v0.3.2 the bare `/` did not match the catch-all
+> route (a matchit edge case) and returned **404**, so the benchmark was timing a
+> 404 error path — not a proxied response (verified: that run was 100% non-2xx).
+> v0.3.2 (#171) fixes the routing; `/` now correctly proxies the 5 KB HTML at
+> ~103k, in line with every other proxy path. The honest baseline above replaces
+> the bogus peak.
 
-Full methodology: `bash benchmarks/bench-scientific.sh` (5 runs, CI95).
+### Fair comparison with nginx
 
-<details>
-<summary>Throughput Matrix (Apple M4, Go backend, TLS 1.3, wrk)</summary>
-
-Payload x concurrency grid -- measures end-to-end TLS throughput. These numbers use the Go backend (lower ceiling than Rust backend above).
-
-| Mode | Payload | c=1 | c=10 | c=100 |
-|---|---|---|---|---|
-| **Dynamic** (Go backend) | 1 MB | 2,067 | 3,491 | 3,138 |
-| | 10 MB | 323 | 406 | 203 |
-| | 100 MB | 9,334 | 22,758 | 18,865 |
-| **Static** (uncached proxy) | 1 MB | 14,328 | 35,543 | 46,416 |
-| | 10 MB | 11,889 | 41,116 | 53,144 |
-| | 100 MB | 15,669 | 46,118 | 39,295 |
-| **Cached RAM** (L1+L2) | 1 MB | 30,247 | 88,181 | **140,301** |
-| | 10 MB | 33,781 | 80,246 | 123,936 |
-| | 100 MB | 36,067 | 90,091 | 96,706 |
-
-</details>
+The previous Docker nginx-vs-Zion table was measured on v0.1.x (pre-#171), so its
+Zion rows shared the 404-routing artifact above and are **not trustworthy** for
+v0.3.2. The harness has been corrected (the bench image now builds on v0.3.2, and
+the error gate counts non-2xx so a 404/503-spewing run can no longer report
+"zero errors"); a refreshed apples-to-apples comparison is pending a re-run:
+`bash benchmarks/bench-scientific.sh` (HTTP/1.1 over TLS 1.3 — wrk has no h2
+client).
 
 ## Features
 
@@ -109,8 +101,8 @@ Payload x concurrency grid -- measures end-to-end TLS throughput. These numbers 
 
 **WAF (Zero-Regex, O(N) Single-Pass)**
 - Aho-Corasick scanner with two pattern sets:
-  - `balanced` (default): ~120 high-precision patterns — anchored SQLi/XSS/CMDi, specific SSRF endpoints, CVE-class strings (Log4Shell, XXE)
-  - `aggressive` (opt-in via `mode = "aggressive"`): adds ~70 broad-substring patterns (`alert(`, `eval(`, `$gt`, `os.system(`, generic event handlers) for higher recall on admin/internal routes
+  - `balanced` (default): ~100 high-precision patterns — anchored SQLi/XSS/CMDi, specific SSRF endpoints, CVE-class strings (Log4Shell, XXE)
+  - `aggressive` (opt-in via `mode = "aggressive"`): adds ~90 broad-substring patterns (`alert(`, `eval(`, `$gt`, `os.system(`, generic event handlers) for higher recall on admin/internal routes
 - Shannon entropy analysis (default 6.5 bits/byte; for JSON, computed on string literals only). Configurable threshold + kill-switch per profile.
 - simd-json structural validation (depth + string length limits)
 - Content-Type strict validation with delimiter enforcement
@@ -139,7 +131,7 @@ Payload x concurrency grid -- measures end-to-end TLS throughput. These numbers 
 **Operations**
 - Config validation at startup (fail fast, validates all profile references)
 - Graceful drain on shutdown (30s timeout, semaphore-tracked)
-- Upstream health checking (30s interval, EWMA latency, gray failure detection)
+- Adaptive upstream recovery (#173): healthy upstreams probed every 30 s; a DOWN upstream is re-probed on a per-upstream **decorrelated-jitter backoff** (100 ms → 3 s cap, AWS/Brooker), so a recovered origin returns to service in **~1.4 s instead of up to 30 s** (~21× faster, measured on the v0.3.2 e2e rig) — jitter avoids a recovery thundering-herd. EWMA latency (α=0.125) + gray-failure circuit breaker (ignores EWMA > 2000 ms). Backoff state survives config reload (Arc-reuse); request path stays lock-free.
 - Bootstrap auto-detection (CPU cores, RAM, L1d cache, AES-NI/NEON, kernel features)
 - Performance Tier badge at boot (S/A/B/C with live AES-GCM calibration)
 - Live TUI dashboard (`zion top`, opt-in `--features tui`)
@@ -302,7 +294,7 @@ See [zion.example.toml](zion.example.toml) for the full configuration reference.
 ```
 Client -> TLS 1.3 -> Security Gates -> Radix Router -> WAF Pipeline (5 gates) -> Proxy/Cache -> Upstream
                          |                                |
-                    URI limit                  Aho-Corasick (~120 balanced / ~190 aggressive)
+                    URI limit                  Aho-Corasick (~100 balanced / ~190 aggressive)
                     Method whitelist           Entropy analysis (JSON-string-only)
                     Rate limiter              simd-json validation
                     CORS pre-flight           Depth/size limits
@@ -326,7 +318,7 @@ bash benchmarks/bench-matrix.sh --quick
 # Docker comparison vs nginx (5 runs, CI95)
 bash benchmarks/bench-scientific.sh
 
-# PGO optimized build (+10-20%)
+# PGO optimized build (~10-20% target; shipped as the -pgo release artifact)
 bash benchmarks/bench-pgo.sh
 ```
 
@@ -338,7 +330,7 @@ Results saved to `benchmarks/bench-history.json` with automatic delta comparison
 # Unit tests (580) <!-- zion-stats:test-count (kept in sync by scripts/update-readme-stats.sh) -->
 cargo test
 
-# Integration tests (19 -- requires running Zion + backend)
+# Integration tests (23 -- requires running Zion + backend)
 # 1. cd benchmarks/backend && cargo run --release &
 # 2. ZION_CONFIG=tests/zion-test.toml ./target/release/zion &
 # 3. Run:

--- a/benchmarks/Dockerfile.zion
+++ b/benchmarks/Dockerfile.zion
@@ -2,7 +2,11 @@ FROM rust:1.86-bookworm@sha256:300ec56abce8cc9448ddea2172747d048ed902a3090e6b57b
 WORKDIR /build
 COPY Cargo.toml Cargo.lock ./
 COPY src/ src/
-RUN cargo build --release
+# v0.3.2's manifest declares [[bench]] targets; cargo refuses to parse the
+# manifest if their source files are absent, so the bench dir must be present
+# even for a --release (non-bench) build. (parity with the release Dockerfile)
+COPY benches/ benches/
+RUN cargo build --release --locked
 
 FROM debian:bookworm-slim@sha256:f9c6a2fd2ddbc23e336b6257a5245e31f996953ef06cd13a59fa0a1df2d5c252
 RUN apt-get update && apt-get install -y ca-certificates curl && rm -rf /var/lib/apt/lists/*

--- a/benchmarks/bench-history.json
+++ b/benchmarks/bench-history.json
@@ -166,5 +166,29 @@
       "conns": 100,
       "method": "wrk, median of N runs, native binary"
     }
+  },
+  {
+    "commit": "d77914f",
+    "branch": "chore/release-v0.3.2",
+    "arch": "native",
+    "timestamp": "2026-06-01T17:34:57Z",
+    "tls_proxy_rps": 107220,
+    "html_rps": 102658,
+    "js_rps": 108055,
+    "png_rps": 104851,
+    "waf_post_rps": 101295,
+    "cache_hit_rps": 190532,
+    "font_rps": 92748,
+    "css_rps": 222410,
+    "sqli_blocked": 1,
+    "xss_blocked": 1,
+    "meta": {
+      "cpu": "Apple M4",
+      "os": "Darwin arm64",
+      "duration": 10,
+      "runs": 5,
+      "conns": 100,
+      "method": "wrk, median of N runs, native binary"
+    }
   }
 ]

--- a/benchmarks/bench-native.sh
+++ b/benchmarks/bench-native.sh
@@ -222,6 +222,14 @@ cd "$PROJECT_DIR"
 cargo build --release 2>&1 | tail -3 || die "cargo build failed"
 log "Build complete ✓"
 
+# ── Step 1b: Ensure TLS bench certs exist (self-signed, gitignored) ──────
+# The TLS profiles bind :443x and need ./benchmarks/certs/tls.{crt,key}; without
+# them Zion cannot bind the TLS listener and the run dies with a connect timeout.
+if [[ ! -f "$SCRIPT_DIR/certs/tls.crt" || ! -f "$SCRIPT_DIR/certs/tls.key" ]]; then
+    log "Generating self-signed bench certs (benchmarks/certs/)..."
+    bash "$SCRIPT_DIR/certs/generate.sh" || die "cert generation failed"
+fi
+
 # ── Step 2: Start backend (Rust preferred, Go fallback) ──────────────────
 RUST_BACKEND="$SCRIPT_DIR/backend/target/release/zion-bench-backend"
 if [[ -f "$RUST_BACKEND" ]] || (cd "$SCRIPT_DIR/backend" && cargo build --release >/dev/null 2>&1); then

--- a/benchmarks/bench-scientific.sh
+++ b/benchmarks/bench-scientific.sh
@@ -85,9 +85,13 @@ extract() {
         p50) grep "50%" "$file" | awk '{print $2}' ;;
         p99) grep "99%" "$file" | awk '{print $2}' ;;
         errors)
+            # Count BOTH socket errors AND non-2xx/3xx responses: a proxy that
+            # 404s/503s every request would otherwise report high RPS with
+            # "zero errors" and silently corrupt the table (this is exactly how
+            # a pre-#171 catch-all-root 404 once masqueraded as a 233k peak).
             local sock=$(grep "Socket errors" "$file" | awk '{print $4+$6+$8+$10}')
-            local non200=$(grep -c "Non-2xx" "$file" || true)
-            echo "${sock:-0}" ;;
+            local non2xx=$(grep "Non-2xx or 3xx" "$file" | awk '{print $NF}')
+            echo "$(( ${sock:-0} + ${non2xx:-0} ))" ;;
     esac
 }
 


### PR DESCRIPTION
## TL;DR

The README headline **"HTML SSR 5KB — 233k req/s" was an artifact, not a benchmark.** Before v0.3.2 the bare `/` didn't match the catch-all route (a matchit edge case) and returned **404** — the bench was timing a 404 error path (verified **100% non-2xx**), never proxying the 5 KB HTML. The **#171** catch-all-root fix makes `/` proxy correctly; the honest number is **~103k**, consistent with every other proxy path. **This is a correctness fix, not a regression.**

Investigated by building **v0.3.1 in a worktree** and comparing back-to-back on the same harness + backend:

| | `/` status | req/s |
|---|---|---|
| v0.3.1 (pre-#171) | **404** | 224k *(error rate)* |
| v0.3.2 (post-#171) | **200** | 106k *(real proxy)* |

## README

- **Native Benchmark table** refreshed to measured **v0.3.2** medians (Apple M4, 5×10s, c=100, **0 errors**): TLS proxy **~100–108k**, TLS+WAF **101k**, cache hit **190–222k**. Adds a "Reliable baseline" line + a note documenting the 404-artifact correction. Badge `233k` → `107k proxy · cache 222k (M4)`.
- **nginx Docker comparison + throughput matrix**: flagged as untrustworthy **v0.1.x** (pre-#171, shared the 404 artifact) pending a re-run, rather than shipping un-sourced numbers.
- **Feature list**: stale "30 s interval" health-check bullet → the v0.3.2 **adaptive decorrelated-jitter recovery (#173)**. WAF pattern counts corrected to real values (balanced ~120→~100, aggressive ~70→~90; arch diagram too). Integration-test count 19→23. PGO claim softened.

## Bench harness fixes

- `benchmarks/Dockerfile.zion`: `COPY benches/` + `--locked` — v0.3.2's `[[bench]]` targets make cargo refuse to parse the manifest without the bench dir, which broke `bench-scientific.sh` entirely on v0.3.2.
- `benchmarks/bench-scientific.sh`: the error gate counted socket errors only and **discarded non-2xx** — a 404/503-spewing proxy would report high RPS with "zero errors" (exactly how the 233k artifact hid). Now sums `sock + non-2xx`.
- `benchmarks/bench-native.sh`: auto-generate the self-signed bench certs if missing (the TLS profiles silently failed to bind otherwise).

Reliable v0.3.2 baseline (1 M4 core, 0 errors): **~106k TLS proxy · ~101k TLS+WAF · 190–222k cache hit** (bare backend reference ~255k).

🤖 Generated with [Claude Code](https://claude.com/claude-code)