### PR TITLE
Bump arc-swap to 1.1.0 (high)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ matchit = "0.8"
 rustls = "0.23"
 rustls-pemfile = "2"
 tokio-rustls = "0.26"
-arc-swap = "1"
+arc-swap = "1.1.0"
 notify = "7"
 
 # AEAD primitives for the boot-time AES-GCM calibration microbench.


### PR DESCRIPTION
### FabGPT — OSV security bump

**Package:** `arc-swap` `1` → `1.1.0`
**Manifest:** `Cargo.toml`
**Severity:** high
**Advisory:** Dangling reference in `access::Map` with Constant CVE-2020-35711

Source: [OSV.dev](https://osv.dev) (deterministic). _Human-approved before opening._

---
🤖 **FabGPT OS** · source `osv` · model `deterministic` · task `76a1ed8bd26b6fcc` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"76a1ed8bd26b6fcc","source":"osv","model":"deterministic","severity":"WARN","iterations":1,"inference_s":0.0,"triage":"WARN"} -->