### PR TITLE
fix(uring): make io_uring accept actually serve — three lifecycle bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ Client -> TLS 1.3 -> Security Gates -> Radix Router -> WAF Pipeline (5 gates) ->
 ```
 
 <!-- zion-stats:modules-lines (kept in sync by scripts/update-readme-stats.sh) -->
-40 modules, ~27,700 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
+40 modules, ~27,800 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
 
 ## Benchmarking
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1588,7 +1588,13 @@ async fn run_https_accept_loop(
             }
             conn = uring_rx.recv() => {
                 let Some(conn) = conn else { return; };
-                spawn_https_handler(conn.stream, conn.addr, state.clone());
+                // Convert std -> tokio TcpStream HERE: we are in a tokio runtime
+                // context, whereas the io_uring accept thread is not (its
+                // `from_std` would panic "no reactor running").
+                match tokio::net::TcpStream::from_std(conn.std_stream) {
+                    Ok(stream) => spawn_https_handler(stream, conn.addr, state.clone()),
+                    Err(e) => eprintln!("  io_uring accept: tokio from_std failed: {e}"),
+                }
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1311,12 +1311,23 @@ async fn async_main(platform: &'static bootstrap::Platform) -> error::ZionResult
         let uring_rx = uring::spawn_uring_accept(fd, 4096);
         // Spawn the accept loop ourselves; pass `https_initial = None`
         // to the supervisor so it tracks no HTTPS slot.
-        let (tx, rx) = tokio::sync::watch::channel(false);
-        let _ = tx; // sender held by main task lifetime; supervisor doesn't touch this loop
+        //
+        // Subscribe to the REAL process shutdown signal (`super_shutdown_tx`,
+        // flipped on SIGINT/SIGTERM). The earlier code created a throwaway
+        // `watch::channel(false)` and then did `let _ = tx;` — which drops the
+        // Sender immediately. With no live sender, the loop's very first
+        // `shutdown_rx.changed()` returned `Err` → the loop `return`ed at once
+        // → `uring_rx` was dropped → the accept thread's `try_send` then failed
+        // (channel closed) for every accepted connection, which was silently
+        // reset. Net effect: io_uring accept "listened" but served nothing
+        // (curl: connection reset during the TLS ClientHello). Subscribing to a
+        // sender that actually lives for the process fixes the lifetime and
+        // gives the loop a working graceful-shutdown path.
+        let uring_shutdown_rx = super_shutdown_tx.subscribe();
         tokio::spawn(run_https_accept_loop(
             https_listener,
             state.clone(),
-            rx,
+            uring_shutdown_rx,
             Some(uring_rx),
         ));
         None

--- a/src/uring.rs
+++ b/src/uring.rs
@@ -27,12 +27,14 @@ mod inner {
     use io_uring::{opcode, types, IoUring};
     use std::net::SocketAddr;
     use std::os::unix::io::{FromRawFd, RawFd};
-    use tokio::net::TcpStream;
     use tokio::sync::mpsc;
 
-    /// Accepted connection ready for TLS handshake.
+    /// A freshly-accepted connection as a *std* `TcpStream`. Conversion to a
+    /// tokio `TcpStream` happens on the consuming side (a tokio worker), NOT
+    /// here: `tokio::net::TcpStream::from_std` panics ("no reactor running")
+    /// when called from this bare std::thread accept loop.
     pub struct AcceptedConn {
-        pub stream: TcpStream,
+        pub std_stream: std::net::TcpStream,
         pub addr: SocketAddr,
     }
 
@@ -182,17 +184,17 @@ mod inner {
                     }
                 };
 
-                // Convert to tokio TcpStream
-                // SAFETY: the raw_fd is fresh from the kernel accept call and exclusive to this thread
+                // Build a *std* TcpStream (runtime-free) and hand it to a tokio
+                // worker, which converts it inside a runtime context. Calling
+                // `tokio::net::TcpStream::from_std` HERE panics — this accept
+                // loop runs on a bare std::thread with no Tokio reactor.
+                // SAFETY: raw_fd is fresh from the kernel accept, exclusive to us.
                 let std_stream = unsafe { std::net::TcpStream::from_raw_fd(raw_fd) };
-                let stream = match TcpStream::from_std(std_stream) {
-                    Ok(s) => s,
-                    Err(_) => continue,
-                };
 
-                // Send to tokio workers — if channel full, drop connection (overload shed)
-                if tx.try_send(AcceptedConn { stream, addr }).is_err() {
-                    // Channel full — connection dropped (back-pressure)
+                // Send to tokio workers — if the channel is full, the connection
+                // is dropped (overload shed).
+                if tx.try_send(AcceptedConn { std_stream, addr }).is_err() {
+                    // Channel full — connection dropped (back-pressure).
                 }
             }
         }

--- a/src/uring.rs
+++ b/src/uring.rs
@@ -44,10 +44,31 @@ mod inner {
     pub fn spawn_uring_accept(listener_fd: RawFd, capacity: usize) -> mpsc::Receiver<AcceptedConn> {
         let (tx, rx) = mpsc::channel(capacity);
 
+        // Own a STABLE fd for the accept thread. `listener_fd` is *borrowed*:
+        // its owning listener can be dropped / recycled out from under us (a
+        // tokio task drop, a config rebind). Once the number is freed,
+        // `io_uring_setup` can reuse it for this thread's own ring fd — and
+        // `accept()` on that fd then floods ENOTSOCK/EBADF (a tight ~10^6/s
+        // spin; reproduced with `zion auto`). `dup()` gives the thread an
+        // independent fd that (a) keeps the listening socket alive and (b)
+        // whose number cannot be recycled while the thread runs.
+        // SAFETY: dup of a currently-valid fd; returns -1 on error.
+        let owned_fd = unsafe { libc::dup(listener_fd) };
+        if owned_fd < 0 {
+            eprintln!(
+                "  io_uring accept: dup(listener_fd) failed: {} — io_uring accept disabled",
+                std::io::Error::last_os_error()
+            );
+            return rx;
+        }
+
         std::thread::Builder::new()
             .name("io_uring-accept".into())
             .spawn(move || {
-                uring_accept_loop(listener_fd, tx);
+                uring_accept_loop(owned_fd, tx);
+                // Release our owned fd once the loop exits.
+                // SAFETY: `owned_fd` is our dup; closed exactly once here.
+                unsafe { libc::close(owned_fd) };
             })
             .expect("failed to spawn io_uring accept thread");
 
@@ -88,6 +109,11 @@ mod inner {
             return;
         }
 
+        // Consecutive non-transient accept errors. A persistently-bad listener
+        // fd would otherwise spin this loop flooding stderr; cap the noise and
+        // bail loudly instead of burning a core forever.
+        let mut consecutive_errors: u32 = 0;
+
         loop {
             // Wait for completions — retry on EINTR (signal handler fired)
             // instead of panicking, which would silently kill the accept thread.
@@ -122,9 +148,19 @@ mod inner {
                     if errno == libc::EAGAIN || errno == libc::EINTR {
                         continue;
                     }
-                    eprintln!("  io_uring accept error: errno {errno}");
+                    consecutive_errors += 1;
+                    if consecutive_errors <= 3 || consecutive_errors % 1000 == 0 {
+                        eprintln!("  io_uring accept error: errno {errno} (#{consecutive_errors})");
+                    }
+                    if consecutive_errors >= 50 {
+                        eprintln!(
+                            "  io_uring accept: {consecutive_errors} consecutive errors (errno {errno}); listener fd unusable — stopping accept loop"
+                        );
+                        return;
+                    }
                     continue;
                 }
+                consecutive_errors = 0;
 
                 // Got a valid accepted fd
                 let raw_fd = fd as RawFd;


### PR DESCRIPTION
## Summary

The `io-uring-accept` feature (opt-in, off by default) was **non-functional end-to-end** — it never served a single request. This PR fixes **three** distinct bugs in the accept path, found and fixed in order (each masked the next). With all three, io_uring accept serves HTTPS end-to-end.

Diagnosed and verified on the contabo nested-virt dev LXC (kernel 6.17) with `zion auto`.

## The three bugs

### 1. Listener fd recycle → `EBADF`/`ENOTSOCK` flood (`684ddab`)
`spawn_uring_accept` took a **borrowed** `RawFd`. Its owning `TcpListener` could be dropped/recycled, after which `io_uring_setup` reused the freed fd *number* for the ring itself, and `accept()` on that number flooded errno 9/88 at ~10⁶/s (a tight spin burning a core; `:8443` never listened).

**strace proof:** `bind(12,:8443)+listen(12)` → `close(12)` → `io_uring_setup()=12` → `accept(12)` hits the ring fd.

**Fix:** `dup()` the listener fd at spawn so the accept thread owns a stable fd that (a) keeps the socket alive and (b) cannot be recycled while the thread runs. Plus rate-limit + bail the error loop instead of spinning forever on a persistently-bad fd.

### 2. `from_std` panic on the bare accept thread (`9f6f032`)
With the flood gone, the first real connection hit `tokio::net::TcpStream::from_std` **on the io_uring accept `std::thread`**, which panics *"there is no reactor running, must be called from the context of a Tokio 1.x runtime"* → thread dies, connection reset.

**Fix:** `AcceptedConn` now carries a `std::net::TcpStream`; the tokio conversion happens in `run_https_accept_loop` (a tokio runtime context).

### 3. Throwaway shutdown channel → accept loop served nothing (`bcf8f6b`)
io_uring `:8443` then *listened* but every HTTPS connection was **reset during the TLS ClientHello** (`curl: code 000 / "Connection reset by peer"`). HTTP `:8080` (the plain tokio accept) served a normal `301` — so the serve path and TLS config were fine; only io_uring-accepted connections failed.

**Root cause:** the loop was handed a throwaway `watch::channel(false)` whose `Sender` was dropped immediately by `let _ = tx;` (the comment claimed it was "held for the main task lifetime" — it was not). With no live sender, the loop's first `shutdown_rx.changed()` returns `Err` → the loop `return`s at once → `uring_rx` is dropped → the accept thread's `try_send` then fails (receiver gone) for every accepted connection, which is silently dropped and RST.

**Fix:** subscribe to `super_shutdown_tx` (the real SIGINT/SIGTERM signal, alive for the whole process). The loop now stays parked in its `select!` serving accepts, and gets a working graceful-shutdown path for free.

## Verification (LXC, kernel 6.17, `cargo build --features io-uring-accept,init`)

```
single healthz:        ok [200]
concurrent 20x healthz: 20/20 returned 200
readyz:                ready [200]
http :8080 /healthz:   301 (HTTP→HTTPS redirect, by design)
flood=0  panics=0
ss: 0.0.0.0:8443 LISTEN   0.0.0.0:8080 LISTEN
```

Before this PR: infinite EBADF flood, `:8443` never listened (bug 1) → after bug 1: panic on first conn (bug 2) → after bug 2: every HTTPS conn reset during ClientHello (bug 3).

## Scope / safety

- `io-uring-accept` is **opt-in, off by default** → zero risk to default builds.
- No change to the non-io_uring accept path (the `#[cfg(not(io-uring-accept))]` loop is untouched).
- Full test suite green; rustfmt clean (incl. the gated `uring.rs` checked with standalone rustfmt, since `cargo fmt` skips cfg'd-out modules on non-Linux).

## Follow-up (not in this PR)
`spawn_https_handler` swallows the rustls handshake error (`_ => { metric++; return; }`). Surfacing it (rate-limited) would have made bug 3 diagnosable in seconds. Worth a separate small PR.
