### PR TITLE
Bump rand to 0.9.3 (medium)

### DIFF
--- a/benchmarks/backend/Cargo.toml
+++ b/benchmarks/backend/Cargo.toml
@@ -9,7 +9,7 @@ hyper-util = { version = "0.1", features = ["tokio", "http1", "server", "server-
 http-body-util = "0.1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "signal"] }
 bytes = "1"
-rand = "0.9"
+rand = "0.9.3"
 mimalloc = "0.1"
 
 [profile.release]


### PR DESCRIPTION
### FabGPT — OSV security bump

**Package:** `rand` `0.9` → `0.9.3`
**Manifest:** `benchmarks/backend/Cargo.toml`
**Severity:** medium
**Advisory:** Rand is unsound with a custom logger using `rand::rng()` GHSA-cq8v-f236-94qc, RUSTSEC-2026-0097

Source: [OSV.dev](https://osv.dev) (deterministic). _Human-approved before opening._

---
🤖 **FabGPT OS** · source `osv` · model `deterministic` · task `ddae4a415dcaa736` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"ddae4a415dcaa736","source":"osv","model":"deterministic","severity":"WARN","iterations":1,"inference_s":0.0,"triage":"WARN"} -->