### PR TITLE
feat(edge): L7 tarpit / slow-drip for flagged sources (#151)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,47 @@ All notable changes to Zion Edge Gateway are documented here.
 
 ## [Unreleased]
 
+### Added
+
+- **L7 tarpit / slow-drip for flagged sources** (#151,
+  [`src/tarpit.rs`](src/tarpit.rs)). Closes the anti-DDoS enforcement arc
+  (#147 → #155 → #150 → #151). When tag-driven enforcement (#150) decides to
+  deny a request, the operator can now escalate the cheap `403` into a
+  *held* connection: the flagged source is parked for a bounded `hold_secs`
+  before the refusal, so a backed flood pays wall-clock and socket budget
+  instead of getting an instant, immediately-recyclable reject.
+  - **Config** `[sovereign.enforce.tarpit]` — `enabled` (default `false`),
+    `hold_secs` (default `10`), `max_concurrent` (default `128`). Only takes
+    effect when `[sovereign.enforce] enabled = true`; geo-gated like the rest
+    of enforcement. Config-load warns if `enabled` with `max_concurrent = 0`
+    (sheds every request → no-op) or `hold_secs > 60` (over-long holds tie up
+    connections), and **clamps `max_concurrent` to ¼ of the global connection
+    ceiling** so held connections can't pin the admission pool (self-DoS guard).
+  - **Bounded** — a single global ceiling caps concurrently held requests; at
+    the ceiling the tarpit *sheds* back to the immediate `403`. A held request
+    keeps its global connection permit + per-IP slot for the hold, so the
+    ceiling is clamped to a small fraction (¼) of the connection pool.
+    Admission is one CAS; a held request is one parked tokio timer + the open
+    socket, released by an RAII guard (gauge and held-time stay correct on
+    early return / panic). The deny still denies — the tarpit only changes how
+    long the flagged client waits.
+  - **Metrics** `zion_tarpit_active` (gauge), `zion_tarpit_total`,
+    `zion_tarpit_shed_total`, `zion_tarpit_held_ms_total` (counters).
+
+### Deferred
+
+- Per-byte **slow header/body drip** (the endlessh-style trickle). The
+  bounded delayed-hold already imposes the wall-clock + socket cost that is
+  the point of a tarpit; a streaming-body trickle is a follow-up. Tarpit on
+  the plain `429` rate-limit path (currently scoped to the `[sovereign.enforce]`
+  deny points) is likewise a follow-up.
+- **Per-IP tarpit sub-cap.** The ceiling is global, and on HTTP/2 each held
+  *stream* consumes a slot, so one source (a few H2 connections) can occupy a
+  large share of the holding capacity and push other flagged sources to a fast
+  `403`. This degrades the tarpit's effectiveness but not zion's stability (the
+  shed fallback is the safe pre-tarpit behaviour, and the global / per-IP
+  connection caps still bound sockets). A per-IP sub-cap is a follow-up.
+
 ## [0.3.4] - 2026-06-05
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -180,14 +180,7 @@ leave on under load. Defence is layered, outside-in:
 | **Origin tagging** | IT/EU range classification (`--features geo-ita` / `geo-eu`), **IPv4 + IPv6** — O(log N) binary search over baked CIDR data + one atomic, **no GeoIP DB, no syscall**. Class lands on the request (`extensions`), a metric, and an optional log. Answers "% EU vs non-EU traffic" out of the box (see [observability](https://fabriziosalmi.github.io/zion/guide/observability)). | ✅ shipping |
 | **Fleet signal** | AIMP serverless mesh (`--features sovereign-aimp`): Ed25519-signed UDP gossip of blocks + IP-reputation, source-bound revocation, no central control plane. Reputation rides to the upstream as `X-Zion-Mesh-Score`. | ✅ shipping (advisory) |
 | **Tag-driven enforcement** | `[sovereign.enforce]` (`#150`) promotes the origin tag / mesh score from *signal* to an opt-in `403` deny — e.g. `deny = ["unknown"]` blocks every non-EU source while EU classes pass (sovereign allowlist by complement), or deny above an AIMP reputation threshold. Off by default; local WAF / rate-limit / auth stay authoritative. Counted in `zion_enforcement_denied_total{reason}`. | ✅ shipping |
-
-**On the roadmap — the lever still to build** (tracked; PRs welcome):
-
-- **L7 tarpit / slow-drip** ([#151](https://github.com/fabriziosalmi/zion/issues/151)) —
-  hold flagged connections (those an enforcement policy or a rate/conn
-  breach marks) instead of a clean `429`, so a backed attacker pays
-  wall-clock and socket budget. Bounded by a hard concurrency ceiling
-  (the per-IP connection-limit primitive) so it can't self-DoS.
+| **L7 tarpit** | `[sovereign.enforce.tarpit]` (`#151`) escalates an enforcement deny from a cheap `403` to a *held* connection: a flagged source is parked `hold_secs` before the refusal, so a backed flood pays wall-clock + socket budget instead of an instantly-recyclable reject. A hard global ceiling (`max_concurrent`) sheds back to an immediate `403`, so the tarpit can't self-DoS. Off by default. Metrics `zion_tarpit_{active,total,shed_total,held_ms_total}`. | ✅ shipping |
 
 The design rule: tagging and reputation never *silently* gate — the
 operator opts a signal into enforcement explicitly, and the local
@@ -319,7 +312,7 @@ Client -> TLS 1.3 -> Security Gates -> Radix Router -> WAF Pipeline (5 gates) ->
 ```
 
 <!-- zion-stats:modules-lines (kept in sync by scripts/update-readme-stats.sh) -->
-39 modules, ~27,300 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
+40 modules, ~27,700 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
 
 ## Benchmarking
 
@@ -345,7 +338,7 @@ Results saved to `benchmarks/bench-history.json` with automatic delta comparison
 ## Testing
 
 ```bash
-# Unit tests (582) <!-- zion-stats:test-count (kept in sync by scripts/update-readme-stats.sh) -->
+# Unit tests (587) <!-- zion-stats:test-count (kept in sync by scripts/update-readme-stats.sh) -->
 cargo test
 
 # Integration tests (23 -- requires running Zion + backend)

--- a/docs/guide/observability.md
+++ b/docs/guide/observability.md
@@ -110,6 +110,26 @@ zion_enforcement_denied_total{reason="mesh_score"}    77
 The local WAF / rate-limiter / auth gates stay authoritative — enforcement
 only *adds* a deny on top, and is off until configured.
 
+**L7 tarpit (`[sovereign.enforce.tarpit]`, #151).** When enforcement is on,
+the operator can escalate a deny from a cheap `403` to a *held* connection:
+a flagged source is parked `hold_secs` before the refusal so a backed flood
+pays wall-clock and socket budget. A hard global ceiling (`max_concurrent`)
+sheds back to an immediate `403` at capacity, and is clamped at config-load
+to ¼ of the global connection pool so held connections can't pin admission.
+
+```
+zion_tarpit_active        12     # gauge: connections currently held
+zion_tarpit_total       4310     # counter: total ever held
+zion_tarpit_shed_total   118     # counter: shed to immediate 403 at the ceiling
+zion_tarpit_held_ms_total 43100  # counter: cumulative held wall-clock (ms)
+```
+
+Mean hold ≈ `rate(zion_tarpit_held_ms_total[5m]) / rate(zion_tarpit_total[5m])`.
+A rising `zion_tarpit_shed_total` means the ceiling is saturated — raise
+`max_concurrent` (bounded by the ¼-pool clamp) or lower `hold_secs`. The
+ceiling counts in-flight held *requests* (HTTP/2 streams), so size it with
+stream fan-out in mind.
+
 ## Access log
 
 Every successful request emits one structured `tracing::info!`

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -38,6 +38,34 @@ use crate::auth;
 use crate::config::ResolvedRoute;
 use http_body_util::Limited;
 
+/// Issue #151: turn an enforcement *deny* into a bounded held (tarpit)
+/// response when the operator enabled it, otherwise the plain immediate
+/// rejection. Bounded by the global ceiling — at capacity it sheds back to
+/// the immediate reject, so the tarpit can never become a self-DoS. The
+/// request is denied either way; the tarpit only changes *how long* the
+/// flagged client waits for the refusal.
+#[cfg(any(feature = "geo-ita", feature = "geo-eu"))]
+async fn deny_or_tarpit(
+    enforce: &crate::sovereign::EnforcePolicy,
+    status: StatusCode,
+) -> Response<ZionBody> {
+    use std::sync::atomic::Ordering::Relaxed;
+    if enforce.tarpit_enabled {
+        match crate::tarpit::try_enter(enforce.tarpit_max_concurrent) {
+            Some(_guard) => {
+                metrics::METRICS.tarpit_total.fetch_add(1, Relaxed);
+                tokio::time::sleep(enforce.tarpit_hold).await;
+                // `_guard` drops here: active gauge--, held-time recorded.
+            }
+            None => {
+                // Ceiling full — shed to the immediate rejection.
+                metrics::METRICS.tarpit_shed_total.fetch_add(1, Relaxed);
+            }
+        }
+    }
+    empty_response(status)
+}
+
 const MAX_URI_LEN: usize = 8192;
 const MAX_CACHEABLE_BODY: usize = 50 * 1024 * 1024;
 
@@ -258,7 +286,7 @@ async fn process_request_inner(
                 metrics::METRICS
                     .enforcement_denied_class
                     .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                return Ok(empty_response(StatusCode::FORBIDDEN));
+                return Ok(deny_or_tarpit(&cfg.enforce, StatusCode::FORBIDDEN).await);
             }
             if cfg.sovereign_log_classification && ip_class != sovereign::IpClass::Unknown {
                 tracing::info!(
@@ -303,7 +331,7 @@ async fn process_request_inner(
                 metrics::METRICS
                     .enforcement_denied_mesh_score
                     .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                return Ok(empty_response(StatusCode::FORBIDDEN));
+                return Ok(deny_or_tarpit(&cfg.enforce, StatusCode::FORBIDDEN).await);
             }
             // 3 decimals so log/grep humans see a stable string;
             // upstreams parse as f32 and tolerate any precision.
@@ -1689,6 +1717,70 @@ mod tests {
     fn test_is_internal_ip_link_local() {
         let ip: std::net::IpAddr = "169.254.0.1".parse().unwrap();
         assert!(is_internal_ip(&ip));
+    }
+
+    // ── #151 L7 tarpit wiring (deny_or_tarpit) ──
+    //
+    // Deterministic, no timing: `hold_secs = 0` exercises the held path
+    // without sleeping; `max_concurrent = 0` forces the shed path. Only
+    // `deny_or_tarpit` ever touches the `zion_tarpit_*` metrics, so these
+    // before/after deltas are race-free across the parallel test run.
+    #[cfg(any(feature = "geo-ita", feature = "geo-eu"))]
+    #[tokio::test]
+    async fn tarpit_wiring_holds_and_sheds() {
+        use crate::sovereign::{EnforceConfig, EnforcePolicy, TarpitConfig};
+        use std::sync::atomic::Ordering::Relaxed;
+
+        let m = &metrics::METRICS;
+
+        // Tarpit disabled → immediate 403, no tarpit accounting.
+        let disabled = EnforcePolicy::from_config(&EnforceConfig {
+            enabled: true,
+            ..Default::default()
+        });
+        assert!(!disabled.tarpit_enabled);
+        let (t0, s0) = (
+            m.tarpit_total.load(Relaxed),
+            m.tarpit_shed_total.load(Relaxed),
+        );
+        let r = deny_or_tarpit(&disabled, StatusCode::FORBIDDEN).await;
+        assert_eq!(r.status(), StatusCode::FORBIDDEN);
+        assert_eq!(m.tarpit_total.load(Relaxed), t0);
+        assert_eq!(m.tarpit_shed_total.load(Relaxed), s0);
+
+        // Tarpit on, zero hold, ceiling 1 → held path: total +1, gauge back to
+        // baseline once the guard drops before return.
+        let held = EnforcePolicy::from_config(&EnforceConfig {
+            enabled: true,
+            tarpit: TarpitConfig {
+                enabled: true,
+                hold_secs: 0,
+                max_concurrent: 1,
+            },
+            ..Default::default()
+        });
+        assert!(held.tarpit_enabled);
+        let (t1, a1) = (m.tarpit_total.load(Relaxed), m.tarpit_active.load(Relaxed));
+        let r = deny_or_tarpit(&held, StatusCode::FORBIDDEN).await;
+        assert_eq!(r.status(), StatusCode::FORBIDDEN);
+        assert_eq!(m.tarpit_total.load(Relaxed), t1 + 1);
+        assert_eq!(m.tarpit_active.load(Relaxed), a1);
+
+        // Tarpit on but ceiling 0 → shed path: shed +1, nothing held.
+        let shed = EnforcePolicy::from_config(&EnforceConfig {
+            enabled: true,
+            tarpit: TarpitConfig {
+                enabled: true,
+                hold_secs: 0,
+                max_concurrent: 0,
+            },
+            ..Default::default()
+        });
+        assert!(shed.tarpit_enabled);
+        let s1 = m.tarpit_shed_total.load(Relaxed);
+        let r = deny_or_tarpit(&shed, StatusCode::FORBIDDEN).await;
+        assert_eq!(r.status(), StatusCode::FORBIDDEN);
+        assert_eq!(m.tarpit_shed_total.load(Relaxed), s1 + 1);
     }
 
     // ── Singleflight primitive (race fix) ──

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,6 +66,7 @@ mod reload;
 mod security;
 #[cfg(any(feature = "geo-ita", feature = "geo-eu"))]
 mod sovereign;
+mod tarpit;
 mod tls;
 #[cfg(feature = "tui")]
 mod tui;
@@ -362,7 +363,7 @@ impl ResolvedAppConfig {
         // never fire, which is exactly the failure an operator can't see.
         #[cfg(any(feature = "geo-ita", feature = "geo-eu"))]
         let enforce = {
-            let policy = sovereign::EnforcePolicy::from_config(&config.sovereign.enforce);
+            let mut policy = sovereign::EnforcePolicy::from_config(&config.sovereign.enforce);
             if config.sovereign.enforce.enabled {
                 let unknown = policy.unknown_deny_labels();
                 if !unknown.is_empty() {
@@ -374,6 +375,46 @@ impl ResolvedAppConfig {
                             sovereign::known_class_labels(),
                         ),
                     );
+                }
+                let tp = &config.sovereign.enforce.tarpit;
+                // #151: a tarpit with a zero ceiling holds nothing — every
+                // flagged request sheds straight to the 403. Surface it so the
+                // operator doesn't think the tarpit is doing anything.
+                if tp.enabled && tp.max_concurrent == 0 {
+                    logging::warn(
+                        "sovereign",
+                        "[sovereign.enforce.tarpit] enabled with max_concurrent = 0 — every flagged request is shed to an immediate 403 (tarpit is a no-op)",
+                    );
+                }
+                // #151 self-DoS guard: a held tarpit connection keeps its
+                // global connection-pool permit and per-IP slot for the whole
+                // hold, so the ceiling must stay a small fraction of the pool —
+                // otherwise a flood of flagged sources pins admission. Clamp to
+                // 1/4 of the global connection ceiling and say so.
+                if tp.enabled && policy.tarpit_max_concurrent > 0 {
+                    let safety_cap = ((conn_limit_max / 4) as u32).max(1);
+                    if policy.tarpit_max_concurrent > safety_cap {
+                        logging::warn(
+                            "sovereign",
+                            &format!(
+                                "[sovereign.enforce.tarpit] max_concurrent {} exceeds 1/4 of the global connection ceiling ({}) — clamping to {} so held connections can't pin the admission pool",
+                                policy.tarpit_max_concurrent, conn_limit_max, safety_cap,
+                            ),
+                        );
+                        policy.tarpit_max_concurrent = safety_cap;
+                    }
+                    // A few seconds already imposes the cost; very long holds
+                    // tie up connections (capped by the connection idle timeout)
+                    // and slow the shutdown drain.
+                    if tp.hold_secs > 60 {
+                        logging::warn(
+                            "sovereign",
+                            &format!(
+                                "[sovereign.enforce.tarpit] hold_secs = {} is very large — a few seconds already imposes the cost; long holds tie up connections and slow shutdown drain",
+                                tp.hold_secs,
+                            ),
+                        );
+                    }
                 }
             }
             policy

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -413,6 +413,17 @@ pub struct Metrics {
     /// Requests denied (403) by tag-driven enforcement because the AIMP
     /// mesh reputation score exceeded `mesh_score_deny_above` (#150).
     pub enforcement_denied_mesh_score: AtomicU64,
+    /// L7 tarpit (#151), `[sovereign.enforce.tarpit]`. Connections currently
+    /// held before their enforcement `403` (gauge).
+    pub tarpit_active: AtomicU64,
+    /// Total requests ever held by the tarpit (counter).
+    pub tarpit_total: AtomicU64,
+    /// Flagged requests shed straight to a `403` because the tarpit was at
+    /// its `max_concurrent` ceiling (counter).
+    pub tarpit_shed_total: AtomicU64,
+    /// Cumulative wall-clock the tarpit held connections, milliseconds
+    /// (counter). With `tarpit_total` it gives the mean hold.
+    pub tarpit_held_ms_total: AtomicU64,
 
     // ── Mesh observability (issue #69) ──────────────────────────────
     // Always-on counters (zero on builds without `--features
@@ -494,6 +505,10 @@ impl Metrics {
             connections_rejected_per_ip: AtomicU64::new(0),
             enforcement_denied_class: AtomicU64::new(0),
             enforcement_denied_mesh_score: AtomicU64::new(0),
+            tarpit_active: AtomicU64::new(0),
+            tarpit_total: AtomicU64::new(0),
+            tarpit_shed_total: AtomicU64::new(0),
+            tarpit_held_ms_total: AtomicU64::new(0),
             mesh_claims_emitted: AtomicU64::new(0),
             mesh_claims_received: AtomicU64::new(0),
             mesh_claims_dropped_signature: AtomicU64::new(0),
@@ -769,6 +784,41 @@ impl Metrics {
         out.extend_from_slice(
             itoa_buf
                 .format(self.enforcement_denied_mesh_score.load(Relaxed))
+                .as_bytes(),
+        );
+        out.extend_from_slice(b"\n");
+
+        // L7 tarpit (#151).
+        out.extend_from_slice(
+            b"# HELP zion_tarpit_active Connections currently held by the L7 tarpit before their 403.\n\
+                                # TYPE zion_tarpit_active gauge\n\
+                                zion_tarpit_active ",
+        );
+        out.extend_from_slice(itoa_buf.format(self.tarpit_active.load(Relaxed)).as_bytes());
+        out.extend_from_slice(
+            b"\n# HELP zion_tarpit_total Total requests held by the L7 tarpit before rejection.\n\
+                                # TYPE zion_tarpit_total counter\n\
+                                zion_tarpit_total ",
+        );
+        out.extend_from_slice(itoa_buf.format(self.tarpit_total.load(Relaxed)).as_bytes());
+        out.extend_from_slice(
+            b"\n# HELP zion_tarpit_shed_total Flagged requests shed to an immediate 403 at the tarpit ceiling.\n\
+                                # TYPE zion_tarpit_shed_total counter\n\
+                                zion_tarpit_shed_total ",
+        );
+        out.extend_from_slice(
+            itoa_buf
+                .format(self.tarpit_shed_total.load(Relaxed))
+                .as_bytes(),
+        );
+        out.extend_from_slice(
+            b"\n# HELP zion_tarpit_held_ms_total Cumulative milliseconds connections were held by the tarpit.\n\
+                                # TYPE zion_tarpit_held_ms_total counter\n\
+                                zion_tarpit_held_ms_total ",
+        );
+        out.extend_from_slice(
+            itoa_buf
+                .format(self.tarpit_held_ms_total.load(Relaxed))
                 .as_bytes(),
         );
         out.extend_from_slice(b"\n");

--- a/src/sovereign/mod.rs
+++ b/src/sovereign/mod.rs
@@ -372,6 +372,10 @@ pub struct EnforceConfig {
     /// high-confidence path). Requires `--features sovereign-aimp`.
     #[serde(default)]
     pub mesh_score_deny_above: f32,
+    /// L7 tarpit (#151): escalate a deny from a cheap `403` to a bounded
+    /// *held* connection. Off by default.
+    #[serde(default)]
+    pub tarpit: TarpitConfig,
 }
 
 impl Default for EnforceConfig {
@@ -380,6 +384,49 @@ impl Default for EnforceConfig {
             enabled: false,
             deny: Vec::new(),
             mesh_score_deny_above: 0.0,
+            tarpit: TarpitConfig::default(),
+        }
+    }
+}
+
+/// `[sovereign.enforce.tarpit]` — escalate an enforcement *deny* from a
+/// cheap `403` to a bounded held connection (issue #151). Off by default.
+/// Bounded by `max_concurrent`: at the ceiling the tarpit sheds back to an
+/// immediate `403`, so it can never become a self-inflicted resource sink.
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct TarpitConfig {
+    /// Master switch. Default: false (denies stay immediate 403s). Only
+    /// takes effect when `[sovereign.enforce] enabled = true`.
+    #[serde(default)]
+    pub enabled: bool,
+    /// How long a flagged connection is held before its rejection, seconds.
+    #[serde(default = "default_tarpit_hold_secs")]
+    pub hold_secs: u64,
+    /// Hard ceiling on concurrently-held connections. At the ceiling the
+    /// tarpit sheds to an immediate `403`. `0` holds nothing (sheds all).
+    #[serde(default = "default_tarpit_max_concurrent")]
+    pub max_concurrent: u32,
+}
+
+fn default_tarpit_hold_secs() -> u64 {
+    10
+}
+
+fn default_tarpit_max_concurrent() -> u32 {
+    // Small fixed fraction of any box's connection pool (the global ceiling
+    // is RAM-scaled with a ~1000 floor). Kept comfortably below the
+    // `conn_limit/4` self-DoS clamp applied at config-load (#151) so the
+    // default never trips the clamp warning. Operators can raise it; the
+    // clamp still bounds an over-large override.
+    128
+}
+
+impl Default for TarpitConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            hold_secs: default_tarpit_hold_secs(),
+            max_concurrent: default_tarpit_max_concurrent(),
         }
     }
 }
@@ -392,6 +439,14 @@ pub struct EnforcePolicy {
     pub enabled: bool,
     deny: std::collections::HashSet<String>,
     mesh_score_deny_above: f32,
+    /// True only when enforcement *and* the tarpit are both on (#151) — a
+    /// tarpit with no enforcement deny would never fire.
+    pub tarpit_enabled: bool,
+    /// How long a flagged connection is held before its rejection.
+    pub tarpit_hold: std::time::Duration,
+    /// Hard ceiling on concurrently-held tarpit connections; at the ceiling
+    /// the deny path sheds to an immediate rejection.
+    pub tarpit_max_concurrent: u32,
 }
 
 impl EnforcePolicy {
@@ -400,6 +455,11 @@ impl EnforcePolicy {
             enabled: c.enabled,
             deny: c.deny.iter().map(|s| s.to_ascii_lowercase()).collect(),
             mesh_score_deny_above: c.mesh_score_deny_above,
+            // The tarpit is an escalation of an enforcement deny, so it is
+            // live only when enforcement itself is enabled.
+            tarpit_enabled: c.enabled && c.tarpit.enabled,
+            tarpit_hold: std::time::Duration::from_secs(c.tarpit.hold_secs),
+            tarpit_max_concurrent: c.tarpit.max_concurrent,
         }
     }
 
@@ -596,6 +656,7 @@ mod tests {
             enabled: false,
             deny: vec!["unknown".into()],
             mesh_score_deny_above: 0.5,
+            ..Default::default()
         });
         assert!(!p.denies_class("unknown"));
         assert!(!p.denies_score(0.99));
@@ -607,6 +668,7 @@ mod tests {
             enabled: true,
             deny: vec!["Unknown".into(), "DATACENTER_EU".into()],
             mesh_score_deny_above: 0.0,
+            ..Default::default()
         });
         assert!(p.denies_class("unknown"));
         assert!(p.denies_class("datacenter_eu"));
@@ -621,6 +683,7 @@ mod tests {
             enabled: true,
             deny: vec![],
             mesh_score_deny_above: 0.0, // 0 = disabled
+            ..Default::default()
         });
         assert!(!off.denies_score(1.0));
 
@@ -628,6 +691,7 @@ mod tests {
             enabled: true,
             deny: vec![],
             mesh_score_deny_above: 0.9,
+            ..Default::default()
         });
         assert!(p.denies_score(0.91));
         assert!(!p.denies_score(0.9)); // strict `>`, equal does not deny
@@ -640,10 +704,45 @@ mod tests {
             enabled: true,
             deny: vec!["unknown".into(), "datacentre_eu".into()], // British typo
             mesh_score_deny_above: 0.0,
+            ..Default::default()
         });
         let unknown = p.unknown_deny_labels();
         assert!(unknown.contains(&"datacentre_eu"));
         assert!(!unknown.contains(&"unknown"));
+    }
+
+    #[test]
+    fn tarpit_resolves_and_requires_enforcement_on() {
+        // Tarpit on but enforcement off → not live (a tarpit with no deny to
+        // escalate would never fire).
+        let off = EnforcePolicy::from_config(&EnforceConfig {
+            enabled: false,
+            tarpit: TarpitConfig {
+                enabled: true,
+                hold_secs: 5,
+                max_concurrent: 32,
+            },
+            ..Default::default()
+        });
+        assert!(!off.tarpit_enabled);
+
+        // Both on → live, with resolved hold + ceiling.
+        let on = EnforcePolicy::from_config(&EnforceConfig {
+            enabled: true,
+            deny: vec!["unknown".into()],
+            tarpit: TarpitConfig {
+                enabled: true,
+                hold_secs: 7,
+                max_concurrent: 64,
+            },
+            ..Default::default()
+        });
+        assert!(on.tarpit_enabled);
+        assert_eq!(on.tarpit_hold, std::time::Duration::from_secs(7));
+        assert_eq!(on.tarpit_max_concurrent, 64);
+
+        // Default config → tarpit off.
+        assert!(!EnforcePolicy::from_config(&EnforceConfig::default()).tarpit_enabled);
     }
 
     #[cfg(feature = "geo-eu")]

--- a/src/tarpit.rs
+++ b/src/tarpit.rs
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: Apache-2.0
+//! L7 tarpit — a bounded *held* response for flagged sources (issue #151).
+//!
+//! When tag-driven enforcement (#150) decides to deny a request — origin
+//! class on the deny list, or AIMP mesh reputation past the threshold — the
+//! default answer is a cheap `403`, which is cheap for the attacker too. The
+//! tarpit turns that into a *held* connection: the flagged request is parked
+//! for a bounded `hold` duration before the rejection is sent, so a backed
+//! flood pays wall-clock and socket budget instead of getting an instant,
+//! immediately-recyclable refusal.
+//!
+//! **Bounded.** A single global ceiling caps how many requests may be held
+//! at once (`max_concurrent`); at the ceiling the tarpit *sheds* back to the
+//! immediate rejection. A held request keeps the connection's global
+//! `conn_limit` permit and per-IP slot for the whole hold, so the ceiling is
+//! clamped at config-load to a small fraction (1/4) of the global connection
+//! pool — the tarpit imposes cost on the attacker without pinning admission
+//! for legitimate traffic. The ceiling counter is the `zion_tarpit_active`
+//! gauge. Note: the ceiling counts in-flight held *requests* (HTTP/2 streams),
+//! so under H2 a few connections can occupy many slots — size `max_concurrent`
+//! with stream fan-out in mind. A per-IP sub-cap (to stop one source
+//! monopolising the holding capacity) is a deferred follow-up.
+//!
+//! **Cost model** mirrors [`crate::connlimit`]: admission is a single CAS on
+//! an atomic; a held connection is one parked tokio timer plus the open
+//! socket, released by an RAII guard so the active gauge and held-time
+//! counter stay correct even on early return or panic. Disabled (the
+//! default) the enforcement deny path never calls in here at all.
+#![cfg_attr(not(any(feature = "geo-ita", feature = "geo-eu")), allow(dead_code))]
+
+use crate::metrics::METRICS;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Instant;
+
+/// RAII guard for one held tarpit slot. While alive it counts against the
+/// `active` ceiling; on drop it releases the slot and records how long the
+/// connection was held. Borrows the counters so the core admission logic is
+/// unit-testable against local atomics (production borrows the `'static`
+/// [`METRICS`]).
+pub struct TarpitGuard<'a> {
+    active: &'a AtomicU64,
+    held_ms_total: &'a AtomicU64,
+    start: Instant,
+}
+
+impl Drop for TarpitGuard<'_> {
+    fn drop(&mut self) {
+        self.active.fetch_sub(1, Ordering::Release);
+        let held = self.start.elapsed().as_millis().min(u64::MAX as u128) as u64;
+        self.held_ms_total.fetch_add(held, Ordering::Relaxed);
+    }
+}
+
+/// Core admission: claim one slot under `ceiling` by CAS-bumping `active`,
+/// or `None` if already at the ceiling. `ceiling == 0` admits nothing.
+/// Decoupled from [`METRICS`] so it is testable with local atomics.
+fn enter<'a>(
+    active: &'a AtomicU64,
+    held_ms_total: &'a AtomicU64,
+    ceiling: u32,
+) -> Option<TarpitGuard<'a>> {
+    let ceiling = ceiling as u64;
+    let mut cur = active.load(Ordering::Relaxed);
+    loop {
+        if cur >= ceiling {
+            return None;
+        }
+        match active.compare_exchange_weak(cur, cur + 1, Ordering::Acquire, Ordering::Relaxed) {
+            Ok(_) => {
+                return Some(TarpitGuard {
+                    active,
+                    held_ms_total,
+                    start: Instant::now(),
+                })
+            }
+            Err(actual) => cur = actual,
+        }
+    }
+}
+
+/// Try to enter the tarpit under the global ceiling. `Some(guard)` → the
+/// caller holds a slot (the gauge is already incremented) and should park
+/// for the hold duration; the guard releases the slot and records the held
+/// time on drop. `None` → the ceiling is full; the caller must shed to an
+/// immediate rejection.
+pub fn try_enter(ceiling: u32) -> Option<TarpitGuard<'static>> {
+    enter(
+        &METRICS.tarpit_active,
+        &METRICS.tarpit_held_ms_total,
+        ceiling,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ceiling_admits_then_sheds() {
+        let active = AtomicU64::new(0);
+        let held = AtomicU64::new(0);
+        let g1 = enter(&active, &held, 2);
+        let g2 = enter(&active, &held, 2);
+        assert!(g1.is_some() && g2.is_some());
+        assert_eq!(active.load(Ordering::Relaxed), 2);
+        // At the ceiling → shed (no slot).
+        assert!(enter(&active, &held, 2).is_none());
+        assert_eq!(active.load(Ordering::Relaxed), 2);
+    }
+
+    #[test]
+    fn drop_releases_slot() {
+        let active = AtomicU64::new(0);
+        let held = AtomicU64::new(0);
+        {
+            let _g = enter(&active, &held, 1).unwrap();
+            assert_eq!(active.load(Ordering::Relaxed), 1);
+            // Second is shed while the first is held.
+            assert!(enter(&active, &held, 1).is_none());
+        } // guard drops here → slot released, held time recorded
+        assert_eq!(active.load(Ordering::Relaxed), 0);
+        // Freed → admits again.
+        assert!(enter(&active, &held, 1).is_some());
+    }
+
+    #[test]
+    fn ceiling_zero_sheds_everything() {
+        let active = AtomicU64::new(0);
+        let held = AtomicU64::new(0);
+        assert!(enter(&active, &held, 0).is_none());
+        assert_eq!(active.load(Ordering::Relaxed), 0);
+    }
+
+    // Lock in the CAS invariant under real contention: the active count must
+    // never exceed the ceiling, and must return to zero once every guard is
+    // dropped. Guards against a future "simplification" (e.g. fetch_add +
+    // post-check) that would transiently overshoot.
+    #[test]
+    fn ceiling_never_exceeded_under_contention() {
+        use std::sync::Arc;
+        use std::thread;
+        const CEILING: u32 = 8;
+        const THREADS: usize = 16;
+        const ITERS: usize = 2_000;
+        let active = Arc::new(AtomicU64::new(0));
+        let held = Arc::new(AtomicU64::new(0));
+        let max_seen = Arc::new(AtomicU64::new(0));
+        let handles: Vec<_> = (0..THREADS)
+            .map(|_| {
+                let active = Arc::clone(&active);
+                let held = Arc::clone(&held);
+                let max_seen = Arc::clone(&max_seen);
+                thread::spawn(move || {
+                    for _ in 0..ITERS {
+                        if let Some(_g) = enter(&active, &held, CEILING) {
+                            // Observe occupancy while holding the slot.
+                            let now = active.load(Ordering::Relaxed);
+                            max_seen.fetch_max(now, Ordering::Relaxed);
+                            // `_g` drops here, releasing the slot.
+                        }
+                    }
+                })
+            })
+            .collect();
+        for h in handles {
+            h.join().unwrap();
+        }
+        assert!(
+            max_seen.load(Ordering::Relaxed) <= CEILING as u64,
+            "active exceeded ceiling under contention: {} > {}",
+            max_seen.load(Ordering::Relaxed),
+            CEILING
+        );
+        assert_eq!(active.load(Ordering::Relaxed), 0);
+    }
+}

