### PR TITLE
feat(uring): io_uring read/write data path — IoUringStream (#51, ADR-0009)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ All notable changes to Zion Edge Gateway are documented here.
 
 ### Added
 
+- **io_uring read/write data path** (`--features io-uring-rw`, Linux 5.19+; #51,
+  ADR-0009, [`src/uring_rw.rs`](src/uring_rw.rs), [`src/rwstream.rs`](src/rwstream.rs)).
+  The accepted TLS connection's read/write half runs over a dedicated io_uring
+  driver thread + owned-buffer slab (`IoUringStream`, a completion→poll bridge
+  implementing tokio `AsyncRead`/`AsyncWrite`), selected once at accept via
+  `RwStream::{Uring,Tcp}` behind a runtime kernel gate, with a transparent
+  fallback to the tokio path; rustls's vectored writes are gathered into one
+  `Send`. **Off by default and not yet default-on** — the double memcpy
+  (kernel↔slab↔caller) over rustls's small records may not pay off, so the
+  feature stays opt-in pending the throughput/syscall **bench gate** (ADR-0009).
+  `tokio-uring` was ruled out (`!Send` runtime + no `AsyncRead`/`AsyncWrite`).
+  Verified on a 6.17 kernel: a real rustls handshake + round-trip over the
+  io_uring stream, EOF/RST/drop-with-inflight (UAF-proof slot reclaim), and
+  concurrent-connection echo. Follow-ups: write-backpressure tuning, the bench
+  gate, then optionally fixed buffers / sharding.
 - **L7 tarpit / slow-drip for flagged sources** (#151,
   [`src/tarpit.rs`](src/tarpit.rs)). Closes the anti-DDoS enforcement arc
   (#147 → #155 → #150 → #151). When tag-driven enforcement (#150) decides to

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5437,6 +5437,7 @@ dependencies = [
  "dashmap 6.1.0",
  "fastrand",
  "fnv",
+ "futures-util",
  "h3",
  "h3-quinn",
  "http-body-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,6 +135,9 @@ tracing-opentelemetry = { version = "0.33", default-features = false, optional =
 [target.'cfg(target_os = "linux")'.dependencies]
 libc = "0.2"
 io-uring = { version = "0.7", optional = true }
+# AtomicWaker for the io_uring rw driver <-> task wakeups (issue #51,
+# ADR-0009). Only `task::AtomicWaker` is used; keep the dep minimal.
+futures-util = { version = "0.3", default-features = false, features = ["std"], optional = true }
 # XDP / eBPF userspace loader (Track A — `--features xdp`).
 # Aya is pure-Rust (no libbpf C dep) and ships its own BTF loader.
 aya = { version = "0.13", optional = true }
@@ -196,7 +199,7 @@ io-uring-accept = ["io-uring"]
 # capability probe and the kernel-version structured log line. The
 # listener supervisor keeps using tokio's `AsyncReadExt` /
 # `AsyncWriteExt` — no behavioural change at runtime.
-io-uring-rw = ["io-uring-accept"]
+io-uring-rw = ["io-uring-accept", "futures-util"]
 acme = ["instant-acme", "rcgen", "base64"]
 auth = ["jsonwebtoken", "reqwest"]
 http3 = ["quinn", "h3", "h3-quinn"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -264,6 +264,9 @@ sovereign-aimp = ["sovereign-signals", "dep:aimp_node", "dep:rmp-serde"]
 # Track C — property-based testing (proptest) only used by `cargo test`.
 [dev-dependencies]
 proptest = { version = "1", default-features = false, features = ["std"] }
+# Self-signed certs for the in-process TLS-handshake test over RwStream
+# (issue #51 increment 4, ADR-0009). Test-only.
+rcgen = "0.14"
 # Criterion microbench harness (issue #54). Pinned to 0.5; the `html_reports`
 # default feature is dropped — we publish a JSON baseline (target/criterion/
 # *.json) and the GitHub Actions runner has no browser to render HTML in.

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Reproduce: `bash benchmarks/bench-scientific.sh`.
 **v0.2.x Tracks (feature-gated, default-off)**
 - **XDP pre-filter** (`--features xdp`, Linux): eBPF LPM-trie drop at the NIC driver layer. Blocked source IPs never reach the userspace TLS handshake — frees CPU for legitimate traffic and keeps the WAF gate cheap.
 - **kTLS post-handshake offload** (`--features ktls`, Linux 5.10+ with `CONFIG_TLS=y`): once the rustls handshake completes the socket is flipped into in-kernel TLS via `SOL_TLS`. Removes the userspace AEAD trip and unlocks `sendfile`-class zero-copy for static cache hits. Handshake cipher must be TLS 1.3 AES-GCM or ChaCha20-Poly1305. Falls back to userspace TLS on upgrade failure.
+- **io_uring read/write** (`--features io-uring-rw`, Linux 5.19+): the accepted TLS connection's read/write half runs over a dedicated io_uring driver (`IoUringStream`, completion→poll bridge) instead of epoll, behind a runtime kernel gate with a transparent fallback to the tokio path. **Experimental, off by default** — kept opt-in pending the throughput/syscall bench gate (ADR-0009).
 - **ML-augmented WAF** (`--features ml-waf`): 16-dim feature extractor + tract-onnx scorer on the WAF hot path, 200µs p99 budget. The score is reported as a metric and travels into the request as a header — never a hard gate; the local Aho-Corasick + entropy gate stays authoritative.
 - **AIMP serverless mesh** (`--features sovereign-aimp`): Ed25519-signed UDP gossip of WAF rule deltas + IP-reputation across a fleet, source-bound revocation, replay LRU, ts-window admission, last-writer-wins merge, periodic anti-entropy. No central control plane — each node keeps serving with its last known map when the mesh partitions. Configure under `[sovereign_aimp]` in `zion.toml` (or via `ZION_AIMP_*` env vars for back-compat).
 
@@ -312,7 +313,7 @@ Client -> TLS 1.3 -> Security Gates -> Radix Router -> WAF Pipeline (5 gates) ->
 ```
 
 <!-- zion-stats:modules-lines (kept in sync by scripts/update-readme-stats.sh) -->
-40 modules, ~27,700 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
+42 modules, ~28,900 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
 
 ## Benchmarking
 
@@ -338,7 +339,7 @@ Results saved to `benchmarks/bench-history.json` with automatic delta comparison
 ## Testing
 
 ```bash
-# Unit tests (587) <!-- zion-stats:test-count (kept in sync by scripts/update-readme-stats.sh) -->
+# Unit tests (588) <!-- zion-stats:test-count (kept in sync by scripts/update-readme-stats.sh) -->
 cargo test
 
 # Integration tests (23 -- requires running Zion + backend)

--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ Client -> TLS 1.3 -> Security Gates -> Radix Router -> WAF Pipeline (5 gates) ->
 ```
 
 <!-- zion-stats:modules-lines (kept in sync by scripts/update-readme-stats.sh) -->
-42 modules, ~28,900 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
+42 modules, ~29,000 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
 
 ## Benchmarking
 

--- a/docs/adr/0009-io-uring-rw-stream.md
+++ b/docs/adr/0009-io-uring-rw-stream.md
@@ -1,0 +1,204 @@
+# ADR-0009: IoUringStream — io_uring read/write data path (issue #51)
+
+- **Status**: accepted
+- **Date**: 2026-06-15
+- **Tags**: io_uring, performance, async, unsafe, linux, v0.2
+
+## Context
+
+`src/uring.rs` uses io_uring today only for **multishot accept**; the
+read/write half of every accepted connection still flows through tokio's
+epoll-based `AsyncRead`/`AsyncWrite`. Issue #51 asks to move the rw path to
+io_uring (vectored, behind the existing `io-uring-rw` feature) to cut
+syscalls on large transfers. The rw data path was *deliberately deferred*
+(`uring.rs:211` — "careful tokio-reactor integration, don't ship
+half-baked"). This ADR is that careful design, produced before any unsafe
+code and hardened by an adversarial review.
+
+The connection stack is fixed by the existing code: an accepted socket →
+`rustls` `TlsStream` → `hyper_util` `TokioIo` → `serve_connection_with_upgrades`
+(`src/main.rs:1652-1730`). So the new stream must implement tokio
+`AsyncRead + AsyncWrite + Unpin + Send + 'static` and slot **under** rustls
+in place of the raw `TcpStream`.
+
+**The core impedance mismatch.** io_uring is *completion-based*: the kernel
+owns a buffer from SQE-submit until the CQE arrives. tokio's traits are
+*poll-based* with a **borrowed** `ReadBuf`/`&[u8]` that hyper may drop or
+reuse the instant `poll_read` returns `Pending`. You cannot hand a borrowed
+buffer to the kernel: if the connection future is dropped while a `Recv` SQE
+is in flight, the kernel writes into freed memory (use-after-free). The
+buffer must be owned by something that outlives the SQE.
+
+**tokio-uring is ruled out** (two independent fatal blockers, verified):
+1. *Runtime incompatibility* — tokio-uring 0.5 is a `!Send`/`!Sync`
+   thread-per-core current-thread runtime; zion runs one shared
+   `multi_thread` runtime (`main.rs:721`) and moves each connection into a
+   `Send`-bounded `tokio::spawn` (`main.rs:1635`). Its `start()`/`block_on`
+   builds a nested current-thread runtime → panics "Cannot start a runtime
+   from within a runtime" on a worker.
+2. *No async traits* — the shipped `tokio_uring::net::TcpStream` implements
+   only `AsRawFd`/`FromRawFd`, **not** `AsyncRead`/`AsyncWrite`
+   (tokio-uring#188, open since 2022). Its owned-buffer `BufResult` API is
+   borrow-incompatible by design.
+
+So the only path that fits zion's stack is a hand-rolled stream over the
+low-level `io-uring` crate (already a dep, 0.7.12) with a custom driver.
+
+## Decision
+
+Implement **Candidate A: a single shared io_uring driver thread + an
+owned-buffer slab**, behind `io-uring-rw`, with a concrete-enum runtime
+fallback. New module `src/uring_rw.rs`, gated
+`cfg(all(target_os = "linux", feature = "io-uring-rw"))`.
+
+### Shape
+
+- **One dedicated driver thread** owns ONE `io_uring` (separate from the
+  accept ring) and a `Slab<ConnState>` keyed by a `u32` slot. It is the
+  *sole owner* of all ring state and all per-connection buffers. It parks in
+  `submit_and_wait(1)` and, on each wake, drains the **entire** completion
+  queue and the **entire** command channel before re-parking.
+- **`IoUringStream`** (the `Send + Unpin + 'static` handle) holds only an
+  `Arc<Shared>` + its slot id + a generation tag. All `!Send` ring state
+  stays on the driver thread, so the handle slots cleanly under rustls and
+  into `tokio::spawn`.
+- **`ConnState`** (driver-owned): `read_buf`/`write_buf` (`Box<[u8]>`, 16 KiB
+  default, tunable), read/write state enums, a `futures::task::AtomicWaker`
+  per direction, fd, in-flight-op count, generation.
+
+### Buffer ownership (the safety core)
+
+The kernel **never** sees a caller-borrowed buffer.
+- `poll_read`: driver submits `Recv` into the driver-owned `read_buf`; on
+  completion the worker `memcpy`s the filled bytes into hyper's borrowed
+  `ReadBuf` **after** the CQE is reaped, then re-arms `Recv`.
+- `poll_write` / `poll_write_vectored`: gather the caller's slice(s) into the
+  driver-owned `write_buf` (one `memcpy`), submit one `Send`.
+
+This is the only `AsyncRead`/`AsyncWrite`-compatible shape over a completion
+engine and satisfies the `io-uring` `push()` contract (params valid until the
+matching CQE).
+
+### Cancellation / Drop (non-blocking, UAF-proof by construction)
+
+`IoUringStream::drop` sends `DriverCmd::Orphan(slot)` and returns immediately
+— **never blocks** (blocking a worker is unsound; futures can be leaked). The
+driver marks the slot `Orphaned`, best-effort `AsyncCancel`s in-flight ops,
+and reclaims the slab entry **only when the slot's in-flight-op count hits 0**
+(every CQE reaped). The slab keep-alive — not the cancel — is the safety net,
+so UAF is impossible whether or not `AsyncCancel` lands. The fd is closed by
+the driver after the final CQE.
+
+### Waker integration
+
+- **Completion → task:** each slot holds a `futures::task::AtomicWaker`;
+  `poll_*` register-then-recheck before returning `Pending`; the driver
+  writes the result with `Release` and calls `wake()`.
+- **New-command → driver:** a permanently-armed `PollAdd(self_eventfd, POLLIN)`
+  SQE; `cmd_tx.send()` is followed by an 8-byte `write(eventfd)` whose CQE
+  breaks `submit_and_wait`. Drain-everything-each-wake + AtomicWaker's
+  recheck close the lost-wakeup window.
+
+### Fallback (two layers, both already scaffolded)
+
+- *Compile-time:* all new code gated on `io-uring-rw`; on macOS / feature-off
+  the binding at `main.rs:1652-1654` stays the plain `TcpStream`/`CorkStream`.
+- *Runtime:* `enum RwStream { Uring(IoUringStream), Tcp(TcpStream) }`
+  implementing `AsyncRead+AsyncWrite+Unpin+Send` by delegation (NOT
+  `Box<dyn>` — the kTLS arms at `main.rs:1713-1725` are the template). Bind
+  `Uring` only when `Platform.has_io_uring_rw_kernel` (`bootstrap.rs`,
+  kernel ≥ 5.19); else `Tcp`.
+
+### Resolutions baked in from the adversarial stress pass (must-haves, v1)
+
+1. **`futures::task::AtomicWaker`**, not `tokio_util::sync::AtomicWaker`
+   (the latter does not exist; tokio's is `pub(crate)`). Add `futures-util`
+   as a direct dep gated under `io-uring-rw`. Pin with a signature test.
+2. **`poll_write_vectored` is a first-class override** — rustls drives the
+   inner IO vectored (tokio-rustls `write_vectored`, up to 64 `IoSlice`s);
+   the default would write only the first slice and serialize every TLS
+   flush, failing the <1% small-payload gate. Gather all slices into one
+   `write_buf` + one `Send`; use a bounded write_buf high-water for
+   backpressure, **not** strict per-`Send` serialization.
+3. **Single-writer ownership protocol**, not a blanket `unsafe impl Send`
+   over shared `ConnState`: the driver is the sole owner of buffers + state
+   enum; the worker touches only the `AtomicWaker` and atomic state/result
+   words (`Acquire` after the driver's `Release`), and reads `read_buf`
+   **only** after the Recv CQE is reaped. Loom-test the state-transition
+   ordering (increment 2 gate).
+4. **Mandatory per-slot generation counter** in `user_data` from increment 1
+   (`user_data = (slot:u32)<<32 | (gen:u16)<<16 | op_kind`). Stale CQE
+   (gen mismatch) → decrement in-flight count to allow free, then discard.
+   Prevents slot-reuse aliasing.
+5. **Driver-thread death = `abort()` the process** (loud). Unlike the accept
+   thread (which only loses accepts), a dead rw-driver while SQEs reference
+   slab buffers is a memory-safety hazard, not a degraded-service one.
+6. **No epoll+uring double-registration:** the accept path's
+   `TcpStream::from_std` (`uring.rs:152`) registers the fd with tokio's
+   epoll. The rw path must lift the raw fd (a from_std-free accept variant,
+   or `into_std()` after `tune_accepted`) before handing it to the driver.
+7. **Full-duplex is a first-class test:** HTTP/2 reads and writes are
+   concurrent on one connection; a `Recv` re-arm must never be gated on a
+   pending `Send`. Add a concurrent up+down stress test + a WebSocket echo.
+8. **Bounded memory:** `active_conns × ~32 KiB` (16 KiB read + write).
+   Reconcile with `conn_limit` / per-IP caps before flipping the seam on;
+   expose held-buffer count on `/metrics` (the parked-Recv-on-Drop case can
+   pin a buffer for the connection lifetime).
+
+### Increments (ordered, each independently testable on the Linux box)
+
+1. **Skeleton driver + echo** (no rustls/hyper): driver thread + slab +
+   self-eventfd + cmd channel; `poll_read`/`poll_write`/`Drop` with the
+   owned-buffer + AtomicWaker + Orphan model (`Recv`/`Send` only). Test:
+   `socketpair` echo 1 MiB both ways via `tokio::io::copy`, byte-exact.
+   Compiles cfg-stripped on macOS; `cargo test` green.
+2. **EOF / error / reset / drop-with-inflight correctness** + Loom test of
+   the state-transition ordering; ASan/Valgrind run on the box for the
+   drop-with-inflight-Recv case (no UAF/double-free).
+3. **`RwStream` enum + runtime gating** off `has_io_uring_rw_kernel`.
+4. **Slot under rustls** (no hyper): real `tokio_rustls` accept over
+   `RwStream::Uring` on loopback; handshake + plaintext round-trip.
+5. **Wire the seam** at `main.rs:1652-1654` (fd lifted without
+   double-registration); end-to-end HTTPS over io_uring rw (curl + small
+   wrk). Full-duplex H2 + WebSocket stress.
+6. **Write backpressure + re-arm tuning** (bounded high-water; slow-consumer
+   test — no deadlock, bounded memory).
+7. *(deferred, post-bench)* Fixed/registered buffers if the copy is the
+   bottleneck.
+8. *(deferred)* Sharding (candidate C) only if the single ring caps
+   throughput on the e2e rig.
+
+### Verification gate
+
+Bench on the e2e rig (bare metal, not the nested-virt dev box): baseline
+(no feature) vs candidate. **Pass = (a) measurable io_uring/read/write
+syscall-count drop on 1 MiB & 10 MiB transfers, AND (b) <1% regression on
+1 KiB req/s & p99.** If small-payload regresses >1% or no syscall drop
+materializes, **do not wire the seam on by default** — keep it opt-in and
+pursue increment 7 / candidate C first. The mandatory double `memcpy`
+(kernel↔slab↔caller) on top of rustls's own copies is the central
+unvalidated hypothesis of #51; the gate decides.
+
+## Consequences
+
+- **Pro:** a `Send+Unpin+'static` stream that fits zion's existing
+  multi-thread + rustls + hyper stack untouched; reuses the proven
+  dedicated-driver-thread pattern; correctness (UAF-proof buffers,
+  lost-wakeup-proof wakeups) established by design + Loom/ASan before ship.
+- **Con / risk:** real unsafe surface; the single driver ring is a potential
+  throughput chokepoint (mitigation = deferred sharding); the extra copy may
+  not pay off at rustls's small-record granularity — hence the hard bench
+  gate before default-on.
+- **kTLS (#52) composition:** `ktls` depends on `io-uring-rw` per Cargo.toml,
+  but v1 keeps them **mutually exclusive per connection** (ktls takes the
+  connection, io_uring rw is not used). Documented so the dependency edge
+  isn't read as "they work together on one connection" yet.
+
+## Alternatives considered
+
+- **tokio-uring** — rejected (runtime `!Send` + nested-runtime panic; no
+  `AsyncRead`/`AsyncWrite`, tokio-uring#188). See Context.
+- **Sharded multi-ring (candidate C)** — the right end-state for scale, but a
+  scale-out of A; deferred until the single-ring path is proven correct *and*
+  beneficial on the rig (must not precede the perf validation that is the
+  entire point of #51).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -20,6 +20,7 @@ defined in [0000-template.md](0000-template.md).
 | 0006  | [`tracing` always-on, OTLP gated by `--features otel`](0006-tracing-with-optional-otlp.md) | accepted |
 | 0007  | [Two-tier MSRV — 1.82 core, 1.88 with optional features](0007-bicapa-msrv.md) | accepted |
 | 0008  | [Embed AIMP as the mesh control-plane bus](0008-mesh-aimp-integration.md) | accepted |
+| 0009  | [IoUringStream — io_uring read/write data path](0009-io-uring-rw-stream.md) | accepted |
 
 ## When to write a new ADR
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,10 +75,10 @@ mod tui;
 // `io-uring-rw` capability probe (issue #51) and its tests stay
 // reachable even when `io-uring-accept` is off, and on non-Linux the
 // probe degrades to "always returns false".
+mod rwstream;
 mod uring;
 #[cfg(all(target_os = "linux", feature = "io-uring-rw"))]
 mod uring_rw;
-mod rwstream;
 mod waf;
 
 // ── Beyond-FAANG tracks (experimental, feature-gated) ─────────────────

--- a/src/main.rs
+++ b/src/main.rs
@@ -1651,9 +1651,23 @@ fn spawn_https_handler(
         // `CorkStream<TcpStream>` adapter (ktls 6.x API). Wrap up-front
         // when the feature is on; the cfg-gated branch costs nothing
         // when compiled without it.
+        // kTLS present → kTLS cork path; io_uring rw is NOT used on this
+        // connection (mutually exclusive in v1, ADR-0009).
         #[cfg(all(target_os = "linux", feature = "ktls"))]
         let inner_for_handshake = crate::ktls::cork_for_handshake(tcp_stream);
-        #[cfg(not(all(target_os = "linux", feature = "ktls")))]
+        // io-uring-rw present (and not kTLS) → io_uring stream when the kernel
+        // supports it, else tokio. `from_accepted` lifts the fd out of epoll
+        // into the driver (no double-registration); `None` → drop the conn (#51).
+        #[cfg(all(target_os = "linux", feature = "io-uring-rw", not(feature = "ktls")))]
+        let inner_for_handshake = match crate::rwstream::from_accepted(tcp_stream) {
+            Some(s) => s,
+            None => return,
+        };
+        // Neither → the portable tokio path (unchanged behaviour).
+        #[cfg(not(any(
+            all(target_os = "linux", feature = "ktls"),
+            all(target_os = "linux", feature = "io-uring-rw")
+        )))]
         let inner_for_handshake = tcp_stream;
 
         let tls_start = std::time::Instant::now();

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,6 +76,8 @@ mod tui;
 // reachable even when `io-uring-accept` is off, and on non-Linux the
 // probe degrades to "always returns false".
 mod uring;
+#[cfg(all(target_os = "linux", feature = "io-uring-rw"))]
+mod uring_rw;
 mod waf;
 
 // ── Beyond-FAANG tracks (experimental, feature-gated) ─────────────────

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,6 +78,7 @@ mod tui;
 mod uring;
 #[cfg(all(target_os = "linux", feature = "io-uring-rw"))]
 mod uring_rw;
+mod rwstream;
 mod waf;
 
 // ── Beyond-FAANG tracks (experimental, feature-gated) ─────────────────

--- a/src/rwstream.rs
+++ b/src/rwstream.rs
@@ -13,9 +13,13 @@
 //! serve-path seam that constructs it (lifting the accepted fd into the
 //! driver) lands in increment 5; until then this is exercised only by tests.
 
-// Interim until the seam is wired (increment 5, ADR-0009): the enum is
-// constructed only by tests for now.
-#![allow(dead_code)]
+// RwStream is constructed by the serve seam only on `linux + io-uring-rw`; on
+// every other build (macOS, default, etc.) it is unused, so allow dead_code
+// there only — `linux + io-uring-rw` keeps full dead-code checking.
+#![cfg_attr(
+    not(all(target_os = "linux", feature = "io-uring-rw")),
+    allow(dead_code)
+)]
 
 use std::io;
 use std::pin::Pin;
@@ -136,6 +140,31 @@ pub fn driver() -> Option<&'static std::sync::Arc<crate::uring_rw::Shared>> {
             }
         })
         .as_ref()
+}
+
+/// Build the connection transport from a freshly-accepted tokio `TcpStream`,
+/// choosing the io_uring path when active. Lifts the fd out of tokio's epoll
+/// reactor into the driver (avoids epoll+io_uring double-registration on the
+/// same fd); falls back to `Tcp` when io_uring is inactive or the driver slab
+/// is full. `None` only on a (practically impossible) fd-conversion error, in
+/// which case the caller drops the connection.
+#[cfg(all(target_os = "linux", feature = "io-uring-rw"))]
+pub fn from_accepted(tcp: TcpStream) -> Option<RwStream> {
+    use std::os::fd::{FromRawFd, IntoRawFd};
+    if !io_uring_rw_active() {
+        return Some(RwStream::Tcp(tcp));
+    }
+    // into_std() deregisters the fd from tokio's epoll reactor; into_raw_fd()
+    // hands ownership to the driver (which closes it on reclaim).
+    let std_stream = tcp.into_std().ok()?;
+    let fd = std_stream.into_raw_fd();
+    if let Some(s) = driver().and_then(|d| d.register(fd)) {
+        return Some(RwStream::Uring(s));
+    }
+    // Driver slab full → give the fd back to tokio (register left it untouched).
+    // SAFETY: we own `fd` — a valid, connected, nonblocking socket.
+    let reclaimed = unsafe { std::net::TcpStream::from_raw_fd(fd) };
+    Some(RwStream::Tcp(TcpStream::from_std(reclaimed).ok()?))
 }
 
 #[cfg(test)]

--- a/src/rwstream.rs
+++ b/src/rwstream.rs
@@ -214,4 +214,70 @@ mod tests {
         assert!(got == data, "uring arm read mismatch");
         w.await.unwrap();
     }
+
+    // Increment 4: a real rustls handshake + round-trip with the SERVER side
+    // running over RwStream::Uring. Proves the AsyncRead/AsyncWrite impl
+    // satisfies tokio_rustls's bounds AND works under rustls's real I/O
+    // pattern (many small reads + vectored writes) — before the serve seam.
+    #[cfg(all(target_os = "linux", feature = "io-uring-rw"))]
+    #[tokio::test]
+    async fn rustls_handshake_and_roundtrip_over_uring() {
+        use std::os::fd::FromRawFd;
+        use std::sync::Arc;
+
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
+        // Self-signed cert for "localhost".
+        let ck = rcgen::generate_simple_self_signed(vec!["localhost".to_string()]).unwrap();
+        let cert_der = ck.cert.der().clone();
+        let key_der = rustls::pki_types::PrivatePkcs8KeyDer::from(ck.signing_key.serialize_der());
+
+        let server_cfg = rustls::ServerConfig::builder()
+            .with_no_client_auth()
+            .with_single_cert(vec![cert_der.clone()], key_der.into())
+            .unwrap();
+        let acceptor = tokio_rustls::TlsAcceptor::from(Arc::new(server_cfg));
+
+        let mut roots = rustls::RootCertStore::empty();
+        roots.add(cert_der).unwrap();
+        let client_cfg = rustls::ClientConfig::builder()
+            .with_root_certificates(roots)
+            .with_no_client_auth();
+        let connector = tokio_rustls::TlsConnector::from(Arc::new(client_cfg));
+
+        // Transport: socketpair; server end through the io_uring driver, client
+        // end a plain tokio stream.
+        let drv = driver().expect("io_uring rw driver");
+        let mut fds = [0 as libc::c_int; 2];
+        assert_eq!(
+            unsafe { libc::socketpair(libc::AF_UNIX, libc::SOCK_STREAM, 0, fds.as_mut_ptr()) },
+            0
+        );
+        let server_io = RwStream::Uring(drv.register(fds[0]).expect("register"));
+        let client_std = unsafe { std::os::unix::net::UnixStream::from_raw_fd(fds[1]) };
+        client_std.set_nonblocking(true).unwrap();
+        let client_io = tokio::net::UnixStream::from_std(client_std).unwrap();
+
+        // Server: accept TLS over the io_uring stream, echo a small message.
+        let srv = tokio::spawn(async move {
+            let mut tls = acceptor.accept(server_io).await.expect("server handshake");
+            let mut buf = [0u8; 5];
+            tls.read_exact(&mut buf).await.unwrap();
+            assert_eq!(&buf, b"PING!");
+            tls.write_all(b"PONG!").await.unwrap();
+            tls.flush().await.unwrap();
+        });
+
+        let name = rustls::pki_types::ServerName::try_from("localhost").unwrap();
+        let mut tls = connector
+            .connect(name, client_io)
+            .await
+            .expect("client handshake");
+        tls.write_all(b"PING!").await.unwrap();
+        tls.flush().await.unwrap();
+        let mut resp = [0u8; 5];
+        tls.read_exact(&mut resp).await.unwrap();
+        assert_eq!(&resp, b"PONG!");
+        srv.await.unwrap();
+    }
 }

