### PR TITLE
Bump 2 dependencies in Cargo.toml (high)

### DIFF
--- a/benchmarks/backend/Cargo.toml
+++ b/benchmarks/backend/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2021"
 hyper = { version = "1", features = ["http1", "server"] }
 hyper-util = { version = "0.1", features = ["tokio", "http1", "server", "server-auto"] }
 http-body-util = "0.1"
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "signal"] }
+tokio = { version = "1.38.2", features = ["rt-multi-thread", "macros", "net", "signal"] }
 bytes = "1"
 rand = "0.9.3"
-mimalloc = "0.1"
+mimalloc = "0.1.39"
 
 [profile.release]
 opt-level = 3


### PR DESCRIPTION
### FabGPT — OSV security bump

**Packages:**
- `mimalloc` `0.1` → `0.1.39` (GHSA-g23h-7vf9-xc25, RUSTSEC-2022-0094)
- `tokio` `1` → `1.38.2` (CVE-2021-38191, CVE-2021-45710, GHSA-4q83-7cq4-p6wg, GHSA-rr8g-9fpq-6wmg, RUSTSEC-2023-0005, RUSTSEC-2025-0023)
**Manifest:** `benchmarks/backend/Cargo.toml`
**Severity:** high
**Advisories:** CVE-2021-38191, CVE-2021-45710, GHSA-4q83-7cq4-p6wg, GHSA-g23h-7vf9-xc25, GHSA-rr8g-9fpq-6wmg, RUSTSEC-2022-0094, RUSTSEC-2023-0005, RUSTSEC-2025-0023

Source: [OSV.dev](https://osv.dev) (deterministic). _Human-approved before opening._

---
🤖 **FabGPT OS** · source `osv` · model `deterministic` · task `a97f619ff3136f30` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"a97f619ff3136f30","source":"osv","model":"deterministic","severity":"WARN","iterations":1,"inference_s":0.0,"triage":"WARN"} -->