### PR TITLE
feat(security): CVE-2026-49975 (HTTP/2 Bomb) hardening + release v0.3.4

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,7 +21,7 @@ A clear and concise description of what you expected to happen.
 **Environment (please complete the following information):**
  - OS: [e.g. Linux, macOS]
  - Architecture: [e.g. arm64, amd64]
- - Zion Version: [e.g. 0.3.3]
+ - Zion Version: [e.g. 0.3.4]
 
 **Additional context**
 Add any other context about the problem here (e.g. logs with `RUST_LOG=trace`, upstream backend type like Go/Node).

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,7 +21,7 @@ A clear and concise description of what you expected to happen.
 **Environment (please complete the following information):**
  - OS: [e.g. Linux, macOS]
  - Architecture: [e.g. arm64, amd64]
- - Zion Version: [e.g. 0.3.2]
+ - Zion Version: [e.g. 0.3.3]
 
 **Additional context**
 Add any other context about the problem here (e.g. logs with `RUST_LOG=trace`, upstream backend type like Go/Node).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Zion Edge Gateway are documented here.
 
 ## [Unreleased]
 
+## [0.3.4] - 2026-06-05
+
 ### Security
 
 - **CVE-2026-49975 ("HTTP/2 Bomb") hardening.** The HTTP/2 Bomb chains an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to Zion Edge Gateway are documented here.
 
 ## [Unreleased]
 