--- a/zion.example.toml
+++ b/zion.example.toml
@@ -67,6 +67,19 @@ listen_https = "0.0.0.0:443"
 # # Requires --features sovereign-aimp. Counted in
 # # `zion_enforcement_denied_total{reason="class"|"mesh_score"}`.
 # mesh_score_deny_above = 0.9
+#
+# # L7 tarpit (#151) — escalate an enforcement deny from a cheap 403 to a
+# # *held* connection: a flagged source is parked `hold_secs` before the
+# # refusal, so a backed flood pays wall-clock + socket budget. A hard
+# # global ceiling sheds back to an immediate 403 at capacity, so the tarpit
+# # can never become a self-DoS. Only active when enforcement is on.
+# # Metrics: zion_tarpit_{active,total,shed_total,held_ms_total}.
+# [sovereign.enforce.tarpit]
+# enabled = true
+# hold_secs = 10        # how long a flagged connection is held (warn if > 60)
+# max_concurrent = 128  # hard ceiling; over → shed to immediate 403.
+#                       # Clamped at load to 1/4 of the global connection pool
+#                       # so held connections can't pin admission.
 
 [tls]
 cert_path = "/etc/ssl/zion/tls.crt"


### PR DESCRIPTION
Closes #151. Closes the anti-DDoS enforcement arc: **#147** (sovereign tag) → **#155** (per-IP conn cap) → **#150** (tag-driven enforce) → **#151** (tarpit).

