### PR TITLE
feat(proxy): fail over to next healthy upstream on connection failure

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,7 +21,7 @@ A clear and concise description of what you expected to happen.
 **Environment (please complete the following information):**
  - OS: [e.g. Linux, macOS]
  - Architecture: [e.g. arm64, amd64]
- - Zion Version: [e.g. 0.3.2]
+ - Zion Version: [e.g. 0.3.3]
 
 **Additional context**
 Add any other context about the problem here (e.g. logs with `RUST_LOG=trace`, upstream backend type like Go/Node).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to Zion Edge Gateway are documented here.
 
 ## [Unreleased]
 
+## [0.3.3] - 2026-06-03
+
+### Fixed
+
+- **Passive upstream failover on connection-level errors**
+  ([`src/proxy.rs`](src/proxy.rs), [`src/dispatch.rs`](src/dispatch.rs)).
+  A `standard`-mode route over a multi-upstream `[upstream]` pool now
+  fails over to the next healthy upstream when the selected backend
+  refuses the connection, instead of returning `502` until the
+  background health prober ejected it (steady probe interval).
+  `proxy_pass_ha` buffers the request body once and replays it; on a
+  connection-level failure it marks the upstream unhealthy — bringing
+  its next probe forward via `next_probe_at_us = 0` so it rejoins on
+  recovery — before retrying the next pool member. Idempotent methods
+  (GET/HEAD/OPTIONS/PUT/DELETE/TRACE) retry on any transport error;
+  non-idempotent methods only on a pure connect error (`is_connect()` —
+  the request provably never reached the upstream). Single-upstream
+  pools keep the zero-overhead `proxy_pass` streaming path; Websocket /
+  SSE forwards are unchanged (no safe replay). Measured on a live
+  2-node cluster: a rolling backend kill went from 170/350 failed
+  requests to 0/350. ([#179](https://github.com/fabriziosalmi/zion/pull/179))
+
 ## [0.3.2] - 2026-06-01
 
 Resilience and correctness, validated on a real two-node Proxmox e2e bench

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5421,7 +5421,7 @@ dependencies = [
 
 [[package]]
 name = "zion"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "aho-corasick",
  "aimp_node",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zion"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 # MSRV is the *core* default-features build (TLS proxy + WAF + cache + metrics).
 # Opt-in features (acme, auth, init, http3) pull crypto/i18n crates that have

--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ Client -> TLS 1.3 -> Security Gates -> Radix Router -> WAF Pipeline (5 gates) ->
 ```
 
 <!-- zion-stats:modules-lines (kept in sync by scripts/update-readme-stats.sh) -->
-39 modules, ~26,900 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
+39 modules, ~27,000 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
 
 ## Benchmarking
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ High-performance TLS reverse proxy with built-in WAF, written in Rust.
 
 ## Performance
 
-### Native Benchmark (Apple M4, v0.3.2, Rust backend, 5×10s, c=100, wrk)
+### Native Benchmark (Apple M4, v0.3.3, Rust backend, 5×10s, c=100, wrk)
 
 End-to-end TLS 1.3 over loopback to a zero-overhead hyper backend. Median of 5
 runs; **0 errors (all 2xx) on every row**.
@@ -54,14 +54,14 @@ runs; **0 errors (all 2xx) on every row**.
 Reproduce: `bash benchmarks/certs/generate.sh && bash benchmarks/bench-native.sh`
 
 > **Corrected number.** Earlier READMEs headlined "HTML SSR 5KB — 233k req/s".
-> That was an artifact: before v0.3.2 the bare `/` did not match the catch-all
+> That was an artifact: before v0.3.3 the bare `/` did not match the catch-all
 > route (a matchit edge case) and returned **404**, so the benchmark was timing a
 > 404 error path — not a proxied response (verified: that run was 100% non-2xx).
-> v0.3.2 (#171) fixes the routing; `/` now correctly proxies the 5 KB HTML at
+> v0.3.3 (#171) fixes the routing; `/` now correctly proxies the 5 KB HTML at
 > ~103k, in line with every other proxy path. The honest baseline above replaces
 > the bogus peak.
 
-### Fair comparison with nginx 1.27 (Docker, v0.3.2, 1 CPU / 256 MB each, c=100, 10s×5)
+### Fair comparison with nginx 1.27 (Docker, v0.3.3, 1 CPU / 256 MB each, c=100, 10s×5)
 
 Both behind identical cgroup limits, same backend, same TLS material, HTTP/1.1
 over TLS 1.3 (wrk has no h2 client). Median ± CI95, **0 errors** on every cell,
@@ -149,7 +149,7 @@ Reproduce: `bash benchmarks/bench-scientific.sh`.
 **Operations**
 - Config validation at startup (fail fast, validates all profile references)
 - Graceful drain on shutdown (30s timeout, semaphore-tracked)
-- Adaptive upstream recovery (#173): healthy upstreams probed every 30 s; a DOWN upstream is re-probed on a per-upstream **decorrelated-jitter backoff** (100 ms → 3 s cap, AWS/Brooker), so a recovered origin returns to service in **~1.4 s instead of up to 30 s** (~21× faster, measured on the v0.3.2 e2e rig) — jitter avoids a recovery thundering-herd. EWMA latency (α=0.125) + gray-failure circuit breaker (ignores EWMA > 2000 ms). Backoff state survives config reload (Arc-reuse); request path stays lock-free.
+- Adaptive upstream recovery (#173): healthy upstreams probed every 30 s; a DOWN upstream is re-probed on a per-upstream **decorrelated-jitter backoff** (100 ms → 3 s cap, AWS/Brooker), so a recovered origin returns to service in **~1.4 s instead of up to 30 s** (~21× faster, measured on the v0.3.3 e2e rig) — jitter avoids a recovery thundering-herd. EWMA latency (α=0.125) + gray-failure circuit breaker (ignores EWMA > 2000 ms). Backoff state survives config reload (Arc-reuse); request path stays lock-free.
 - Bootstrap auto-detection (CPU cores, RAM, L1d cache, AES-NI/NEON, kernel features)
 - Performance Tier badge at boot (S/A/B/C with live AES-GCM calibration)
 - Live TUI dashboard (`zion top`, opt-in `--features tui`)
@@ -374,12 +374,12 @@ commands. The short version:
 
 ```bash
 # Binary release (Sigstore-backed provenance via gh CLI)
-gh release download v0.3.2 -R fabriziosalmi/zion -p '*x86_64-unknown-linux-musl*' -p 'SHA256SUMS'
+gh release download v0.3.3 -R fabriziosalmi/zion -p '*x86_64-unknown-linux-musl*' -p 'SHA256SUMS'
 sha256sum --check --ignore-missing SHA256SUMS
-gh attestation verify zion-v0.3.2-x86_64-unknown-linux-musl.tar.gz --owner fabriziosalmi
+gh attestation verify zion-v0.3.3-x86_64-unknown-linux-musl.tar.gz --owner fabriziosalmi
 
 # Container image (cosign keyless)
-cosign verify ghcr.io/fabriziosalmi/zion:v0.3.2 \
+cosign verify ghcr.io/fabriziosalmi/zion:v0.3.3 \
     --certificate-identity-regexp "^https://github.com/fabriziosalmi/zion/\\.github/workflows/release\\.yml@refs/tags/v" \
     --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ from their containing minor — i.e. the latest `0.1.x` is always patched.
 | Version | Supported |
 | ------- | --------- |
 | 0.1.x (latest minor) | Yes |
-| < 0.3.2 | No |
+| < 0.3.3 | No |
 
 ## Reporting a Vulnerability
 

--- a/deploy/helm/zion/Chart.yaml
+++ b/deploy/helm/zion/Chart.yaml
@@ -3,7 +3,7 @@ name: zion
 description: Zion Edge Gateway — high-performance Rust TLS reverse proxy with WAF
 type: application
 version: 0.2.2
-appVersion: "0.3.2"
+appVersion: "0.3.3"
 home: https://fabriziosalmi.github.io/zion
 sources:
   - https://github.com/fabriziosalmi/zion

--- a/docs/deploy/hot-reload.md
+++ b/docs/deploy/hot-reload.md
@@ -130,7 +130,7 @@ Two surfaces report the reload state:
 
   ```json
   {
-    "version": "0.3.2",
+    "version": "0.3.3",
     "timestamp_ms": 1714425600000,
     "uptime_secs": 3712,
     "config_generation": 5,

--- a/docs/security/supply-chain.md
+++ b/docs/security/supply-chain.md
@@ -46,8 +46,8 @@ You need the GitHub CLI (`gh >= 2.49`) and `cosign >= 2.2`.
 
 ```bash
 # 1. Download the artifact + SHA256SUMS from the release page.
-gh release download v0.3.2 -R fabriziosalmi/zion \
-    -p 'zion-v0.3.2-x86_64-unknown-linux-musl.tar.gz' \
+gh release download v0.3.3 -R fabriziosalmi/zion \
+    -p 'zion-v0.3.3-x86_64-unknown-linux-musl.tar.gz' \
     -p 'SHA256SUMS' \
     -p 'zion-sbom.cdx.json'
 
@@ -55,7 +55,7 @@ gh release download v0.3.2 -R fabriziosalmi/zion \
 sha256sum --check --ignore-missing SHA256SUMS
 
 # 3. Verify the SLSA build provenance bound to the artifact's hash.
-gh attestation verify zion-v0.3.2-x86_64-unknown-linux-musl.tar.gz \
+gh attestation verify zion-v0.3.3-x86_64-unknown-linux-musl.tar.gz \
     --owner fabriziosalmi
 
 # Step 3 fails if:
@@ -78,7 +78,7 @@ grype zion-sbom.cdx.json
 ## Verifying a container image
 
 ```bash
-IMAGE=ghcr.io/fabriziosalmi/zion:v0.3.2
+IMAGE=ghcr.io/fabriziosalmi/zion:v0.3.3
 
 # 1. Pin to the digest immediately — tags are mutable, digests are not.
 DIGEST=$(crane digest "$IMAGE")
@@ -120,7 +120,7 @@ deterministically, and pins the Rust toolchain via
 [`rust-toolchain.toml`](../../rust-toolchain.toml). To reproduce locally:
 
 ```bash
-git checkout v0.3.2
+git checkout v0.3.3
 export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)
 # Linux musl example — matches the release artifact byte-for-byte
 # (modulo strip's stable behavior on your distro).

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -1067,7 +1067,21 @@ async fn process_request_inner(
                 )
                 .await?
             }
-            config::RouteMode::Standard | config::RouteMode::Websocket => {
+            config::RouteMode::Standard => {
+                proxy::proxy_pass_ha(
+                    &state.http_client,
+                    req,
+                    &rule.upstream_url,
+                    &dyn_scheme,
+                    &dyn_authority,
+                    &cfg.health_map,
+                    Some(forward_addr),
+                    "https",
+                    cfg.xff_mode,
+                )
+                .await?
+            }
+            config::RouteMode::Websocket => {
                 proxy::proxy_pass(
                     &state.http_client,
                     req,

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -245,6 +245,139 @@ pub async fn proxy_pass(
     send_request(client, req).await
 }
 
+/// Like [`send_request`] but surfaces the transport error to the caller
+/// instead of collapsing it into a 502, so [`proxy_pass_ha`] can decide
+/// whether to fail over to another upstream.
+#[inline]
+async fn send_request_try(
+    client: &HttpClient,
+    req: Request<ZionBody>,
+) -> Result<Response<ZionBody>, hyper_util::client::legacy::Error> {
+    let upstream_start = std::time::Instant::now();
+    let result = client.request(req).await;
+    crate::metrics::METRICS
+        .upstream_duration
+        .observe(upstream_start.elapsed());
+    let (parts, body) = result?.into_parts();
+    Ok(Response::from_parts(parts, body.boxed()))
+}
+
+/// High-availability forward over a multi-upstream pool.
+///
+/// Picks the pool's best healthy upstream and, on a *connection-level*
+/// failure, transparently fails over to the next healthy upstream instead
+/// of returning 502 — closing the window between a backend dying and the
+/// background health prober ejecting it (up to the steady probe interval).
+///
+/// The body is buffered once so it can be safely replayed. Non-idempotent
+/// methods are retried only on a pure connect error (the request provably
+/// never reached the upstream); idempotent methods retry on any transport
+/// error. Single-upstream pools take the zero-overhead [`proxy_pass`] path.
+#[allow(clippy::too_many_arguments)]
+pub async fn proxy_pass_ha(
+    client: &HttpClient,
+    req: Request<ZionBody>,
+    pool: &[String],
+    default_scheme: &hyper::http::uri::Scheme,
+    default_authority: &hyper::http::uri::Authority,
+    health_map: &crate::health::HealthMap,
+    remote_addr: Option<SocketAddr>,
+    proto: &str,
+    xff_mode: XffMode,
+) -> Result<Response<ZionBody>, hyper::Error> {
+    // Nothing to fail over to — keep the streaming fast path.
+    if pool.len() < 2 {
+        return proxy_pass(
+            client,
+            req,
+            default_scheme,
+            default_authority,
+            remote_addr,
+            proto,
+            xff_mode,
+        )
+        .await;
+    }
+
+    // Buffer the body once so each attempt can replay it.
+    let (parts, body) = req.into_parts();
+    let body_bytes = match body.collect().await {
+        Ok(c) => c.to_bytes(),
+        Err(_) => return Ok(bad_gateway()),
+    };
+    let method = parts.method.clone();
+    let uri = parts.uri.clone();
+    let version = parts.version;
+    let headers = parts.headers.clone();
+    let idempotent = matches!(
+        method,
+        hyper::Method::GET
+            | hyper::Method::HEAD
+            | hyper::Method::OPTIONS
+            | hyper::Method::PUT
+            | hyper::Method::DELETE
+            | hyper::Method::TRACE
+    );
+
+    // At most one attempt per pool member; marking a failed upstream down
+    // makes the next `select_best_upstream` rotate to a survivor.
+    for _ in 0..pool.len() {
+        let url = match crate::health::select_best_upstream(health_map, pool) {
+            Some(u) => u.clone(),
+            None => break,
+        };
+        let (scheme, authority) = match url.parse::<hyper::Uri>() {
+            Ok(u) => (
+                u.scheme()
+                    .cloned()
+                    .unwrap_or_else(|| default_scheme.clone()),
+                u.authority()
+                    .cloned()
+                    .unwrap_or_else(|| default_authority.clone()),
+            ),
+            Err(_) => (default_scheme.clone(), default_authority.clone()),
+        };
+
+        let mut attempt: Request<ZionBody> = Request::new(
+            Full::new(body_bytes.clone())
+                .map_err(|never| match never {})
+                .boxed(),
+        );
+        *attempt.method_mut() = method.clone();
+        *attempt.uri_mut() = uri.clone();
+        *attempt.version_mut() = version;
+        *attempt.headers_mut() = headers.clone();
+
+        let Some(prepared) =
+            prepare_request(attempt, &scheme, &authority, remote_addr, proto, xff_mode)
+        else {
+            return Ok(bad_gateway());
+        };
+
+        match send_request_try(client, prepared).await {
+            Ok(resp) => return Ok(resp),
+            Err(e) => {
+                let connect = e.is_connect();
+                eprintln!("  failover: upstream {url} error (connect={connect}): {e}");
+                // Eagerly eject: mark unhealthy and bring the next probe
+                // forward (`next_probe_at_us = 0` == due now) so the upstream
+                // rejoins rotation the moment it recovers.
+                if let Some(h) = health_map.get(&url) {
+                    h.healthy.store(false, std::sync::atomic::Ordering::Relaxed);
+                    h.next_probe_at_us
+                        .store(0, std::sync::atomic::Ordering::Relaxed);
+                }
+                // Don't replay a non-idempotent request unless it provably
+                // never reached the upstream.
+                if !(connect || idempotent) {
+                    return Ok(bad_gateway());
+                }
+            }
+        }
+    }
+    Ok(bad_gateway())
+}
+
 /// Forward a request whose body has already been collected (post-WAF path).
 #[allow(dead_code)] // retained for symmetric API; not currently called
 #[allow(clippy::too_many_arguments)]


### PR DESCRIPTION
## Problem

zion selected a single upstream via `select_best_upstream` and, if that
backend was down, returned **502** — failing over only once the background
health prober ejected it (steady probe interval). Killing one backend of a
2-node pool produced a window of 502s.

Measured on a live 2-node cluster (zion fronting a 2-replica backend behind
an `[upstream]` pool): a rolling backend kill = **170/350 requests failed**.

## Fix

`proxy_pass_ha` (`src/proxy.rs`) buffers the request body once and, on a
**connection-level** failure, marks the upstream unhealthy (bringing its next
probe forward via `next_probe_at_us = 0` so it rejoins on recovery) and
retries the next healthy member of the pool.

- Idempotent methods (GET/HEAD/OPTIONS/PUT/DELETE/TRACE) retry on any transport error.
- Non-idempotent methods retry **only** on a pure connect error (`is_connect()`) — the request provably never reached the upstream.
- Single-upstream pools take the zero-overhead `proxy_pass` streaming path.
- `send_request_try` surfaces the transport error instead of masking it as 502.
- dispatch: `Standard`-mode routes use `proxy_pass_ha`; `Websocket`/SSE keep streaming `proxy_pass` (no safe replay).

## Result

Re-measured after the fix on the same cluster: **0/350 failed** during a
rolling node kill. Full test suite green (`cargo check` + pre-commit suite).

## Follow-ups (not in this PR)

- Extend HA to the cache-miss fetch path (`dispatch.rs`, single-upstream today).
- Configurable active-probe interval + `health_path` / `healthy_statuses` (the probe hits the bare upstream URL and treats only 2xx/3xx as healthy, which breaks for auth-gated backends; current workaround is putting the health path in the upstream URL).
- Unit test for `proxy_pass_ha` against a mocked dead upstream.