+## [0.3.3] - 2026-06-03
+
+### Fixed
+
+- **Passive upstream failover on connection-level errors**
+  ([`src/proxy.rs`](src/proxy.rs), [`src/dispatch.rs`](src/dispatch.rs)).
+  A `standard`-mode route over a multi-upstream `[upstream]` pool now
+  fails over to the next healthy upstream when the selected backend
+  refuses the connection, instead of returning `502` until the
+  background health prober ejected it (steady probe interval).
+  `proxy_pass_ha` buffers the request body once and replays it; on a
+  connection-level failure it marks the upstream unhealthy — bringing
+  its next probe forward via `next_probe_at_us = 0` so it rejoins on
+  recovery — before retrying the next pool member. Idempotent methods
+  (GET/HEAD/OPTIONS/PUT/DELETE/TRACE) retry on any transport error;
+  non-idempotent methods only on a pure connect error (`is_connect()` —
+  the request provably never reached the upstream). Single-upstream
+  pools keep the zero-overhead `proxy_pass` streaming path; Websocket /
+  SSE forwards are unchanged (no safe replay). Measured on a live
+  2-node cluster: a rolling backend kill went from 170/350 failed
+  requests to 0/350. ([#179](https://github.com/fabriziosalmi/zion/pull/179))
+
 ## [0.3.2] - 2026-06-01
 
 Resilience and correctness, validated on a real two-node Proxmox e2e bench

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,47 @@ All notable changes to Zion Edge Gateway are documented here.
 
 ## [Unreleased]
 
+### Security
+
+- **CVE-2026-49975 ("HTTP/2 Bomb") hardening.** The HTTP/2 Bomb chains an
+  HPACK decompression bomb with a flow-control "hold". Zion's single-connection
+  resistance was *inherited* from hyper/h2 defaults rather than asserted, and
+  the multi-connection variant was unbounded with the per-IP cap off (the
+  default). This makes the ceilings explicit and on by default. Verified live
+  on the e2e rig: released 0.3.3 advertised the inherited
+  `max_concurrent_streams = 200`; a single-connection bomb stayed bounded
+  (~3 MB/conn, RSS flat, 0 panics), confirming the premise.
+  - **Explicit HTTP/2 limits** ([`src/main.rs`](src/main.rs)) — pinned on the
+    server builder instead of inherited: `max_concurrent_streams = 128` (was
+    the inherited 200), `max_header_list_size = 16 KiB`,
+    `max_pending_accept_reset_streams = 20` (CVE-2023-44487 Rapid-Reset bound),
+    plus HTTP/2 keep-alive PINGs (30 s / 10 s) to reap a connection gone silent
+    mid-hold. A regression test pins the invariant that worst-case retained
+    header memory per connection (`streams × header-list`) stays ≤ 4 MiB.
+  - **Per-IP connection cap ON by default** ([`src/config.rs`](src/config.rs),
+    [`src/main.rs`](src/main.rs)) — `server.max_connections_per_ip` is now
+    tri-state: omitted → **auto** (~1/8 of the global connection ceiling,
+    scaling with RAM so it won't pinch CGNAT/large-NAT on big nodes); `0` →
+    explicitly disabled; `N` → explicit. Resolved in `try_build` and read live
+    at accept, so a hot-reload retunes it without dropping live connections.
+  - **`compute_conn_limit` re-based to 256 KB/connection**
+    ([`src/bootstrap.rs`](src/bootstrap.rs)) — was 50 KB, which
+    under-provisioned the global ceiling ~5× against an *active* HTTP/2
+    connection (1 MB flow-control window + per-stream/HPACK state + TLS
+    buffers). The per-connection worst case stays bounded by the explicit H2
+    limits and the per-IP cap above.
+
+### Fixed
+
+- **Rate-limit map scavenger spawned unconditionally**
+  ([`src/main.rs`](src/main.rs)) — it was gated on the boot-time
+  `rate_limit_rps > 0`, so enabling the limiter via hot-reload (`0 → N`) left
+  the per-IP rate map without garbage collection, risking unbounded growth to
+  `MAX_RATE_MAP_ENTRIES` and the fail-closed path for new IPs. It now always
+  runs (a cheap no-op when the map is empty) and reads the window live. A
+  regression test pins that a hot-reload carries `rate_limit_rps`,
+  `rate_limit_window`, and `max_connections_per_ip` into the new snapshot.
+
 ## [0.3.3] - 2026-06-03
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5421,7 +5421,7 @@ dependencies = [
 
 [[package]]
 name = "zion"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "aho-corasick",
  "aimp_node",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5421,7 +5421,7 @@ dependencies = [
 
 [[package]]
 name = "zion"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "aho-corasick",
  "aimp_node",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zion"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 # MSRV is the *core* default-features build (TLS proxy + WAF + cache + metrics).
 # Opt-in features (acme, auth, init, http3) pull crypto/i18n crates that have

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zion"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
 # MSRV is the *core* default-features build (TLS proxy + WAF + cache + metrics).
 # Opt-in features (acme, auth, init, http3) pull crypto/i18n crates that have

--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ Client -> TLS 1.3 -> Security Gates -> Radix Router -> WAF Pipeline (5 gates) ->
 ```
 
 <!-- zion-stats:modules-lines (kept in sync by scripts/update-readme-stats.sh) -->
-39 modules, ~26,900 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
+39 modules, ~27,000 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
 
 ## Benchmarking
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ High-performance TLS reverse proxy with built-in WAF, written in Rust.
 
 ## Performance
 
-### Native Benchmark (Apple M4, v0.3.2, Rust backend, 5×10s, c=100, wrk)
+### Native Benchmark (Apple M4, v0.3.3, Rust backend, 5×10s, c=100, wrk)
 
 End-to-end TLS 1.3 over loopback to a zero-overhead hyper backend. Median of 5
 runs; **0 errors (all 2xx) on every row**.
@@ -54,14 +54,14 @@ runs; **0 errors (all 2xx) on every row**.
 Reproduce: `bash benchmarks/certs/generate.sh && bash benchmarks/bench-native.sh`
 
 > **Corrected number.** Earlier READMEs headlined "HTML SSR 5KB — 233k req/s".
-> That was an artifact: before v0.3.2 the bare `/` did not match the catch-all
+> That was an artifact: before v0.3.3 the bare `/` did not match the catch-all
 > route (a matchit edge case) and returned **404**, so the benchmark was timing a
 > 404 error path — not a proxied response (verified: that run was 100% non-2xx).
-> v0.3.2 (#171) fixes the routing; `/` now correctly proxies the 5 KB HTML at
+> v0.3.3 (#171) fixes the routing; `/` now correctly proxies the 5 KB HTML at
 > ~103k, in line with every other proxy path. The honest baseline above replaces
 > the bogus peak.
 
-### Fair comparison with nginx 1.27 (Docker, v0.3.2, 1 CPU / 256 MB each, c=100, 10s×5)
+### Fair comparison with nginx 1.27 (Docker, v0.3.3, 1 CPU / 256 MB each, c=100, 10s×5)
 
 Both behind identical cgroup limits, same backend, same TLS material, HTTP/1.1
 over TLS 1.3 (wrk has no h2 client). Median ± CI95, **0 errors** on every cell,
@@ -149,7 +149,7 @@ Reproduce: `bash benchmarks/bench-scientific.sh`.
 **Operations**
 - Config validation at startup (fail fast, validates all profile references)
 - Graceful drain on shutdown (30s timeout, semaphore-tracked)
-- Adaptive upstream recovery (#173): healthy upstreams probed every 30 s; a DOWN upstream is re-probed on a per-upstream **decorrelated-jitter backoff** (100 ms → 3 s cap, AWS/Brooker), so a recovered origin returns to service in **~1.4 s instead of up to 30 s** (~21× faster, measured on the v0.3.2 e2e rig) — jitter avoids a recovery thundering-herd. EWMA latency (α=0.125) + gray-failure circuit breaker (ignores EWMA > 2000 ms). Backoff state survives config reload (Arc-reuse); request path stays lock-free.
+- Adaptive upstream recovery (#173): healthy upstreams probed every 30 s; a DOWN upstream is re-probed on a per-upstream **decorrelated-jitter backoff** (100 ms → 3 s cap, AWS/Brooker), so a recovered origin returns to service in **~1.4 s instead of up to 30 s** (~21× faster, measured on the v0.3.3 e2e rig) — jitter avoids a recovery thundering-herd. EWMA latency (α=0.125) + gray-failure circuit breaker (ignores EWMA > 2000 ms). Backoff state survives config reload (Arc-reuse); request path stays lock-free.
 - Bootstrap auto-detection (CPU cores, RAM, L1d cache, AES-NI/NEON, kernel features)
 - Performance Tier badge at boot (S/A/B/C with live AES-GCM calibration)
 - Live TUI dashboard (`zion top`, opt-in `--features tui`)
@@ -374,12 +374,12 @@ commands. The short version:
 
 ```bash
 # Binary release (Sigstore-backed provenance via gh CLI)
-gh release download v0.3.2 -R fabriziosalmi/zion -p '*x86_64-unknown-linux-musl*' -p 'SHA256SUMS'
+gh release download v0.3.3 -R fabriziosalmi/zion -p '*x86_64-unknown-linux-musl*' -p 'SHA256SUMS'
 sha256sum --check --ignore-missing SHA256SUMS
-gh attestation verify zion-v0.3.2-x86_64-unknown-linux-musl.tar.gz --owner fabriziosalmi
+gh attestation verify zion-v0.3.3-x86_64-unknown-linux-musl.tar.gz --owner fabriziosalmi
 
 # Container image (cosign keyless)
-cosign verify ghcr.io/fabriziosalmi/zion:v0.3.2 \
+cosign verify ghcr.io/fabriziosalmi/zion:v0.3.3 \
     --certificate-identity-regexp "^https://github.com/fabriziosalmi/zion/\\.github/workflows/release\\.yml@refs/tags/v" \
     --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 ```

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ High-performance TLS reverse proxy with built-in WAF, written in Rust.
 
 ## Performance
 
-### Native Benchmark (Apple M4, v0.3.3, Rust backend, 5×10s, c=100, wrk)
+### Native Benchmark (Apple M4, v0.3.4, Rust backend, 5×10s, c=100, wrk)
 
 End-to-end TLS 1.3 over loopback to a zero-overhead hyper backend. Median of 5
 runs; **0 errors (all 2xx) on every row**.
@@ -54,14 +54,14 @@ runs; **0 errors (all 2xx) on every row**.
 Reproduce: `bash benchmarks/certs/generate.sh && bash benchmarks/bench-native.sh`
 
 > **Corrected number.** Earlier READMEs headlined "HTML SSR 5KB — 233k req/s".
-> That was an artifact: before v0.3.3 the bare `/` did not match the catch-all
+> That was an artifact: before v0.3.4 the bare `/` did not match the catch-all
 > route (a matchit edge case) and returned **404**, so the benchmark was timing a
 > 404 error path — not a proxied response (verified: that run was 100% non-2xx).
-> v0.3.3 (#171) fixes the routing; `/` now correctly proxies the 5 KB HTML at
+> v0.3.4 (#171) fixes the routing; `/` now correctly proxies the 5 KB HTML at
 > ~103k, in line with every other proxy path. The honest baseline above replaces
 > the bogus peak.
 
-### Fair comparison with nginx 1.27 (Docker, v0.3.3, 1 CPU / 256 MB each, c=100, 10s×5)
+### Fair comparison with nginx 1.27 (Docker, v0.3.4, 1 CPU / 256 MB each, c=100, 10s×5)
 
 Both behind identical cgroup limits, same backend, same TLS material, HTTP/1.1
 over TLS 1.3 (wrk has no h2 client). Median ± CI95, **0 errors** on every cell,
@@ -149,7 +149,7 @@ Reproduce: `bash benchmarks/bench-scientific.sh`.
 **Operations**
 - Config validation at startup (fail fast, validates all profile references)
 - Graceful drain on shutdown (30s timeout, semaphore-tracked)
-- Adaptive upstream recovery (#173): healthy upstreams probed every 30 s; a DOWN upstream is re-probed on a per-upstream **decorrelated-jitter backoff** (100 ms → 3 s cap, AWS/Brooker), so a recovered origin returns to service in **~1.4 s instead of up to 30 s** (~21× faster, measured on the v0.3.3 e2e rig) — jitter avoids a recovery thundering-herd. EWMA latency (α=0.125) + gray-failure circuit breaker (ignores EWMA > 2000 ms). Backoff state survives config reload (Arc-reuse); request path stays lock-free.
+- Adaptive upstream recovery (#173): healthy upstreams probed every 30 s; a DOWN upstream is re-probed on a per-upstream **decorrelated-jitter backoff** (100 ms → 3 s cap, AWS/Brooker), so a recovered origin returns to service in **~1.4 s instead of up to 30 s** (~21× faster, measured on the v0.3.4 e2e rig) — jitter avoids a recovery thundering-herd. EWMA latency (α=0.125) + gray-failure circuit breaker (ignores EWMA > 2000 ms). Backoff state survives config reload (Arc-reuse); request path stays lock-free.
 - Bootstrap auto-detection (CPU cores, RAM, L1d cache, AES-NI/NEON, kernel features)
 - Performance Tier badge at boot (S/A/B/C with live AES-GCM calibration)
 - Live TUI dashboard (`zion top`, opt-in `--features tui`)
@@ -319,7 +319,7 @@ Client -> TLS 1.3 -> Security Gates -> Radix Router -> WAF Pipeline (5 gates) ->
 ```
 
 <!-- zion-stats:modules-lines (kept in sync by scripts/update-readme-stats.sh) -->
-39 modules, ~27,000 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
+39 modules, ~27,300 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
 
 ## Benchmarking
 
@@ -345,7 +345,7 @@ Results saved to `benchmarks/bench-history.json` with automatic delta comparison
 ## Testing
 
 ```bash
-# Unit tests (580) <!-- zion-stats:test-count (kept in sync by scripts/update-readme-stats.sh) -->
+# Unit tests (582) <!-- zion-stats:test-count (kept in sync by scripts/update-readme-stats.sh) -->
 cargo test
 
 # Integration tests (23 -- requires running Zion + backend)
@@ -374,12 +374,12 @@ commands. The short version:
 
 ```bash
 # Binary release (Sigstore-backed provenance via gh CLI)
-gh release download v0.3.3 -R fabriziosalmi/zion -p '*x86_64-unknown-linux-musl*' -p 'SHA256SUMS'
+gh release download v0.3.4 -R fabriziosalmi/zion -p '*x86_64-unknown-linux-musl*' -p 'SHA256SUMS'
 sha256sum --check --ignore-missing SHA256SUMS
-gh attestation verify zion-v0.3.3-x86_64-unknown-linux-musl.tar.gz --owner fabriziosalmi
+gh attestation verify zion-v0.3.4-x86_64-unknown-linux-musl.tar.gz --owner fabriziosalmi
 
 # Container image (cosign keyless)
-cosign verify ghcr.io/fabriziosalmi/zion:v0.3.3 \
+cosign verify ghcr.io/fabriziosalmi/zion:v0.3.4 \
     --certificate-identity-regexp "^https://github.com/fabriziosalmi/zion/\\.github/workflows/release\\.yml@refs/tags/v" \
     --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ from their containing minor — i.e. the latest `0.1.x` is always patched.
 | Version | Supported |
 | ------- | --------- |
 | 0.1.x (latest minor) | Yes |
-| < 0.3.2 | No |
+| < 0.3.3 | No |
 
 ## Reporting a Vulnerability
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ from their containing minor — i.e. the latest `0.1.x` is always patched.
 | Version | Supported |
 | ------- | --------- |
 | 0.1.x (latest minor) | Yes |
-| < 0.3.3 | No |
+| < 0.3.4 | No |
 
 ## Reporting a Vulnerability
 

--- a/deploy/helm/zion/Chart.yaml
+++ b/deploy/helm/zion/Chart.yaml
@@ -3,7 +3,7 @@ name: zion
 description: Zion Edge Gateway — high-performance Rust TLS reverse proxy with WAF
 type: application
 version: 0.2.2
-appVersion: "0.3.3"
+appVersion: "0.3.4"
 home: https://fabriziosalmi.github.io/zion
 sources:
   - https://github.com/fabriziosalmi/zion

--- a/deploy/helm/zion/Chart.yaml
+++ b/deploy/helm/zion/Chart.yaml
@@ -3,7 +3,7 @@ name: zion
 description: Zion Edge Gateway — high-performance Rust TLS reverse proxy with WAF
 type: application
 version: 0.2.2
-appVersion: "0.3.2"
+appVersion: "0.3.3"
 home: https://fabriziosalmi.github.io/zion
 sources:
   - https://github.com/fabriziosalmi/zion

--- a/docs/deploy/hot-reload.md
+++ b/docs/deploy/hot-reload.md
@@ -130,7 +130,7 @@ Two surfaces report the reload state:
 
   ```json
   {
-    "version": "0.3.2",
+    "version": "0.3.3",
     "timestamp_ms": 1714425600000,
     "uptime_secs": 3712,
     "config_generation": 5,

--- a/docs/deploy/hot-reload.md
+++ b/docs/deploy/hot-reload.md
@@ -130,7 +130,7 @@ Two surfaces report the reload state:
 
   ```json
   {
-    "version": "0.3.3",
+    "version": "0.3.4",
     "timestamp_ms": 1714425600000,
     "uptime_secs": 3712,
     "config_generation": 5,

--- a/docs/security/supply-chain.md
+++ b/docs/security/supply-chain.md
@@ -46,8 +46,8 @@ You need the GitHub CLI (`gh >= 2.49`) and `cosign >= 2.2`.
 
 ```bash
 # 1. Download the artifact + SHA256SUMS from the release page.
-gh release download v0.3.3 -R fabriziosalmi/zion \
-    -p 'zion-v0.3.3-x86_64-unknown-linux-musl.tar.gz' \
+gh release download v0.3.4 -R fabriziosalmi/zion \
+    -p 'zion-v0.3.4-x86_64-unknown-linux-musl.tar.gz' \
     -p 'SHA256SUMS' \
     -p 'zion-sbom.cdx.json'
 
@@ -55,7 +55,7 @@ gh release download v0.3.3 -R fabriziosalmi/zion \
 sha256sum --check --ignore-missing SHA256SUMS
 
 # 3. Verify the SLSA build provenance bound to the artifact's hash.
-gh attestation verify zion-v0.3.3-x86_64-unknown-linux-musl.tar.gz \
+gh attestation verify zion-v0.3.4-x86_64-unknown-linux-musl.tar.gz \
     --owner fabriziosalmi
 
 # Step 3 fails if:
@@ -78,7 +78,7 @@ grype zion-sbom.cdx.json
 ## Verifying a container image
 
 ```bash
-IMAGE=ghcr.io/fabriziosalmi/zion:v0.3.3
+IMAGE=ghcr.io/fabriziosalmi/zion:v0.3.4
 
 # 1. Pin to the digest immediately — tags are mutable, digests are not.
 DIGEST=$(crane digest "$IMAGE")
@@ -120,7 +120,7 @@ deterministically, and pins the Rust toolchain via
 [`rust-toolchain.toml`](../../rust-toolchain.toml). To reproduce locally:
 
 ```bash
-git checkout v0.3.3
+git checkout v0.3.4
 export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)
 # Linux musl example — matches the release artifact byte-for-byte
 # (modulo strip's stable behavior on your distro).

--- a/docs/security/supply-chain.md
+++ b/docs/security/supply-chain.md
@@ -46,8 +46,8 @@ You need the GitHub CLI (`gh >= 2.49`) and `cosign >= 2.2`.
 
 ```bash
 # 1. Download the artifact + SHA256SUMS from the release page.
-gh release download v0.3.2 -R fabriziosalmi/zion \
-    -p 'zion-v0.3.2-x86_64-unknown-linux-musl.tar.gz' \
+gh release download v0.3.3 -R fabriziosalmi/zion \
+    -p 'zion-v0.3.3-x86_64-unknown-linux-musl.tar.gz' \
     -p 'SHA256SUMS' \
     -p 'zion-sbom.cdx.json'
 
@@ -55,7 +55,7 @@ gh release download v0.3.2 -R fabriziosalmi/zion \
 sha256sum --check --ignore-missing SHA256SUMS
 
 # 3. Verify the SLSA build provenance bound to the artifact's hash.
-gh attestation verify zion-v0.3.2-x86_64-unknown-linux-musl.tar.gz \
+gh attestation verify zion-v0.3.3-x86_64-unknown-linux-musl.tar.gz \
     --owner fabriziosalmi
 
 # Step 3 fails if:
@@ -78,7 +78,7 @@ grype zion-sbom.cdx.json
 ## Verifying a container image
 
 ```bash
-IMAGE=ghcr.io/fabriziosalmi/zion:v0.3.2
+IMAGE=ghcr.io/fabriziosalmi/zion:v0.3.3
 
 # 1. Pin to the digest immediately — tags are mutable, digests are not.
 DIGEST=$(crane digest "$IMAGE")
@@ -120,7 +120,7 @@ deterministically, and pins the Rust toolchain via
 [`rust-toolchain.toml`](../../rust-toolchain.toml). To reproduce locally:
 
 ```bash
-git checkout v0.3.2
+git checkout v0.3.3
 export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)
 # Linux musl example — matches the release artifact byte-for-byte
 # (modulo strip's stable behavior on your distro).

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -1203,10 +1203,18 @@ fn compute_workers(cores: usize) -> usize {
 }
 
 /// Connection limit: scale with available RAM.
-/// ~50KB per TLS connection (buffers + state).
+///
+/// Budget **256 KB per connection**, not the ~50 KB of an idle keep-alive:
+/// an *active* HTTP/2 connection carries a 1 MB flow-control window
+/// (amortized), per-stream + HPACK state, and TLS buffers, so the old 50 KB
+/// figure under-provisioned the ceiling by ~5× against a connection actually
+/// doing work. The per-connection *worst case* under the CVE-2026-49975
+/// HTTP/2 Bomb is bounded separately by the explicit H2 limits (`H2_*` in
+/// `main.rs`) and the per-IP connection cap; this is the global admission
+/// ceiling, sized for healthy concurrency.
 fn compute_conn_limit(ram_mb: u64) -> usize {
     let available_mb = ram_mb / 4; // use max 25% of RAM for connections
-    let max_conns = (available_mb * 1024 / 50) as usize; // 50KB per conn
+    let max_conns = (available_mb * 1024 / 256) as usize; // 256 KB per conn
     max_conns.clamp(1_000, 100_000)
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -146,13 +146,23 @@ pub struct ServerConfig {
     /// Rate limit window in seconds. Default: 1.
     #[serde(default = "default_rate_window")]
     pub rate_limit_window_secs: u64,
-    /// Max *concurrent* connections from a single source IP. 0 = unlimited
-    /// (default). This is the connection-exhaustion lever: rate_limit_rps
-    /// caps request frequency, this caps how many sockets one source can
-    /// hold open at once — the resource a slow/backed flood actually
-    /// drains. The global ceiling is the platform connection semaphore.
+    /// Max *concurrent* connections from a single source IP.
+    ///
+    /// Tri-state (CVE-2026-49975 multi-connection hardening):
+    ///   * omitted → **AUTO**: ~1/8 of the platform connection ceiling
+    ///     (`compute_conn_limit`), so one peer cannot monopolize admission or
+    ///     drive a multi-connection HTTP/2 Bomb. Scales with box size, so it
+    ///     won't pinch CGNAT / large-NAT clients on big nodes.
+    ///   * `0` → explicitly **DISABLED** (one source may hold any number of
+    ///     slots, up to the global ceiling).
+    ///   * `N` → explicit per-IP cap.
+    ///
+    /// Complements `rate_limit_rps` (request frequency); this caps the held
+    /// sockets a slow/backed flood actually drains. The tri-state is resolved
+    /// to a concrete cap in `ResolvedAppConfig::try_build` and read live at
+    /// accept, so a hot-reload retunes it without dropping live connections.
     #[serde(default)]
-    pub max_connections_per_ip: u32,
+    pub max_connections_per_ip: Option<u32>,
     /// Log format: "text" (default) or "json".
     #[serde(default = "default_log_format")]
     pub log_format: String,

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -1067,7 +1067,21 @@ async fn process_request_inner(
                 )
                 .await?
             }
-            config::RouteMode::Standard | config::RouteMode::Websocket => {
+            config::RouteMode::Standard => {
+                proxy::proxy_pass_ha(
+                    &state.http_client,
+                    req,
+                    &rule.upstream_url,
+                    &dyn_scheme,
+                    &dyn_authority,
+                    &cfg.health_map,
+                    Some(forward_addr),
+                    "https",
+                    cfg.xff_mode,
+                )
+                .await?
+            }
+            config::RouteMode::Websocket => {
                 proxy::proxy_pass(
                     &state.http_client,
                     req,

--- a/src/main.rs
+++ b/src/main.rs
@@ -270,7 +270,10 @@ impl ResolvedAppConfig {
     /// `main()` and the process exits with the structured ZionResult code;
     /// during hot-reload the existing snapshot stays in place and the
     /// new config is rejected with a logged WARN.
-    pub(crate) fn try_build(config: &config::ZionConfig) -> error::ZionResult<Self> {
+    pub(crate) fn try_build(
+        config: &config::ZionConfig,
+        conn_limit_max: usize,
+    ) -> error::ZionResult<Self> {
         let router = config::build_router(config).map_err(error::ZionError::Config)?;
 
         // Health map: one entry per upstream URL referenced by any route.
@@ -376,6 +379,17 @@ impl ResolvedAppConfig {
             policy
         };
 
+        // Per-IP connection cap (CVE-2026-49975 multi-connection hardening),
+        // resolved from the tri-state config field. `None` (omitted) defaults
+        // ON at ~1/8 of the global connection ceiling so no single source can
+        // monopolize admission or run the multi-connection HTTP/2 Bomb; the
+        // cap scales with the box (via `conn_limit_max`) so it won't pinch
+        // CGNAT/large-NAT on big nodes. `Some(0)` is an explicit opt-out.
+        let max_connections_per_ip = match config.server.max_connections_per_ip {
+            None => ((conn_limit_max / 8) as u32).max(1),
+            Some(explicit) => explicit,
+        };
+
         Ok(Self {
             router,
             health_map,
@@ -383,7 +397,7 @@ impl ResolvedAppConfig {
             xff_mode,
             rate_limit_rps: config.server.rate_limit_rps,
             rate_limit_window: config.server.rate_limit_window_secs,
-            max_connections_per_ip: config.server.max_connections_per_ip,
+            max_connections_per_ip,
             #[cfg(any(feature = "geo-ita", feature = "geo-eu"))]
             enforce,
             listen_http,
@@ -480,6 +494,80 @@ static EMPTY_BYTES: Bytes = Bytes::new();
 /// Maximum allowed URI length (bytes). Requests exceeding this are dropped
 /// before routing — prevents buffer overflow probes and log pollution.
 const MAX_URI_LEN: usize = 8192;
+
+// ── Explicit HTTP/2 limits — CVE-2026-49975 ("HTTP/2 Bomb") hardening ──
+//
+// These are pinned on the server builder (see the `http_builder` block in
+// `async_main`) rather than left to hyper/h2's defaults, so the
+// per-connection memory ceiling is an ASSERTED property of Zion, not a
+// transitive-dependency default a future bump could silently move. The
+// HTTP/2 Bomb chains an HPACK decompression bomb with a flow-control "hold";
+// the defence is (a) a small decoded-header-list cap that h2 enforces
+// incrementally during HPACK decode, (b) a stream cap bounding how many such
+// lists can be held open at once, (c) the Rapid-Reset bound, and (d)
+// keep-alive PINGs that reap a connection gone silent mid-hold.
+//
+// Worst-case retained decoded-header memory per connection is therefore
+// bounded by `H2_MAX_CONCURRENT_STREAMS * H2_MAX_HEADER_LIST_SIZE`
+// (= 2 MiB here). `h2_limit_tests` pins that invariant.
+
+/// SETTINGS_MAX_CONCURRENT_STREAMS advertised to peers. 128 matches the
+/// common hardened default (e.g. nginx) and is ample for legitimate
+/// multiplexing while halving hyper's 200 default.
+const H2_MAX_CONCURRENT_STREAMS: u32 = 128;
+/// SETTINGS_MAX_HEADER_LIST_SIZE — the decoded (post-HPACK) header-list cap
+/// h2 enforces incrementally per stream. 16 KiB matches the conservative
+/// default; this is the per-stream half of the bomb ceiling.
+const H2_MAX_HEADER_LIST_SIZE: u32 = 16 * 1024;
+/// Rapid-Reset (CVE-2023-44487) bound: peer-reset streams allowed to sit
+/// pending-accept before the connection is treated as abusive.
+const H2_MAX_PENDING_ACCEPT_RESET_STREAMS: usize = 20;
+/// Keep-alive PING cadence / deadline. A client that opens streams and then
+/// goes silent (the flow-control "hold" half of the bomb) fails the PING and
+/// is dropped instead of pinning stream state indefinitely.
+const H2_KEEPALIVE_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
+const H2_KEEPALIVE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+#[cfg(test)]
+mod h2_limit_tests {
+    use super::*;
+
+    /// CVE-2026-49975 regression guard. Pinning the H2 limits explicitly only
+    /// buys safety if the per-connection memory ceiling stays an asserted
+    /// invariant: if someone widens these, this test fails and forces a
+    /// conscious re-evaluation of the bound rather than a silent regression.
+    #[test]
+    fn h2_per_connection_memory_is_bounded() {
+        // Every concurrent stream may hold a decoded header list up to the cap.
+        let worst_case_header_bytes =
+            H2_MAX_CONCURRENT_STREAMS as u64 * H2_MAX_HEADER_LIST_SIZE as u64;
+        assert!(
+            worst_case_header_bytes <= 4 * 1024 * 1024,
+            "H2 per-conn header ceiling {worst_case_header_bytes} B exceeds 4 MiB — \
+             the HTTP/2 Bomb single-connection bound would regress"
+        );
+        // Functional floors: not so small they break legitimate multiplexing
+        // or normal request headers.
+        assert!(
+            H2_MAX_CONCURRENT_STREAMS >= 64,
+            "stream cap too low for legit multiplexing"
+        );
+        assert!(
+            H2_MAX_HEADER_LIST_SIZE >= 8 * 1024,
+            "header cap too low for normal requests"
+        );
+        // Rapid-Reset defence must stay present and bounded.
+        assert!(
+            (1..=100).contains(&H2_MAX_PENDING_ACCEPT_RESET_STREAMS),
+            "pending-accept reset bound must be a small positive number"
+        );
+        // A silent-hold must be reaped before it can pin state for long.
+        assert!(
+            H2_KEEPALIVE_TIMEOUT <= H2_KEEPALIVE_INTERVAL,
+            "keep-alive timeout should not exceed the interval"
+        );
+    }
+}
 
 pub(crate) fn empty_response(status: StatusCode) -> Response<ZionBody> {
     // INVARIANT: hyper's `Response::builder().status(StatusCode).body(...)`
@@ -703,7 +791,7 @@ async fn async_main(platform: &'static bootstrap::Platform) -> error::ZionResult
     // proxies, XFF policy, rate-limit settings — everything that follows
     // from `zion.toml`). This is the single entry point that future
     // hot-reload phases will re-invoke and atomic-swap.
-    let resolved = ResolvedAppConfig::try_build(&config)?;
+    let resolved = ResolvedAppConfig::try_build(&config, platform.conn_limit)?;
 
     // Boot-time visibility: structured logs for the bits operators
     // commonly check at startup. (Validation of `xff_mode` happens
@@ -911,6 +999,20 @@ async fn async_main(platform: &'static bootstrap::Platform) -> error::ZionResult
                 .header_read_timeout(std::time::Duration::from_secs(15));
             b.http1().preserve_header_case(false);
             b.http1().title_case_headers(false);
+            // Explicit HTTP/2 limits — CVE-2026-49975 ("HTTP/2 Bomb")
+            // hardening. Pinned, not inherited from hyper/h2 defaults, so the
+            // per-connection memory ceiling is an asserted property (see the
+            // H2_* consts + `h2_limit_tests`). max_concurrent_streams ×
+            // max_header_list_size bounds retained decoded-header memory per
+            // connection; the Rapid-Reset bound blunts CVE-2023-44487; the
+            // keep-alive PING reaps a connection gone silent mid-hold (the
+            // flow-control half of the bomb).
+            b.http2().max_concurrent_streams(H2_MAX_CONCURRENT_STREAMS);
+            b.http2().max_header_list_size(H2_MAX_HEADER_LIST_SIZE);
+            b.http2()
+                .max_pending_accept_reset_streams(H2_MAX_PENDING_ACCEPT_RESET_STREAMS);
+            b.http2().keep_alive_interval(H2_KEEPALIVE_INTERVAL);
+            b.http2().keep_alive_timeout(H2_KEEPALIVE_TIMEOUT);
             b
         }),
         #[cfg(feature = "sovereign-aimp")]
@@ -937,6 +1039,7 @@ async fn async_main(platform: &'static bootstrap::Platform) -> error::ZionResult
     reload::spawn_config_watcher(
         config_path.clone().into(),
         state.config.clone(),
+        platform.conn_limit,
         Some(config_change_tx),
         Some(config.tls.cert_path.clone()),
         Some(config.tls.key_path.clone()),
@@ -959,24 +1062,35 @@ async fn async_main(platform: &'static bootstrap::Platform) -> error::ZionResult
         );
     }
 
-    // 7. Spawn rate limit cleanup (scavenge stale IPs every 60s).
-    // This prevents the rate map from reaching MAX_RATE_MAP_ENTRIES
-    // with dead entries, which would trigger the fail-closed path
-    // for legitimate new IPs.
-    if config.server.rate_limit_rps > 0 {
-        let rate_map = state.rate_map.clone();
-        let window = config.server.rate_limit_window_secs;
+    // 7. Spawn rate-limit map cleanup (scavenge stale IPs every 60s).
+    // This prevents the rate map from reaching MAX_RATE_MAP_ENTRIES with
+    // dead entries, which would trigger the fail-closed path for legitimate
+    // new IPs.
+    //
+    // Spawned UNCONDITIONALLY rather than gated on the boot-time
+    // `rate_limit_rps`: the limiter can be turned on by a hot-reload
+    // (rps 0 → N, enforced live in `check_rate_limit`), and without a running
+    // scavenger the map would then grow unbounded and trip the fail-closed
+    // path. The window is read live from the current snapshot each pass so a
+    // window change is honored too. When the limiter is disabled the map
+    // stays ~empty and the 60 s scavenge is a cheap no-op.
+    {
+        let state_for_scavenge = state.clone();
         tokio::spawn(async move {
             loop {
                 tokio::time::sleep(std::time::Duration::from_secs(60)).await;
-                let removed = security::scavenge_rate_map(&rate_map, window);
+                // `.max(1)` guards scavenge_rate_map's `now / window` against a
+                // 0 window ever reaching the snapshot.
+                let window = state_for_scavenge.cfg().rate_limit_window.max(1);
+                let removed =
+                    security::scavenge_rate_map(&state_for_scavenge.rate_map, window);
                 if removed > 0 {
                     logging::info(
                         "rate_limit",
                         &format!(
                             "scavenged {} stale IPs ({} tracked)",
                             removed,
-                            rate_map.len()
+                            state_for_scavenge.rate_map.len()
                         ),
                     );
                 }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -245,6 +245,139 @@ pub async fn proxy_pass(
     send_request(client, req).await
 }
 
+/// Like [`send_request`] but surfaces the transport error to the caller
+/// instead of collapsing it into a 502, so [`proxy_pass_ha`] can decide
+/// whether to fail over to another upstream.
+#[inline]
+async fn send_request_try(
+    client: &HttpClient,
+    req: Request<ZionBody>,
+) -> Result<Response<ZionBody>, hyper_util::client::legacy::Error> {
+    let upstream_start = std::time::Instant::now();
+    let result = client.request(req).await;
+    crate::metrics::METRICS
+        .upstream_duration
+        .observe(upstream_start.elapsed());
+    let (parts, body) = result?.into_parts();
+    Ok(Response::from_parts(parts, body.boxed()))
+}
+
+/// High-availability forward over a multi-upstream pool.
+///
+/// Picks the pool's best healthy upstream and, on a *connection-level*
+/// failure, transparently fails over to the next healthy upstream instead
+/// of returning 502 — closing the window between a backend dying and the
+/// background health prober ejecting it (up to the steady probe interval).
+///
+/// The body is buffered once so it can be safely replayed. Non-idempotent
+/// methods are retried only on a pure connect error (the request provably
+/// never reached the upstream); idempotent methods retry on any transport
+/// error. Single-upstream pools take the zero-overhead [`proxy_pass`] path.
+#[allow(clippy::too_many_arguments)]
+pub async fn proxy_pass_ha(
+    client: &HttpClient,
+    req: Request<ZionBody>,
+    pool: &[String],
+    default_scheme: &hyper::http::uri::Scheme,
+    default_authority: &hyper::http::uri::Authority,
+    health_map: &crate::health::HealthMap,
+    remote_addr: Option<SocketAddr>,
+    proto: &str,
+    xff_mode: XffMode,
+) -> Result<Response<ZionBody>, hyper::Error> {
+    // Nothing to fail over to — keep the streaming fast path.
+    if pool.len() < 2 {
+        return proxy_pass(
+            client,
+            req,
+            default_scheme,
+            default_authority,
+            remote_addr,
+            proto,
+            xff_mode,
+        )
+        .await;
+    }
+
+    // Buffer the body once so each attempt can replay it.
+    let (parts, body) = req.into_parts();
+    let body_bytes = match body.collect().await {
+        Ok(c) => c.to_bytes(),
+        Err(_) => return Ok(bad_gateway()),
+    };
+    let method = parts.method.clone();
+    let uri = parts.uri.clone();
+    let version = parts.version;
+    let headers = parts.headers.clone();
+    let idempotent = matches!(
+        method,
+        hyper::Method::GET
+            | hyper::Method::HEAD
+            | hyper::Method::OPTIONS
+            | hyper::Method::PUT
+            | hyper::Method::DELETE
+            | hyper::Method::TRACE
+    );
+
+    // At most one attempt per pool member; marking a failed upstream down
+    // makes the next `select_best_upstream` rotate to a survivor.
+    for _ in 0..pool.len() {
+        let url = match crate::health::select_best_upstream(health_map, pool) {
+            Some(u) => u.clone(),
+            None => break,
+        };
+        let (scheme, authority) = match url.parse::<hyper::Uri>() {
+            Ok(u) => (
+                u.scheme()
+                    .cloned()
+                    .unwrap_or_else(|| default_scheme.clone()),
+                u.authority()
+                    .cloned()
+                    .unwrap_or_else(|| default_authority.clone()),
+            ),
+            Err(_) => (default_scheme.clone(), default_authority.clone()),
+        };
+
+        let mut attempt: Request<ZionBody> = Request::new(
+            Full::new(body_bytes.clone())
+                .map_err(|never| match never {})
+                .boxed(),
+        );
+        *attempt.method_mut() = method.clone();
+        *attempt.uri_mut() = uri.clone();
+        *attempt.version_mut() = version;
+        *attempt.headers_mut() = headers.clone();
+
+        let Some(prepared) =
+            prepare_request(attempt, &scheme, &authority, remote_addr, proto, xff_mode)
+        else {
+            return Ok(bad_gateway());
+        };
+
+        match send_request_try(client, prepared).await {
+            Ok(resp) => return Ok(resp),
+            Err(e) => {
+                let connect = e.is_connect();
+                eprintln!("  failover: upstream {url} error (connect={connect}): {e}");
+                // Eagerly eject: mark unhealthy and bring the next probe
+                // forward (`next_probe_at_us = 0` == due now) so the upstream
+                // rejoins rotation the moment it recovers.
+                if let Some(h) = health_map.get(&url) {
+                    h.healthy.store(false, std::sync::atomic::Ordering::Relaxed);
+                    h.next_probe_at_us
+                        .store(0, std::sync::atomic::Ordering::Relaxed);
+                }
+                // Don't replay a non-idempotent request unless it provably
+                // never reached the upstream.
+                if !(connect || idempotent) {
+                    return Ok(bad_gateway());
+                }
+            }
+        }
+    }
+    Ok(bad_gateway())
+}
+
 /// Forward a request whose body has already been collected (post-WAF path).
 #[allow(dead_code)] // retained for symmetric API; not currently called
 #[allow(clippy::too_many_arguments)]

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -15,7 +15,11 @@
 //!     entropy threshold + kill-switch)
 //!   * trusted proxy CIDRs
 //!   * xff_mode
-//!   * rate-limit rps + window
+//!   * rate-limit rps + window (enforcement is read live at the request
+//!     path; the rate-map scavenger is spawned unconditionally in
+//!     `async_main` so a 0 → N hot-enable still gets garbage collection)
+//!   * per-IP connection cap (`max_connections_per_ip`) — read live at
+//!     accept, so a reload retunes the cap without dropping live conns
 //!
 //! Out of scope for Phase 1 (require a separate path):
 //!   * `[server.listen_http]` / `[server.listen_https]` — changing
@@ -72,8 +76,9 @@ pub(crate) fn current_generation() -> u64 {
 fn rebuild(
     new_config: &ZionConfig,
     previous: &ResolvedAppConfig,
+    conn_limit_max: usize,
 ) -> Result<ResolvedAppConfig, crate::error::ZionError> {
-    let mut snap = ResolvedAppConfig::try_build(new_config)?;
+    let mut snap = ResolvedAppConfig::try_build(new_config, conn_limit_max)?;
     let mut merged: fnv::FnvHashMap<String, Arc<health::UpstreamHealth>> =
         fnv::FnvHashMap::default();
     for (url, fresh) in snap.health_map.iter() {
@@ -102,6 +107,10 @@ fn rebuild(
 pub(crate) fn spawn_config_watcher(
     config_path: PathBuf,
     state_config: Arc<ArcSwap<ResolvedAppConfig>>,
+    // Platform global connection ceiling — needed to resolve the tri-state
+    // `max_connections_per_ip` (omitted → ~conn_limit/8) on every reload, so a
+    // reloaded snapshot derives the same auto per-IP cap the boot path did.
+    conn_limit_max: usize,
     change_notifier: Option<tokio::sync::watch::Sender<u64>>,
     boot_tls_cert_path: Option<String>,
     boot_tls_key_path: Option<String>,
@@ -203,7 +212,7 @@ pub(crate) fn spawn_config_watcher(
                     let previous = state_config.load_full();
                     let rebuild_result =
                         std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                            rebuild(&new_config, &previous)
+                            rebuild(&new_config, &previous, conn_limit_max)
                         }));
                     let new_snapshot = match rebuild_result {
                         Ok(Ok(snap)) => snap,
@@ -286,6 +295,11 @@ pub(crate) fn spawn_config_watcher(
 mod tests {
     use super::*;
 
+    /// Stand-in for the platform global connection ceiling in tests that
+    /// exercise `try_build` / `rebuild` (which resolve the tri-state per-IP
+    /// cap against it). 10_000 → auto per-IP cap = 1_250.
+    const TEST_CONN_LIMIT_MAX: usize = 10_000;
+
     /// `rebuild` must reuse `Arc<UpstreamHealth>` for URLs that exist
     /// in both old and new configs — otherwise a hot-reload would
     /// reset every upstream's health state to "untested" and cause a
@@ -330,7 +344,7 @@ mod tests {
         // Bypass disk validation by parsing TOML directly — we only
         // test the rebuild() merging logic, not file I/O.
         let parsed: ZionConfig = toml::from_str(config_toml).unwrap();
-        let merged = rebuild(&parsed, &previous).expect("test config rebuilds");
+        let merged = rebuild(&parsed, &previous, TEST_CONN_LIMIT_MAX).expect("test config rebuilds");
 
         let merged_arc = merged
             .health_map
@@ -380,7 +394,7 @@ mod tests {
             upstream = "billing"
         "#;
         let parsed: ZionConfig = toml::from_str(config_toml).unwrap();
-        let merged = rebuild(&parsed, &previous).expect("test config rebuilds");
+        let merged = rebuild(&parsed, &previous, TEST_CONN_LIMIT_MAX).expect("test config rebuilds");
 
         // Old upstream gone, new one present, with default state
         // ("healthy = true, latency = 0", per ResolvedAppConfig::build).
@@ -398,6 +412,90 @@ mod tests {
             health::PROBE_BASE_US
         );
         assert_eq!(billing.next_probe_at_us.load(Ordering::Relaxed), 0);
+    }
+
+    /// Reload-completeness guard. `try_build` is the SINGLE builder used by
+    /// both boot and hot-reload, and the accept/request paths read these
+    /// `[server]` fields live off the swapped snapshot
+    /// (`max_connections_per_ip` at the per-IP cap, `rate_limit_rps` /
+    /// `rate_limit_window` at the rate limiter). A refactor that dropped any
+    /// of them here would silently turn a hot-reload of that field into a
+    /// no-op — the precise failure this test exists to catch. (Verified live
+    /// on the e2e rig 2026-06-05: editing `max_connections_per_ip` 0→50 and
+    /// waiting past the debounce enforced cap=50 on the next connections.)
+    #[test]
+    fn try_build_carries_security_fields_for_hot_reload() {
+        let toml_text = r#"
+            [server]
+            listen_http = "0.0.0.0:8080"
+            listen_https = "0.0.0.0:8443"
+            rate_limit_rps = 99
+            rate_limit_window_secs = 7
+            max_connections_per_ip = 50
+
+            [tls]
+            cert_path = "/tmp/zion-test.crt"
+            key_path  = "/tmp/zion-test.key"
+
+            [upstreams]
+            api = "http://api:8000"
+
+            [[route]]
+            path = "/api/{*rest}"
+            upstream = "api"
+        "#;
+        let cfg = parse_inline(toml_text);
+
+        let snap = ResolvedAppConfig::try_build(&cfg, TEST_CONN_LIMIT_MAX)
+            .expect("test config builds");
+        // Explicit per-IP cap (Some(50)) is carried verbatim.
+        assert_eq!(snap.max_connections_per_ip, 50, "per-IP cap must survive build");
+        assert_eq!(snap.rate_limit_rps, 99, "rate_limit_rps must survive build");
+        assert_eq!(snap.rate_limit_window, 7, "rate_limit_window must survive build");
+
+        // The merge path used by every hot-reload must preserve them too.
+        let merged = rebuild(&cfg, &snap, TEST_CONN_LIMIT_MAX).expect("test config rebuilds");
+        assert_eq!(merged.max_connections_per_ip, 50);
+        assert_eq!(merged.rate_limit_rps, 99);
+        assert_eq!(merged.rate_limit_window, 7);
+
+        // Tri-state resolution (CVE-2026-49975 #2): an OMITTED per-IP cap must
+        // default ON at ~conn_limit/8; an explicit 0 must stay an opt-out (the
+        // e2e bench's intrinsic lane relies on 0 == off).
+        let auto = parse_inline(
+            r#"
+            [server]
+            listen_http = "0.0.0.0:8080"
+            listen_https = "0.0.0.0:8443"
+
+            [tls]
+            cert_path = "/tmp/zion-test.crt"
+            key_path  = "/tmp/zion-test.key"
+
+            [upstreams]
+            api = "http://api:8000"
+
+            [[route]]
+            path = "/api/{*rest}"
+            upstream = "api"
+        "#,
+        );
+        let auto_snap =
+            ResolvedAppConfig::try_build(&auto, TEST_CONN_LIMIT_MAX).expect("builds");
+        assert_eq!(
+            auto_snap.max_connections_per_ip,
+            (TEST_CONN_LIMIT_MAX / 8) as u32,
+            "omitted per-IP cap must default ON at ~conn_limit/8"
+        );
+
+        let mut off = auto;
+        off.server.max_connections_per_ip = Some(0);
+        let off_snap =
+            ResolvedAppConfig::try_build(&off, TEST_CONN_LIMIT_MAX).expect("builds");
+        assert_eq!(
+            off_snap.max_connections_per_ip, 0,
+            "explicit 0 must disable the cap"
+        );
     }
 
     #[test]
@@ -471,7 +569,7 @@ mod tests {
     fn atomic_swap_preserves_old_snapshot_for_inflight_readers() {
         // Initial snapshot, exposed only via `/api/...`.
         let v1 = parse_inline(TOML_V1);
-        let snap_v1 = ResolvedAppConfig::try_build(&v1).expect("test config builds");
+        let snap_v1 = ResolvedAppConfig::try_build(&v1, TEST_CONN_LIMIT_MAX).expect("test config builds");
         let store = ArcSwap::from_pointee(snap_v1);
 
         // Reader A grabs an Arc clone *before* the swap. This models a
@@ -482,7 +580,7 @@ mod tests {
 
         // Hot-reload: build v2 (adds /billing) and swap.
         let v2 = parse_inline(TOML_V2);
-        let snap_v2 = rebuild(&v2, &reader_a).expect("test config rebuilds");
+        let snap_v2 = rebuild(&v2, &reader_a, TEST_CONN_LIMIT_MAX).expect("test config rebuilds");
         store.store(Arc::new(snap_v2));
 
         // Reader A sees the old routing table (route /api works,
@@ -521,12 +619,12 @@ mod tests {
         // empty `[[route]]` section before the first edit).
         let mut empty = parse_inline(TOML_V1);
         empty.route.clear();
-        let snap_empty = ResolvedAppConfig::try_build(&empty).expect("test config builds");
+        let snap_empty = ResolvedAppConfig::try_build(&empty, TEST_CONN_LIMIT_MAX).expect("test config builds");
         let store = ArcSwap::from_pointee(snap_empty);
 
         let v1 = parse_inline(TOML_V1);
         let prev = store.load_full();
-        let snap_v1 = rebuild(&v1, &prev).expect("test config rebuilds");
+        let snap_v1 = rebuild(&v1, &prev, TEST_CONN_LIMIT_MAX).expect("test config rebuilds");
         store.store(Arc::new(snap_v1));
 
         let after = store.load_full();

--- a/zion.example.toml
+++ b/zion.example.toml
@@ -17,11 +17,18 @@ listen_https = "0.0.0.0:443"
 # rate_limit_rps = 1000
 # rate_limit_window_secs = 1
 
-# Per-IP concurrent-connection cap. 0 = disabled (default). Caps how many
-# sockets a single source IP may hold open at once (enforced at accept,
-# before the TLS handshake) — the resource a slow/backed flood drains.
-# Complements rate_limit_rps (which caps request frequency, not sockets).
+# Per-IP concurrent-connection cap. Caps how many sockets a single source IP
+# may hold open at once (enforced at accept, before the TLS handshake) — the
+# resource a slow/backed flood (e.g. the CVE-2026-49975 HTTP/2 Bomb) drains.
+# Complements rate_limit_rps (which caps request frequency, not sockets);
 # rejected connections are counted in `zion_connections_rejected_per_ip`.
+#
+# Tri-state:
+#   * omitted (this line commented) → AUTO: ~1/8 of the global connection
+#     ceiling, which scales with RAM. ON by default; safe for CGNAT on large
+#     nodes because the cap grows with the box.
+#   * 0 → explicitly disabled (one source may hold any number of sockets).
+#   * N → explicit cap.
 # max_connections_per_ip = 256
 
 # Trusted proxy CIDR ranges. When the TCP peer matches one of these,


### PR DESCRIPTION
## What

Harden Zion against **CVE-2026-49975 ("HTTP/2 Bomb")** — an HPACK decompression bomb chained with a flow-control hold — and cut **v0.3.4**.

Single-connection resistance was *inherited* from hyper/h2 defaults (not asserted), and the multi-connection variant was unbounded with the per-IP cap off (the default). This makes the ceilings explicit and on by default.

## Changes

- **Explicit HTTP/2 limits** (`src/main.rs`): `max_concurrent_streams=128` (was the inherited 200), `max_header_list_size=16 KiB`, `max_pending_accept_reset_streams=20` (CVE-2023-44487 Rapid-Reset), + keep-alive PINGs (30s/10s). Regression test pins worst-case per-conn header memory (`streams × header-list`) ≤ 4 MiB.
- **Per-IP connection cap ON by default** (`src/config.rs`, `src/main.rs`): tri-state `max_connections_per_ip` — omitted → **auto** (~conn_limit/8, RAM-scaled so it won't pinch CGNAT/large-NAT on big nodes); `0` → disabled; `N` → explicit. Resolved in `try_build`, read live at accept (hot-reloadable).
- **`compute_conn_limit` re-based to 256 KB/conn** (`src/bootstrap.rs`), was 50 KB.
- **Rate-limit scavenger spawned unconditionally** (`src/main.rs`) so a hot-enable (`rate_limit_rps 0→N`) still gets GC; regression test pins that a hot-reload carries rps/window/per-IP cap.

## Verification

Investigated + tested live on the e2e rig (CT 9001, 2 GB LXC) against the **released 0.3.3**: it advertised the inherited `max_concurrent_streams=200`; a single-connection HPACK-bomb + flow-control hold stayed bounded (~3 MB/conn, RSS flat, 0 panics, healthz 200 throughout). The multi-connection variant could pressure a small node with the per-IP cap off — closed here by default.

`cargo check`/`clippy` (default + cross-platform features) clean; 395 unit tests + 2 new regression tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)