--- a/src/rwstream.rs
+++ b/src/rwstream.rs
@@ -9,9 +9,10 @@
 //! today. The `Uring` arm only exists on `linux + io-uring-rw`; everywhere
 //! else `RwStream` is just the `Tcp` arm.
 //!
-//! Increment 3 (ADR-0009): the enum + delegation + the runtime gate. The
-//! serve-path seam that constructs it (lifting the accepted fd into the
-//! driver) lands in increment 5; until then this is exercised only by tests.
+//! The serve seam (`spawn_https_handler`) constructs it via [`from_accepted`],
+//! which lifts the accepted fd out of tokio's epoll reactor into the io_uring
+//! driver when the kernel supports it, otherwise binds the `Tcp` arm
+//! (ADR-0009).
 
 // RwStream is constructed by the serve seam only on `linux + io-uring-rw`; on
 // every other build (macOS, default, etc.) it is unused, so allow dead_code

--- a/src/rwstream.rs
+++ b/src/rwstream.rs
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: Apache-2.0
+//! `RwStream` — the connection byte transport: io_uring when the kernel
+//! supports it, tokio `TcpStream` otherwise (issue #51, ADR-0009).
+//!
+//! A *concrete enum* (not `Box<dyn>`) so the serve path stays monomorphic and
+//! the runtime io_uring-vs-tokio choice is a single branch made once at
+//! accept. It implements tokio `AsyncRead`/`AsyncWrite` by delegating to the
+//! active arm, so it slots under rustls exactly where the raw `TcpStream` does
+//! today. The `Uring` arm only exists on `linux + io-uring-rw`; everywhere
+//! else `RwStream` is just the `Tcp` arm.
+//!
+//! Increment 3 (ADR-0009): the enum + delegation + the runtime gate. The
+//! serve-path seam that constructs it (lifting the accepted fd into the
+//! driver) lands in increment 5; until then this is exercised only by tests.
+
+// Interim until the seam is wired (increment 5, ADR-0009): the enum is
+// constructed only by tests for now.
+#![allow(dead_code)]
+
+use std::io;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio::net::TcpStream;
+
+/// Per-connection byte transport. `Send + Unpin + 'static` (both arms are), so
+/// it drops in under `rustls` + `hyper_util::TokioIo` unchanged.
+pub enum RwStream {
+    /// The portable path: tokio's epoll-backed `TcpStream`.
+    Tcp(TcpStream),
+    /// The io_uring path (`linux + io-uring-rw`, kernel >= 5.19).
+    #[cfg(all(target_os = "linux", feature = "io-uring-rw"))]
+    Uring(crate::uring_rw::IoUringStream),
+}
+
+impl AsyncRead for RwStream {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        match self.get_mut() {
+            RwStream::Tcp(s) => Pin::new(s).poll_read(cx, buf),
+            #[cfg(all(target_os = "linux", feature = "io-uring-rw"))]
+            RwStream::Uring(s) => Pin::new(s).poll_read(cx, buf),
+        }
+    }
+}
+
+impl AsyncWrite for RwStream {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        match self.get_mut() {
+            RwStream::Tcp(s) => Pin::new(s).poll_write(cx, buf),
+            #[cfg(all(target_os = "linux", feature = "io-uring-rw"))]
+            RwStream::Uring(s) => Pin::new(s).poll_write(cx, buf),
+        }
+    }
+
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &[io::IoSlice<'_>],
+    ) -> Poll<io::Result<usize>> {
+        match self.get_mut() {
+            RwStream::Tcp(s) => Pin::new(s).poll_write_vectored(cx, bufs),
+            #[cfg(all(target_os = "linux", feature = "io-uring-rw"))]
+            RwStream::Uring(s) => Pin::new(s).poll_write_vectored(cx, bufs),
+        }
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        match self {
+            RwStream::Tcp(s) => s.is_write_vectored(),
+            #[cfg(all(target_os = "linux", feature = "io-uring-rw"))]
+            RwStream::Uring(s) => s.is_write_vectored(),
+        }
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        match self.get_mut() {
+            RwStream::Tcp(s) => Pin::new(s).poll_flush(cx),
+            #[cfg(all(target_os = "linux", feature = "io-uring-rw"))]
+            RwStream::Uring(s) => Pin::new(s).poll_flush(cx),
+        }
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        match self.get_mut() {
+            RwStream::Tcp(s) => Pin::new(s).poll_shutdown(cx),
+            #[cfg(all(target_os = "linux", feature = "io-uring-rw"))]
+            RwStream::Uring(s) => Pin::new(s).poll_shutdown(cx),
+        }
+    }
+}
+
+/// Runtime gate: whether the io_uring rw path should be used. `false` unless
+/// built `linux + io-uring-rw` AND the kernel is recent enough (>= 5.19, the
+/// `probe_io_uring_rw_supported` check). The serve seam (increment 5) calls
+/// this once per accept to pick the `RwStream` arm.
+pub fn io_uring_rw_active() -> bool {
+    #[cfg(all(target_os = "linux", feature = "io-uring-rw"))]
+    {
+        crate::uring::probe_io_uring_rw_supported() && driver().is_some()
+    }
+    #[cfg(not(all(target_os = "linux", feature = "io-uring-rw")))]
+    {
+        false
+    }
+}
+
+/// Lazily-started global rw driver. `None` if the kernel doesn't support the
+/// rw path or the ring failed to init — callers fall back to `RwStream::Tcp`.
+/// One driver (one ring) for the whole process (ADR-0009).
+#[cfg(all(target_os = "linux", feature = "io-uring-rw"))]
+pub fn driver() -> Option<&'static std::sync::Arc<crate::uring_rw::Shared>> {
+    use std::sync::OnceLock;
+    static DRIVER: OnceLock<Option<std::sync::Arc<crate::uring_rw::Shared>>> = OnceLock::new();
+    DRIVER
+        .get_or_init(|| {
+            if !crate::uring::probe_io_uring_rw_supported() {
+                return None;
+            }
+            match crate::uring_rw::start() {
+                Ok(s) => Some(s),
+                Err(e) => {
+                    crate::logging::warn(
+                        "uring",
+                        &format!("io_uring rw driver init failed: {e}; falling back to tokio I/O"),
+                    );
+                    None
+                }
+            }
+        })
+        .as_ref()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    async fn loopback_pair() -> (TcpStream, TcpStream) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (client, accepted) = tokio::join!(TcpStream::connect(addr), listener.accept());
+        (client.unwrap(), accepted.unwrap().0)
+    }
+
+    fn payload(n: usize) -> Vec<u8> {
+        (0..n).map(|i| (i % 251) as u8).collect()
+    }
+
+    // The Tcp arm must behave exactly like a bare TcpStream (delegation is
+    // transparent). Runs on every OS — local verification of the enum.
+    #[tokio::test]
+    async fn tcp_arm_echo_both_directions() {
+        let (client, server) = loopback_pair().await;
+        let mut a = RwStream::Tcp(server);
+        let mut peer = client;
+        let data = payload(256 * 1024);
+
+        // peer -> a
+        let d2 = data.clone();
+        let w = tokio::spawn(async move {
+            peer.write_all(&d2).await.unwrap();
+            peer.shutdown().await.unwrap();
+            peer
+        });
+        let mut got = Vec::new();
+        a.read_to_end(&mut got).await.unwrap();
+        assert!(got == data, "tcp arm read mismatch");
+        let mut peer = w.await.unwrap();
+
+        // a -> peer
+        let d3 = data.clone();
+        let w2 = tokio::spawn(async move {
+            a.write_all(&d3).await.unwrap();
+            a.shutdown().await.unwrap();
+        });
+        let mut got2 = Vec::new();
+        peer.read_to_end(&mut got2).await.unwrap();
+        assert!(got2 == data, "tcp arm write mismatch");
+        w2.await.unwrap();
+    }
+
+    // The Uring arm echoes byte-exact through the driver, exactly like the
+    // bare IoUringStream (increment 1) — proves the delegation is transparent.
+    #[cfg(all(target_os = "linux", feature = "io-uring-rw"))]
+    #[tokio::test]
+    async fn uring_arm_echo_read() {
+        use std::os::fd::FromRawFd;
+        let drv = driver().expect("io_uring rw driver (kernel >= 5.19)");
+        // socketpair: one end into the driver, the other a tokio peer.
+        let mut fds = [0 as libc::c_int; 2];
+        let rc = unsafe { libc::socketpair(libc::AF_UNIX, libc::SOCK_STREAM, 0, fds.as_mut_ptr()) };
+        assert_eq!(rc, 0);
+        let mut a = RwStream::Uring(drv.register(fds[0]).expect("register"));
+        let peer_std = unsafe { std::os::unix::net::UnixStream::from_raw_fd(fds[1]) };
+        peer_std.set_nonblocking(true).unwrap();
+        let mut peer = tokio::net::UnixStream::from_std(peer_std).unwrap();
+        let data = payload(512 * 1024);
+
+        let d2 = data.clone();
+        let w = tokio::spawn(async move {
+            peer.write_all(&d2).await.unwrap();
+            peer.shutdown().await.unwrap();
+        });
+        let mut got = Vec::new();
+        a.read_to_end(&mut got).await.unwrap();
+        assert!(got == data, "uring arm read mismatch");
+        w.await.unwrap();
+    }
+}

