### PR TITLE
Add guard for non‑git repository execution

### DIFF
--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -16,6 +16,12 @@ if ! [[ "$NEW" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?$ ]]; then
   exit 2
 fi
 
+# Ensure we are inside a Git repository.
+if ! git rev-parse --show-toplevel >/dev/null 2>&1; then
+  echo "error: this script must be run from within a Git repository" >&2
+  exit 2
+fi
+
 cd "$(git rev-parse --show-toplevel)"
 
 OLD=$(awk '


### PR DESCRIPTION
### FabGPT — code quality

**File:** `scripts/bump-version.sh`

**Rationale:** The script assumes it is run inside a Git repository and uses `git rev-parse`. When executed outside a repo, `git rev-parse` fails and the script changes to an empty directory, causing obscure errors later. Adding an explicit check provides a clear error message and prevents unintended side‑effects.

_Proposed by FabGPT OS and approved by a human before opening._

---
🤖 **FabGPT OS** · source `quality` · model `gpt-oss-120b` · task `b4d5e1bc22cb2a7d` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"b4d5e1bc22cb2a7d","source":"quality","model":"gpt-oss-120b","severity":"INFO","iterations":2,"inference_s":43.11,"prompt_sha":"419e0e0e1971e9d0","triage":"INFO"} -->