### PR TITLE
Bump mimalloc to 0.1.39 (medium)

### DIFF
--- a/benchmarks/backend/Cargo.toml
+++ b/benchmarks/backend/Cargo.toml
@@ -10,7 +10,7 @@ http-body-util = "0.1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "signal"] }
 bytes = "1"
 rand = "0.9"
-mimalloc = "0.1"
+mimalloc = "0.1.39"
 
 [profile.release]
 opt-level = 3


### PR DESCRIPTION
### FabGPT — OSV security bump

**Package:** `mimalloc` `0.1` → `0.1.39`
**Manifest:** `benchmarks/backend/Cargo.toml`
**Severity:** medium
**Advisory:** Mimalloc Can Allocate Memory with Bad Alignment GHSA-g23h-7vf9-xc25, RUSTSEC-2022-0094

Source: [OSV.dev](https://osv.dev) (deterministic). _Human-approved before opening._

---
🤖 **FabGPT OS** · source `osv` · model `deterministic` · task `b397ed8af0893ca8` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"b397ed8af0893ca8","source":"osv","model":"deterministic","severity":"WARN","iterations":1,"inference_s":0.0,"triage":"WARN"} -->