--- a/src/uring_rw.rs
+++ b/src/uring_rw.rs
@@ -30,6 +30,11 @@
 //! in-flight-op count reaches 0, so a dropped stream with a `Recv`/`Send`
 //! still in flight can never use-after-free.
 
+// Interim: until the serve-path seam is wired (increment 5, ADR-0009), every
+// item here is exercised only by the in-module tests, so a non-test build
+// sees them as dead. Lifted when `spawn_https_handler` constructs the stream.
+#![allow(dead_code)]
+
 use std::io;
 use std::os::fd::RawFd;
 use std::pin::Pin;

--- a/src/uring_rw.rs
+++ b/src/uring_rw.rs
@@ -1,0 +1,654 @@
+// SPDX-License-Identifier: Apache-2.0
+//! io_uring read/write data path — `IoUringStream` (issue #51, ADR-0009).
+//!
+//! Increment 1 (skeleton): a single dedicated driver thread owns ONE
+//! `io_uring` plus a slab of per-connection slots; `IoUringStream` is a
+//! `Send + Unpin + 'static` handle that implements tokio's
+//! `AsyncRead`/`AsyncWrite` by talking to that driver. This is the
+//! completion→poll bridge `uring.rs:211` deferred.
+//!
+//! ## Why this shape
+//! io_uring is completion-based (the kernel owns the buffer from SQE-submit
+//! until the CQE), tokio's traits are poll-based with a *borrowed* buffer
+//! that hyper may drop the instant `poll_read` returns `Pending`. So the
+//! kernel never sees a caller buffer: each slot owns a `read_buf`/`write_buf`
+//! and we `memcpy` across the poll boundary.
+//!
+//! ## v1 soundness model (writable without a local Linux compiler)
+//! Each slot's mutable state lives behind a `Mutex<SlotInner>`. The kernel
+//! writes into `read_buf` only while a `Recv` is in flight — a window during
+//! which NO Rust reference to that `Box<[u8]>` is live (we handed the raw
+//! pointer to the SQE and don't touch it; the `Box` heap address is stable
+//! and the slot is kept alive until every in-flight CQE is reaped). The lock
+//! only guards state transitions and the copy-out at `Ready`. The zero-lock
+//! atomic/`UnsafeCell` optimisation is a later increment, once this is proven
+//! correct (ADR-0009).
+//!
+//! ## Safety net on Drop
+//! `IoUringStream::drop` sends a non-blocking `Orphan` command and returns
+//! immediately. The driver frees the slot (and closes the fd) ONLY when its
+//! in-flight-op count reaches 0, so a dropped stream with a `Recv`/`Send`
+//! still in flight can never use-after-free.
+
+use std::io;
+use std::os::fd::RawFd;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll};
+
+use futures_util::task::AtomicWaker;
+use io_uring::{opcode, squeue, types, IoUring};
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
+
+/// io_uring submission/completion ring depth for the rw driver.
+const RING_DEPTH: u32 = 4096;
+/// Per-direction buffer size (one TLS-record-ish granularity). Tunable.
+const BUF_SIZE: usize = 16 * 1024;
+/// Max concurrently-registered connections on this single ring. Reconciled
+/// with `conn_limit` in a later increment (ADR-0009 §memory bound).
+const MAX_SLOTS: usize = 8192;
+
+// `user_data` layout: (slot:u32) << 32 | (gen:u16) << 16 | op_kind:u16.
+const OP_READ: u64 = 0;
+const OP_WRITE: u64 = 1;
+/// Reserved `user_data` for the self-eventfd interrupt poll.
+const UD_INTERRUPT: u64 = u64::MAX;
+
+#[inline]
+fn pack_ud(slot: u32, gen: u16, op: u64) -> u64 {
+    ((slot as u64) << 32) | ((gen as u64) << 16) | op
+}
+#[inline]
+fn unpack_ud(ud: u64) -> (u32, u16, u64) {
+    (((ud >> 32) & 0xFFFF_FFFF) as u32, ((ud >> 16) & 0xFFFF) as u16, ud & 0xFFFF)
+}
+
+/// Driver command from a handle (or its `Drop`) to the driver thread.
+enum DriverCmd {
+    /// Arm a `Recv` into the slot's read buffer.
+    ArmRead { slot: u32, gen: u16 },
+    /// Submit the bytes already staged in the slot's write buffer.
+    Write { slot: u32, gen: u16 },
+    /// The handle was dropped — orphan + reclaim the slot when safe.
+    Orphan { slot: u32, gen: u16 },
+}
+
+#[derive(Clone, Copy)]
+enum ReadState {
+    /// No read armed; a `poll_read` will request one.
+    Idle,
+    /// A `poll_read` requested an arm; the driver hasn't pushed the SQE yet.
+    Arming,
+    /// A `Recv` SQE is in flight; the kernel owns `read_buf`.
+    Submitted,
+    /// Data available in `read_buf[pos..filled]` to copy to the caller.
+    Ready { filled: usize, pos: usize },
+    /// Peer half-closed (Recv returned 0).
+    Eof,
+    /// Recv failed with this errno.
+    Err(i32),
+}
+
+#[derive(Clone, Copy)]
+enum WriteState {
+    /// No write in flight; `poll_write` may stage one.
+    Idle,
+    /// `write_buf[off..len]` still to be sent (a `Send` SQE is/will be in flight).
+    Submitted { off: usize, len: usize },
+    /// Send failed with this errno.
+    Err(i32),
+}
+
+/// Driver-owned per-slot state, guarded by the slot mutex.
+struct SlotInner {
+    fd: RawFd,
+    gen: u16,
+    in_use: bool,
+    orphaned: bool,
+    /// Count of in-flight SQEs (read + write) referencing this slot's buffers.
+    /// The slot is reclaimed only when this reaches 0.
+    inflight: u32,
+    read_buf: Box<[u8]>,
+    write_buf: Box<[u8]>,
+    read_state: ReadState,
+    write_state: WriteState,
+}
+
+impl SlotInner {
+    fn empty() -> Self {
+        Self {
+            fd: -1,
+            gen: 0,
+            in_use: false,
+            orphaned: false,
+            inflight: 0,
+            read_buf: Box::new([]),
+            write_buf: Box::new([]),
+            read_state: ReadState::Idle,
+            write_state: WriteState::Idle,
+        }
+    }
+}
+
+struct SlotShared {
+    read_waker: AtomicWaker,
+    write_waker: AtomicWaker,
+    inner: Mutex<SlotInner>,
+}
+
+/// Shared driver handle: connection registry + command channel. Cloned into
+/// every `IoUringStream`. `Send + Sync` (all fields are).
+pub struct Shared {
+    cmd_tx: UnboundedSender<DriverCmd>,
+    eventfd: RawFd,
+    slots: Box<[SlotShared]>,
+    free: Mutex<Vec<u32>>,
+}
+
+impl Shared {
+    #[inline]
+    fn kick(&self) {
+        // Wake the driver out of `submit_and_wait` by posting to the eventfd.
+        let one: u64 = 1;
+        // SAFETY: write 8 bytes of a u64 to a valid eventfd; EAGAIN is fine.
+        unsafe {
+            libc::write(self.eventfd, &one as *const u64 as *const libc::c_void, 8);
+        }
+    }
+
+    fn send(&self, cmd: DriverCmd) {
+        // Unbounded send never blocks; if the driver is gone the process is
+        // already aborting (driver death = abort, ADR-0009).
+        let _ = self.cmd_tx.send(cmd);
+        self.kick();
+    }
+
+    /// Register an accepted socket `fd` and return a stream handle, or `None`
+    /// if the slab is full (caller falls back to the tokio path). The handle
+    /// takes ownership of `fd` (closed by the driver on reclaim).
+    pub fn register(self: &Arc<Self>, fd: RawFd) -> Option<IoUringStream> {
+        let slot = self.free.lock().unwrap().pop()?;
+        let s = &self.slots[slot as usize];
+        let mut inner = s.inner.lock().unwrap();
+        inner.gen = inner.gen.wrapping_add(1);
+        inner.fd = fd;
+        inner.in_use = true;
+        inner.orphaned = false;
+        inner.inflight = 0;
+        inner.read_buf = vec![0u8; BUF_SIZE].into_boxed_slice();
+        inner.write_buf = vec![0u8; BUF_SIZE].into_boxed_slice();
+        inner.read_state = ReadState::Idle;
+        inner.write_state = WriteState::Idle;
+        let gen = inner.gen;
+        // Clear any stale waker registrations from the previous tenant.
+        s.read_waker.take();
+        s.write_waker.take();
+        drop(inner);
+        Some(IoUringStream { shared: self.clone(), slot, gen })
+    }
+}
+
+/// Start the rw driver: create the ring + eventfd + slab, spawn the driver
+/// thread, and return the shared handle. The driver runs for the process
+/// lifetime (ADR-0009: a driver panic aborts the process).
+pub fn start() -> io::Result<Arc<Shared>> {
+    let ring = IoUring::new(RING_DEPTH)?;
+    // SAFETY: eventfd(2) with valid flags; returns -1 on error.
+    let eventfd = unsafe { libc::eventfd(0, libc::EFD_NONBLOCK | libc::EFD_CLOEXEC) };
+    if eventfd < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let slots: Vec<SlotShared> = (0..MAX_SLOTS)
+        .map(|_| SlotShared {
+            read_waker: AtomicWaker::new(),
+            write_waker: AtomicWaker::new(),
+            inner: Mutex::new(SlotInner::empty()),
+        })
+        .collect();
+    let free: Vec<u32> = (0..MAX_SLOTS as u32).collect();
+    let (cmd_tx, cmd_rx) = unbounded_channel();
+    let shared = Arc::new(Shared {
+        cmd_tx,
+        eventfd,
+        slots: slots.into_boxed_slice(),
+        free: Mutex::new(free),
+    });
+    let driver_shared = shared.clone();
+    std::thread::Builder::new()
+        .name("io_uring-rw".into())
+        .spawn(move || driver_loop(ring, driver_shared, cmd_rx, eventfd))
+        .map_err(io::Error::other)?;
+    Ok(shared)
+}
+
+fn interrupt_entry(eventfd: RawFd) -> squeue::Entry {
+    opcode::PollAdd::new(types::Fd(eventfd), libc::POLLIN as u32)
+        .build()
+        .user_data(UD_INTERRUPT)
+}
+
+fn push_all(ring: &mut IoUring, entries: &[squeue::Entry]) {
+    for e in entries {
+        loop {
+            // SAFETY: each entry's referenced buffer/fd is kept valid until
+            // its CQE is reaped (slot keep-alive); push copies the SQE.
+            let pushed = unsafe { ring.submission().push(e) };
+            if pushed.is_ok() {
+                break;
+            }
+            // SQ full: flush to the kernel to free ring space, then retry.
+            if ring.submit().is_err() {
+                // Best effort; a failed submit here will surface on the next
+                // submit_and_wait. Drop out to avoid a busy loop.
+                break;
+            }
+        }
+    }
+}
+
+fn driver_loop(
+    mut ring: IoUring,
+    shared: Arc<Shared>,
+    mut rx: UnboundedReceiver<DriverCmd>,
+    eventfd: RawFd,
+) {
+    let mut intr_buf = [0u8; 8];
+    push_all(&mut ring, &[interrupt_entry(eventfd)]);
+    let _ = ring.submit();
+
+    loop {
+        match ring.submit_and_wait(1) {
+            Ok(_) => {}
+            Err(ref e) if e.raw_os_error() == Some(libc::EINTR) => continue,
+            Err(e) => {
+                eprintln!("io_uring-rw driver fatal submit_and_wait: {e}");
+                std::process::abort();
+            }
+        }
+
+        // 1) Drain completions (collect first so we don't hold the CQ borrow
+        // while locking slots).
+        let mut comps: Vec<(u64, i32)> = Vec::new();
+        {
+            let cq = ring.completion();
+            for cqe in cq {
+                comps.push((cqe.user_data(), cqe.result()));
+            }
+        }
+        let mut followups: Vec<squeue::Entry> = Vec::new();
+        let mut rearm_intr = false;
+        for (ud, res) in comps {
+            if ud == UD_INTERRUPT {
+                rearm_intr = true;
+                continue;
+            }
+            if let Some(e) = process_cqe(&shared, ud, res) {
+                followups.push(e);
+            }
+        }
+        if rearm_intr {
+            // Drain the eventfd counter and re-arm the poll.
+            // SAFETY: read up to 8 bytes into a valid stack buffer.
+            unsafe {
+                libc::read(eventfd, intr_buf.as_mut_ptr() as *mut libc::c_void, 8);
+            }
+            followups.push(interrupt_entry(eventfd));
+        }
+
+        // 2) Drain commands → SQEs.
+        while let Ok(cmd) = rx.try_recv() {
+            if let Some(e) = process_cmd(&shared, cmd) {
+                followups.push(e);
+            }
+        }
+
+        // 3) Submit everything.
+        push_all(&mut ring, &followups);
+        let _ = ring.submit();
+    }
+}
+
+/// Handle a completion. Returns an optional follow-up SQE (e.g. a partial
+/// `Send` remainder).
+fn process_cqe(shared: &Arc<Shared>, ud: u64, res: i32) -> Option<squeue::Entry> {
+    let (slot, gen, op) = unpack_ud(ud);
+    let s = &shared.slots[slot as usize];
+    let mut inner = s.inner.lock().unwrap();
+    if inner.gen != gen {
+        // Stale CQE for a previous tenant — should not happen (reclaim waits
+        // for inflight==0) but discard defensively without touching the new
+        // tenant's state.
+        return None;
+    }
+    inner.inflight = inner.inflight.saturating_sub(1);
+
+    let mut followup = None;
+    match op {
+        OP_READ => {
+            inner.read_state = if res < 0 {
+                ReadState::Err(-res)
+            } else if res == 0 {
+                ReadState::Eof
+            } else {
+                ReadState::Ready { filled: res as usize, pos: 0 }
+            };
+        }
+        OP_WRITE => {
+            if res < 0 {
+                inner.write_state = WriteState::Err(-res);
+            } else if let WriteState::Submitted { off, len } = inner.write_state {
+                let new_off = off + res as usize;
+                if new_off >= len {
+                    inner.write_state = WriteState::Idle;
+                } else {
+                    // Partial send: resubmit the remainder.
+                    inner.write_state = WriteState::Submitted { off: new_off, len };
+                    let fd = inner.fd;
+                    // SAFETY: write_buf is alive (slot kept alive) and new_off < len.
+                    let ptr = unsafe { inner.write_buf.as_ptr().add(new_off) };
+                    inner.inflight += 1;
+                    followup = Some(
+                        opcode::Send::new(types::Fd(fd), ptr, (len - new_off) as u32)
+                            .build()
+                            .user_data(pack_ud(slot, gen, OP_WRITE)),
+                    );
+                }
+            }
+        }
+        _ => {}
+    }
+
+    // Reclaim if orphaned and fully drained.
+    if inner.orphaned && inner.inflight == 0 {
+        let fd = inner.fd;
+        inner.in_use = false;
+        inner.read_buf = Box::new([]);
+        inner.write_buf = Box::new([]);
+        drop(inner);
+        // SAFETY: fd was owned by this slot and has no more in-flight ops.
+        unsafe {
+            libc::close(fd);
+        }
+        shared.free.lock().unwrap().push(slot);
+        return followup;
+    }
+
+    let read_done = matches!(op, OP_READ);
+    let write_idle_or_err =
+        matches!(inner.write_state, WriteState::Idle | WriteState::Err(_));
+    drop(inner);
+    if read_done {
+        s.read_waker.wake();
+    } else if write_idle_or_err {
+        // Only wake the writer when the whole staged buffer drained (or errored).
+        s.write_waker.wake();
+    }
+    followup
+}
+
+/// Handle a command. Returns an optional SQE to submit.
+fn process_cmd(shared: &Arc<Shared>, cmd: DriverCmd) -> Option<squeue::Entry> {
+    match cmd {
+        DriverCmd::ArmRead { slot, gen } => {
+            let s = &shared.slots[slot as usize];
+            let mut inner = s.inner.lock().unwrap();
+            if inner.gen != gen || inner.orphaned {
+                return None;
+            }
+            if !matches!(inner.read_state, ReadState::Arming) {
+                return None;
+            }
+            let fd = inner.fd;
+            let len = inner.read_buf.len() as u32;
+            let ptr = inner.read_buf.as_mut_ptr();
+            inner.read_state = ReadState::Submitted;
+            inner.inflight += 1;
+            Some(
+                opcode::Recv::new(types::Fd(fd), ptr, len)
+                    .build()
+                    .user_data(pack_ud(slot, gen, OP_READ)),
+            )
+        }
+        DriverCmd::Write { slot, gen } => {
+            let s = &shared.slots[slot as usize];
+            let mut inner = s.inner.lock().unwrap();
+            if inner.gen != gen || inner.orphaned {
+                return None;
+            }
+            if let WriteState::Submitted { off, len } = inner.write_state {
+                let fd = inner.fd;
+                // SAFETY: off < len <= write_buf.len(); buffer alive.
+                let ptr = unsafe { inner.write_buf.as_ptr().add(off) };
+                inner.inflight += 1;
+                Some(
+                    opcode::Send::new(types::Fd(fd), ptr, (len - off) as u32)
+                        .build()
+                        .user_data(pack_ud(slot, gen, OP_WRITE)),
+                )
+            } else {
+                None
+            }
+        }
+        DriverCmd::Orphan { slot, gen } => {
+            let s = &shared.slots[slot as usize];
+            let mut inner = s.inner.lock().unwrap();
+            if inner.gen != gen {
+                return None;
+            }
+            inner.orphaned = true;
+            if inner.inflight == 0 {
+                let fd = inner.fd;
+                inner.in_use = false;
+                inner.read_buf = Box::new([]);
+                inner.write_buf = Box::new([]);
+                drop(inner);
+                // SAFETY: no in-flight ops reference this fd's buffers.
+                unsafe {
+                    libc::close(fd);
+                }
+                shared.free.lock().unwrap().push(slot);
+            }
+            // else: reclaimed by process_cqe when the last CQE lands. (A
+            // parked Recv with no data stays pinned until peer activity; a
+            // best-effort AsyncCancel is a later increment.)
+            None
+        }
+    }
+}
+
+/// `Send + Unpin + 'static` stream handle backed by the io_uring rw driver.
+pub struct IoUringStream {
+    shared: Arc<Shared>,
+    slot: u32,
+    gen: u16,
+}
+
+impl AsyncRead for IoUringStream {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        if buf.remaining() == 0 {
+            return Poll::Ready(Ok(()));
+        }
+        let s = &self.shared.slots[self.slot as usize];
+        let mut inner = s.inner.lock().unwrap();
+        match inner.read_state {
+            ReadState::Idle => {
+                inner.read_state = ReadState::Arming;
+                s.read_waker.register(cx.waker());
+                drop(inner);
+                self.shared.send(DriverCmd::ArmRead { slot: self.slot, gen: self.gen });
+                Poll::Pending
+            }
+            ReadState::Arming | ReadState::Submitted => {
+                s.read_waker.register(cx.waker());
+                Poll::Pending
+            }
+            ReadState::Ready { filled, pos } => {
+                let n = std::cmp::min(buf.remaining(), filled - pos);
+                buf.put_slice(&inner.read_buf[pos..pos + n]);
+                let new_pos = pos + n;
+                if new_pos >= filled {
+                    inner.read_state = ReadState::Idle;
+                    drop(inner);
+                    // Re-arm the next Recv eagerly so the pipeline stays full.
+                    self.shared.send(DriverCmd::ArmRead { slot: self.slot, gen: self.gen });
+                } else {
+                    inner.read_state = ReadState::Ready { filled, pos: new_pos };
+                }
+                Poll::Ready(Ok(()))
+            }
+            ReadState::Eof => Poll::Ready(Ok(())),
+            ReadState::Err(e) => Poll::Ready(Err(io::Error::from_raw_os_error(e))),
+        }
+    }
+}
+
+impl AsyncWrite for IoUringStream {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        data: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        if data.is_empty() {
+            return Poll::Ready(Ok(0));
+        }
+        let s = &self.shared.slots[self.slot as usize];
+        let mut inner = s.inner.lock().unwrap();
+        match inner.write_state {
+            WriteState::Idle => {
+                let n = std::cmp::min(data.len(), inner.write_buf.len());
+                inner.write_buf[..n].copy_from_slice(&data[..n]);
+                inner.write_state = WriteState::Submitted { off: 0, len: n };
+                drop(inner);
+                self.shared.send(DriverCmd::Write { slot: self.slot, gen: self.gen });
+                Poll::Ready(Ok(n))
+            }
+            WriteState::Submitted { .. } => {
+                // One staged write at a time (v1 backpressure).
+                s.write_waker.register(cx.waker());
+                Poll::Pending
+            }
+            WriteState::Err(e) => Poll::Ready(Err(io::Error::from_raw_os_error(e))),
+        }
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let s = &self.shared.slots[self.slot as usize];
+        let inner = s.inner.lock().unwrap();
+        match inner.write_state {
+            WriteState::Idle => Poll::Ready(Ok(())),
+            WriteState::Submitted { .. } => {
+                s.write_waker.register(cx.waker());
+                Poll::Pending
+            }
+            WriteState::Err(e) => Poll::Ready(Err(io::Error::from_raw_os_error(e))),
+        }
+    }
+
+    fn poll_shutdown(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<io::Result<()>> {
+        // Flush any staged write first.
+        let fd = {
+            let s = &self.shared.slots[self.slot as usize];
+            let inner = s.inner.lock().unwrap();
+            match inner.write_state {
+                WriteState::Submitted { .. } => {
+                    s.write_waker.register(cx.waker());
+                    return Poll::Pending;
+                }
+                WriteState::Err(e) => return Poll::Ready(Err(io::Error::from_raw_os_error(e))),
+                WriteState::Idle => inner.fd,
+            }
+        };
+        // Half-close the write side so the peer observes EOF.
+        // SAFETY: fd is valid for the lifetime of this handle.
+        unsafe {
+            libc::shutdown(fd, libc::SHUT_WR);
+        }
+        Poll::Ready(Ok(()))
+    }
+}
+
+impl Drop for IoUringStream {
+    fn drop(&mut self) {
+        // Non-blocking: the driver reclaims the slot + closes the fd once all
+        // in-flight ops are reaped (UAF-proof, ADR-0009).
+        self.shared.send(DriverCmd::Orphan { slot: self.slot, gen: self.gen });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::fd::FromRawFd;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    /// AF_UNIX SOCK_STREAM socketpair → (a, b) raw fds.
+    fn socketpair() -> (RawFd, RawFd) {
+        let mut fds = [0 as libc::c_int; 2];
+        let rc = unsafe { libc::socketpair(libc::AF_UNIX, libc::SOCK_STREAM, 0, fds.as_mut_ptr()) };
+        assert_eq!(rc, 0, "socketpair failed: {}", io::Error::last_os_error());
+        (fds[0], fds[1])
+    }
+
+    fn tokio_peer(fd: RawFd) -> tokio::net::UnixStream {
+        // SAFETY: fd is a freshly-created connected SOCK_STREAM end.
+        let std = unsafe { std::os::unix::net::UnixStream::from_raw_fd(fd) };
+        std.set_nonblocking(true).unwrap();
+        tokio::net::UnixStream::from_std(std).unwrap()
+    }
+
+    fn payload() -> Vec<u8> {
+        (0..1024 * 1024).map(|i| (i % 251) as u8).collect()
+    }
+
+    // peer -> IoUringStream: exercises poll_read (the Recv path) end to end.
+    #[tokio::test]
+    async fn echo_read_1mib_byte_exact() {
+        let shared = start().expect("driver start");
+        let (fa, fb) = socketpair();
+        let mut a = shared.register(fa).expect("register");
+        let mut peer = tokio_peer(fb);
+        let data = payload();
+
+        let d2 = data.clone();
+        let writer = tokio::spawn(async move {
+            peer.write_all(&d2).await.unwrap();
+            peer.shutdown().await.unwrap();
+        });
+
+        let mut got = Vec::new();
+        a.read_to_end(&mut got).await.unwrap();
+        assert_eq!(got.len(), data.len());
+        assert!(got == data, "read payload mismatch");
+        writer.await.unwrap();
+    }
+
+    // IoUringStream -> peer: exercises poll_write + poll_shutdown (Send path).
+    #[tokio::test]
+    async fn echo_write_1mib_byte_exact() {
+        let shared = start().expect("driver start");
+        let (fa, fb) = socketpair();
+        let mut a = shared.register(fa).expect("register");
+        let mut peer = tokio_peer(fb);
+        let data = payload();
+
+        let d2 = data.clone();
+        let writer = tokio::spawn(async move {
+            a.write_all(&d2).await.unwrap();
+            a.shutdown().await.unwrap();
+        });
+
+        let mut got = Vec::new();
+        peer.read_to_end(&mut got).await.unwrap();
+        assert_eq!(got.len(), data.len());
+        assert!(got == data, "write payload mismatch");
+        writer.await.unwrap();
+    }
+}

--- a/src/uring_rw.rs
+++ b/src/uring_rw.rs
@@ -192,6 +192,12 @@ impl Shared {
         drop(inner);
         Some(IoUringStream { shared: self.clone(), slot, gen })
     }
+
+    /// Introspection (tests today, `/metrics` later): slots currently
+    /// registered and not yet reclaimed.
+    pub(crate) fn active_slots(&self) -> usize {
+        MAX_SLOTS - self.free.lock().unwrap().len()
+    }
 }
 
 /// Start the rw driver: create the ring + eventfd + slab, spawn the driver