## What

When tag-driven enforcement (#150) decides to **deny** a request (origin class on the deny list, or AIMP mesh score over threshold), the operator can now escalate the cheap `403` into a bounded **held** connection: the flagged source is parked `hold_secs` before the refusal, so a backed flood pays wall-clock + socket budget instead of an instantly-recyclable reject. Off by default; the request is still denied — the tarpit only changes *how long* the flagged client waits.

- **`src/tarpit.rs`** — global-ceiling limiter: CAS admission + RAII guard, decoupled from `METRICS` so the core is unit-tested against local atomics (+ a concurrency stress test that locks the "never exceed the ceiling" invariant under contention).
- **Config** `[sovereign.enforce.tarpit]` — `enabled` (default `false`), `hold_secs` (default `10`), `max_concurrent` (default `128`). Resolved into `EnforcePolicy`; wired at both enforce deny points (class + mesh-score). Only active when `[sovereign.enforce] enabled = true`; geo-gated.
- **Bounded / sheds** — at the ceiling the tarpit sheds back to the immediate `403`, so it can't become a self-inflicted sink.
- **Metrics** — `zion_tarpit_active` (gauge), `zion_tarpit_total`, `zion_tarpit_shed_total`, `zion_tarpit_held_ms_total` (counters).

## Self-DoS hardening (from an adversarial review pass)

A held request keeps its **global connection permit + per-IP slot** for the whole hold, so the ceiling can't be unbounded relative to the pool:
- `max_concurrent` is **clamped at config-load to ¼ of the global connection ceiling** (with a warn), and the default (128) stays comfortably under that on any box size.
- Config-load **warns** on `max_concurrent = 0` (no-op) and `hold_secs > 60` (over-long holds tie up connections / slow shutdown drain).
- The "never a self-inflicted sink" doc claim was corrected to be accurate.

## Deferred (documented in CHANGELOG)

- Per-byte **slow header/body drip** (the bounded delayed-hold already imposes the cost; streaming-body trickle is a follow-up).
- Tarpit on the plain `429` **rate-limit path** (this PR scopes to the `[sovereign.enforce]` deny points).
- **Per-IP tarpit sub-cap** — the ceiling is global and on HTTP/2 each held *stream* takes a slot, so one source (a few H2 conns) can occupy a large share of the holding capacity. This degrades the tarpit's *effectiveness* but **not** zion's stability (shed fallback = the safe pre-tarpit behaviour; global / per-IP conn caps still bound sockets). A per-IP sub-cap is a follow-up.

## Verification

- `cargo clippy --features geo-eu,sovereign-aimp --all-targets -- -D warnings` — clean
- `cargo test` (default) and `cargo test --features geo-eu,sovereign-aimp` — green (incl. tarpit limiter unit tests, the contention stress test, the `tarpit_resolves_*` config test, and the deterministic `tarpit_wiring_holds_and_sheds` async test)
- `cargo fmt` clean; README stats synced (587 tests / 40 modules)

🤖 Generated with [Claude Code](https://claude.com/claude-code)