@@ -592,6 +598,7 @@ impl Drop for IoUringStream {
 mod tests {
     use super::*;
     use std::os::fd::FromRawFd;
+    use std::time::Duration;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
     /// AF_UNIX SOCK_STREAM socketpair → (a, b) raw fds.
@@ -655,5 +662,126 @@ mod tests {
         assert_eq!(got.len(), data.len());
         assert!(got == data, "write payload mismatch");
         writer.await.unwrap();
+    }
+
+    // EOF: peer half-closes; reader gets the full payload then a clean 0, and
+    // EOF is sticky (a second read also yields 0).
+    #[tokio::test]
+    async fn eof_is_clean_and_sticky() {
+        let shared = start().unwrap();
+        let (fa, fb) = socketpair();
+        let mut a = shared.register(fa).unwrap();
+        let mut peer = tokio_peer(fb);
+        peer.write_all(b"hello uring").await.unwrap();
+        peer.shutdown().await.unwrap();
+        drop(peer);
+        let mut got = Vec::new();
+        a.read_to_end(&mut got).await.unwrap();
+        assert_eq!(&got, b"hello uring");
+        // Sticky EOF.
+        let n = a.read(&mut [0u8; 8]).await.unwrap();
+        assert_eq!(n, 0);
+    }
+
+    // RST mid-read must surface as an Err, not a silent EOF. TCP loopback +
+    // SO_LINGER 0 forces a reset.
+    #[tokio::test]
+    async fn reset_surfaces_as_error() {
+        use std::net::{TcpListener, TcpStream};
+        use std::os::fd::{AsRawFd, IntoRawFd};
+        let shared = start().unwrap();
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let peer = TcpStream::connect(addr).unwrap();
+        let (server, _) = listener.accept().unwrap();
+        let mut a = shared.register(server.into_raw_fd()).unwrap();
+        // Arm a Recv with no data available (times out → stays in flight).
+        let read = tokio::time::timeout(Duration::from_millis(100), a.read(&mut [0u8; 64])).await;
+        assert!(read.is_err(), "expected a pending read");
+        // Force a RST on close: SO_LINGER {on, 0} (std::net::set_linger is
+        // unstable on stable Rust, so set the sockopt via libc).
+        let lin = libc::linger { l_onoff: 1, l_linger: 0 };
+        // SAFETY: setsockopt on a valid TCP fd with a correctly-sized linger.
+        unsafe {
+            libc::setsockopt(
+                peer.as_raw_fd(),
+                libc::SOL_SOCKET,
+                libc::SO_LINGER,
+                &lin as *const libc::linger as *const libc::c_void,
+                std::mem::size_of::<libc::linger>() as libc::socklen_t,
+            );
+        }
+        drop(peer);
+        let r = tokio::time::timeout(Duration::from_secs(2), a.read(&mut [0u8; 64]))
+            .await
+            .expect("read should resolve after RST");
+        assert!(r.is_err(), "RST must surface as Err, got {r:?}");
+    }
+
+    // Drop while a Recv is in flight: the slot must NOT be reclaimed until the
+    // CQE lands (slot keep-alive is the UAF-proof mechanism), then it must.
+    #[tokio::test]
+    async fn drop_with_inflight_recv_reclaims_only_after_cqe() {
+        let shared = start().unwrap();
+        let (fa, fb) = socketpair();
+        let mut a = shared.register(fa).unwrap();
+        let peer = tokio_peer(fb);
+        assert_eq!(shared.active_slots(), 1);
+        // Arm a Recv (no data → in flight).
+        let read = tokio::time::timeout(Duration::from_millis(100), a.read(&mut [0u8; 64])).await;
+        assert!(read.is_err());
+        drop(a); // Orphan — but the Recv is still in flight.
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        assert_eq!(shared.active_slots(), 1, "slot freed while Recv in flight (UAF risk)");
+        // Close the peer → the Recv completes (EOF) → driver reclaims.
+        drop(peer);
+        let mut reclaimed = false;
+        for _ in 0..200 {
+            if shared.active_slots() == 0 {
+                reclaimed = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert!(reclaimed, "slot not reclaimed after the in-flight Recv completed");
+    }
+
+    // Many concurrent connections through the single driver ring: no lost
+    // wakeups / hangs, all byte-exact, and every slot reclaims at the end.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_connections_echo() {
+        let shared = start().unwrap();
+        const N: usize = 64;
+        const SZ: usize = 64 * 1024;
+        let mut tasks = Vec::new();
+        for k in 0..N {
+            let (fa, fb) = socketpair();
+            let mut a = shared.register(fa).unwrap();
+            let mut peer = tokio_peer(fb);
+            tasks.push(tokio::spawn(async move {
+                let data: Vec<u8> = (0..SZ).map(|i| ((i + k) % 251) as u8).collect();
+                let d2 = data.clone();
+                let w = tokio::spawn(async move {
+                    peer.write_all(&d2).await.unwrap();
+                    peer.shutdown().await.unwrap();
+                });
+                let mut got = Vec::new();
+                a.read_to_end(&mut got).await.unwrap();
+                w.await.unwrap();
+                assert!(got == data, "conn {k} mismatch");
+            }));
+        }
+        for t in tasks {
+            t.await.unwrap();
+        }
+        let mut ok = false;
+        for _ in 0..200 {
+            if shared.active_slots() == 0 {
+                ok = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert!(ok, "slots not reclaimed after all conns done");
     }
 }

--- a/src/uring_rw.rs
+++ b/src/uring_rw.rs
@@ -30,11 +30,6 @@
 //! in-flight-op count reaches 0, so a dropped stream with a `Recv`/`Send`
 //! still in flight can never use-after-free.
 
-// Interim: until the serve-path seam is wired (increment 5, ADR-0009), every
-// item here is exercised only by the in-module tests, so a non-test build
-// sees them as dead. Lifted when `spawn_https_handler` constructs the stream.
-#![allow(dead_code)]
-
 use std::io;
 use std::os::fd::RawFd;
 use std::pin::Pin;
@@ -109,6 +104,8 @@ enum WriteState {
 struct SlotInner {
     fd: RawFd,
     gen: u16,
+    /// Occupancy flag; written on register/reclaim. Read via `/metrics` later.
+    #[allow(dead_code)]
     in_use: bool,
     orphaned: bool,
     /// Count of in-flight SQEs (read + write) referencing this slot's buffers.
@@ -195,6 +192,7 @@ impl Shared {
 
     /// Introspection (tests today, `/metrics` later): slots currently
     /// registered and not yet reclaimed.
+    #[allow(dead_code)]
     pub(crate) fn active_slots(&self) -> usize {
         MAX_SLOTS - self.free.lock().unwrap().len()
     }
@@ -545,6 +543,49 @@ impl AsyncWrite for IoUringStream {
             }
             WriteState::Err(e) => Poll::Ready(Err(io::Error::from_raw_os_error(e))),
         }
+    }
+
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &[io::IoSlice<'_>],
+    ) -> Poll<io::Result<usize>> {
+        let s = &self.shared.slots[self.slot as usize];
+        let mut inner = s.inner.lock().unwrap();
+        match inner.write_state {
+            WriteState::Idle => {
+                // Gather as many slices as fit into the one staged buffer and
+                // submit a SINGLE Send — rustls drives bulk writes vectored
+                // (up to 64 slices), so this avoids one Send per slice and the
+                // per-flush serialization that would otherwise kill throughput.
+                let cap = inner.write_buf.len();
+                let mut n = 0;
+                for b in bufs {
+                    if n >= cap {
+                        break;
+                    }
+                    let take = std::cmp::min(b.len(), cap - n);
+                    inner.write_buf[n..n + take].copy_from_slice(&b[..take]);
+                    n += take;
+                }
+                if n == 0 {
+                    return Poll::Ready(Ok(0));
+                }
+                inner.write_state = WriteState::Submitted { off: 0, len: n };
+                drop(inner);
+                self.shared.send(DriverCmd::Write { slot: self.slot, gen: self.gen });
+                Poll::Ready(Ok(n))
+            }
+            WriteState::Submitted { .. } => {
+                s.write_waker.register(cx.waker());
+                Poll::Pending
+            }
+            WriteState::Err(e) => Poll::Ready(Err(io::Error::from_raw_os_error(e))),
+        }
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        true
     }
 
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {

--- a/src/uring_rw.rs
+++ b/src/uring_rw.rs
@@ -61,7 +61,11 @@ fn pack_ud(slot: u32, gen: u16, op: u64) -> u64 {
 }
 #[inline]
 fn unpack_ud(ud: u64) -> (u32, u16, u64) {
-    (((ud >> 32) & 0xFFFF_FFFF) as u32, ((ud >> 16) & 0xFFFF) as u16, ud & 0xFFFF)
+    (
+        ((ud >> 32) & 0xFFFF_FFFF) as u32,
+        ((ud >> 16) & 0xFFFF) as u16,
+        ud & 0xFFFF,
+    )
 }
 
 /// Driver command from a handle (or its `Drop`) to the driver thread.
@@ -187,7 +191,11 @@ impl Shared {
         s.read_waker.take();
         s.write_waker.take();
         drop(inner);
-        Some(IoUringStream { shared: self.clone(), slot, gen })
+        Some(IoUringStream {
+            shared: self.clone(),
+            slot,
+            gen,
+        })
     }
 
     /// Introspection (tests today, `/metrics` later): slots currently
@@ -340,7 +348,10 @@ fn process_cqe(shared: &Arc<Shared>, ud: u64, res: i32) -> Option<squeue::Entry>
             } else if res == 0 {
                 ReadState::Eof
             } else {
-                ReadState::Ready { filled: res as usize, pos: 0 }
+                ReadState::Ready {
+                    filled: res as usize,
+                    pos: 0,
+                }
             };
         }
         OP_WRITE => {
@@ -384,8 +395,7 @@ fn process_cqe(shared: &Arc<Shared>, ud: u64, res: i32) -> Option<squeue::Entry>
     }
 
     let read_done = matches!(op, OP_READ);
-    let write_idle_or_err =
-        matches!(inner.write_state, WriteState::Idle | WriteState::Err(_));
+    let write_idle_or_err = matches!(inner.write_state, WriteState::Idle | WriteState::Err(_));
     drop(inner);
     if read_done {
         s.read_waker.wake();
@@ -489,7 +499,10 @@ impl AsyncRead for IoUringStream {
                 inner.read_state = ReadState::Arming;
                 s.read_waker.register(cx.waker());
                 drop(inner);
-                self.shared.send(DriverCmd::ArmRead { slot: self.slot, gen: self.gen });
+                self.shared.send(DriverCmd::ArmRead {
+                    slot: self.slot,
+                    gen: self.gen,
+                });
                 Poll::Pending
             }
             ReadState::Arming | ReadState::Submitted => {
@@ -504,9 +517,15 @@ impl AsyncRead for IoUringStream {
                     inner.read_state = ReadState::Idle;
                     drop(inner);
                     // Re-arm the next Recv eagerly so the pipeline stays full.
-                    self.shared.send(DriverCmd::ArmRead { slot: self.slot, gen: self.gen });
+                    self.shared.send(DriverCmd::ArmRead {
+                        slot: self.slot,
+                        gen: self.gen,
+                    });
                 } else {
-                    inner.read_state = ReadState::Ready { filled, pos: new_pos };
+                    inner.read_state = ReadState::Ready {
+                        filled,
+                        pos: new_pos,
+                    };
                 }
                 Poll::Ready(Ok(()))
             }
@@ -533,7 +552,10 @@ impl AsyncWrite for IoUringStream {
                 inner.write_buf[..n].copy_from_slice(&data[..n]);
                 inner.write_state = WriteState::Submitted { off: 0, len: n };
                 drop(inner);
-                self.shared.send(DriverCmd::Write { slot: self.slot, gen: self.gen });
+                self.shared.send(DriverCmd::Write {
+                    slot: self.slot,
+                    gen: self.gen,
+                });
                 Poll::Ready(Ok(n))
             }
             WriteState::Submitted { .. } => {
@@ -573,7 +595,10 @@ impl AsyncWrite for IoUringStream {
                 }
                 inner.write_state = WriteState::Submitted { off: 0, len: n };
                 drop(inner);
-                self.shared.send(DriverCmd::Write { slot: self.slot, gen: self.gen });
+                self.shared.send(DriverCmd::Write {
+                    slot: self.slot,
+                    gen: self.gen,
+                });
                 Poll::Ready(Ok(n))
             }
             WriteState::Submitted { .. } => {
@@ -601,10 +626,7 @@ impl AsyncWrite for IoUringStream {
         }
     }
 
-    fn poll_shutdown(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<io::Result<()>> {
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         // Flush any staged write first.
         let fd = {
             let s = &self.shared.slots[self.slot as usize];
@@ -631,7 +653,10 @@ impl Drop for IoUringStream {
     fn drop(&mut self) {
         // Non-blocking: the driver reclaims the slot + closes the fd once all
         // in-flight ops are reaped (UAF-proof, ADR-0009).
-        self.shared.send(DriverCmd::Orphan { slot: self.slot, gen: self.gen });
+        self.shared.send(DriverCmd::Orphan {
+            slot: self.slot,
+            gen: self.gen,
+        });
     }
 }
 
@@ -741,7 +766,10 @@ mod tests {
         assert!(read.is_err(), "expected a pending read");
         // Force a RST on close: SO_LINGER {on, 0} (std::net::set_linger is
         // unstable on stable Rust, so set the sockopt via libc).
-        let lin = libc::linger { l_onoff: 1, l_linger: 0 };
+        let lin = libc::linger {
+            l_onoff: 1,
+            l_linger: 0,
+        };
         // SAFETY: setsockopt on a valid TCP fd with a correctly-sized linger.
         unsafe {
             libc::setsockopt(
@@ -773,7 +801,11 @@ mod tests {
         assert!(read.is_err());
         drop(a); // Orphan — but the Recv is still in flight.
         tokio::time::sleep(Duration::from_millis(80)).await;
-        assert_eq!(shared.active_slots(), 1, "slot freed while Recv in flight (UAF risk)");
+        assert_eq!(
+            shared.active_slots(),
+            1,
+            "slot freed while Recv in flight (UAF risk)"
+        );
         // Close the peer → the Recv completes (EOF) → driver reclaims.
         drop(peer);
         let mut reclaimed = false;
@@ -784,7 +816,10 @@ mod tests {
             }
             tokio::time::sleep(Duration::from_millis(10)).await;
         }
-        assert!(reclaimed, "slot not reclaimed after the in-flight Recv completed");
+        assert!(
+            reclaimed,
+            "slot not reclaimed after the in-flight Recv completed"
+        );
     }
 
     // Many concurrent connections through the single driver ring: no lost

--- a/src/uring_rw.rs
+++ b/src/uring_rw.rs
@@ -825,4 +825,44 @@ mod tests {
         }
         assert!(ok, "slots not reclaimed after all conns done");
     }
+
+    // Increment 6: backpressure. A slow consumer must throttle the writer
+    // (poll_write returns Pending while a Send is in flight — the one-staged-
+    // buffer high-water) WITHOUT deadlocking, with memory bounded to that one
+    // buffer, and the payload arrives byte-exact.
+    #[tokio::test]
+    async fn backpressure_slow_consumer_no_deadlock() {
+        let shared = start().unwrap();
+        let (fa, fb) = socketpair();
+        let mut a = shared.register(fa).unwrap();
+        let mut peer = tokio_peer(fb);
+        let data = payload(); // 1 MiB
+        let total = data.len();
+
+        let d2 = data.clone();
+        // Writer: push the whole payload through the io_uring stream. If
+        // backpressure deadlocked, this never completes and the test times out.
+        let w = tokio::spawn(async move {
+            a.write_all(&d2).await.unwrap();
+            a.shutdown().await.unwrap();
+        });
+
+        // Slow reader: drain in small chunks with periodic pauses so the socket
+        // buffer fills and the writer is forced to wait on backpressure.
+        let mut got = Vec::with_capacity(total);
+        let mut chunk = [0u8; 4096];
+        loop {
+            let n = peer.read(&mut chunk).await.unwrap();
+            if n == 0 {
+                break;
+            }
+            got.extend_from_slice(&chunk[..n]);
+            if got.len() % (64 * 1024) < 4096 {
+                tokio::time::sleep(Duration::from_millis(1)).await;
+            }
+        }
+        w.await.unwrap();
+        assert_eq!(got.len(), total);
+        assert!(got == data, "backpressure payload mismatch");
+    }
 }


### PR DESCRIPTION
Implements the io_uring read/write data path for #51 (v0.2 performance ceiling), behind the existing **`io-uring-rw`** feature. **Off by default**; a runtime kernel gate (≥5.19) picks the path per-accept with a transparent tokio fallback. Default / macOS / ktls builds are unchanged.

Designed from zero in **[ADR-0009](docs/adr/0009-io-uring-rw-stream.md)** (research → architecture → adversarial stress, which caught 8 issues *before* any code — e.g. the `AtomicWaker` is `futures::task::` not `tokio_util::`; rustls writes vectored; mandatory generation counter).

## What lands (increments 1–5)
- **`src/uring_rw.rs` — `IoUringStream`**: a completion→poll bridge. One dedicated io_uring driver thread + an owned-buffer slab; the kernel only ever touches driver-owned buffers (never hyper's borrowed `ReadBuf`). `user_data` carries a per-slot generation; `poll_write_vectored` gathers rustls's slices into one `Send`; **Drop is non-blocking and UAF-proof** — a slot is reclaimed only once its in-flight ops are all reaped. tokio-uring was ruled out (`!Send` runtime + no `AsyncRead`/`AsyncWrite`, tokio-uring#188).
- **`src/rwstream.rs` — `RwStream { Uring | Tcp }`**: a concrete enum (not `Box<dyn>`) delegating `AsyncRead`/`AsyncWrite`, so the serve path stays monomorphic. `from_accepted` lifts the accepted fd out of tokio's epoll reactor into the driver (no epoll+io_uring double-registration), falling back to `Tcp` when the kernel is too old or the slab is full.
- **Serve seam** (`spawn_https_handler`): binds `inner_for_handshake = RwStream` via three mutually-exclusive cfg arms (ktls | io-uring-rw | neither). io_uring rw and kTLS are mutually exclusive per connection in v1.

## Verification (on a 6.17 kernel)
- **Real rustls handshake + round-trip over `RwStream::Uring`** — proves the stream satisfies `tokio_rustls`'s bounds *and* works under rustls's real I/O pattern (many small reads + vectored writes).
- `IoUringStream` unit + integration: 1 MiB echo byte-exact (both directions), **EOF** clean+sticky, **RST** → `Err`, **drop-with-inflight** (slot pinned until the CQE → UAF-proof reclaim), **64-connection concurrent** echo (no lost wakeups).
- `cargo clippy --features io-uring-rw --all-targets -- -D warnings` clean (this also type-proves the production `serve_connection_with_upgrades(... TlsStream<RwStream> ...)` path accepts the io_uring stream). Default build + clippy clean.
- *Note:* `valgrind` is not viable here (it deadlocks on the io_uring_enter busy loop in nested-virt); memory-safety rests on the design (keep-alive until `inflight==0`) + the behavioral drop-with-inflight test. A native ASan pass on CI/bare-metal is a follow-up.

## Honest caveats / not in this PR
- **Not default-on.** The central unvalidated hypothesis is that the double memcpy (kernel↔slab↔caller) over rustls's small records may erase io_uring's syscall win. The feature stays opt-in until the **bench gate** (ADR-0009: syscall-count drop on 1/10 MiB **and** <1% small-payload regression on the bare-metal e2e rig) decides default-on.
- **Daemon end-to-end (curl over io_uring) not shown here**: the dev box's *io_uring **accept*** path (pre-existing `io-uring-accept`, unchanged by this PR — `git diff` on `src/uring.rs`/`src/listener.rs` is empty) floods `errno 9 EBADF` in this nested-virt container, so :443 never binds. That's an orthogonal accept-layer/environment issue; the rw path is verified independently above.
- **Follow-ups (ADR-0009):** increment 6 write-backpressure tuning; the bench gate; then optionally fixed/registered buffers and per-ring sharding; a per-IP tarpit-style sub-cap is N/A here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)