### PR TITLE
ci(release): move attestation path to Node 24 (attest-build-provenance v4.1.0)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -196,7 +196,10 @@ jobs:
       # ── Cross-compile path: zigbuild handles musl + aarch64 + aws-lc-rs ──
       - name: Setup zigbuild
         if: matrix.cross == 'zig'
-        uses: mlugg/setup-zig@53fc45b17fe98b52f92ee5ea08ff48a85a3e7eb7 # v1
+        # NOTE: v2.2.1 is still a Node 20 action (mlugg/setup-zig has no Node 24
+        # release yet), so GitHub's Node-20 deprecation warning persists for this
+        # step until upstream migrates — it runs forced-on-node24 meanwhile.
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
         with:
           version: 0.13.0
 
@@ -363,7 +366,7 @@ jobs:
       # ── Provenance: bind the cryptographic hash of every archive to the
       # workflow run identity (GitHub OIDC -> Fulcio -> Rekor). SLSA v1.0 L3.
       - name: Generate SLSA build provenance
-        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-path: "dist/${{ steps.stage.outputs.archive }}"
 
@@ -440,7 +443,7 @@ jobs:
           cat SHA256SUMS
 
       - name: Attest SHA256SUMS + SBOM
-        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-path: |
             dist/SHA256SUMS
@@ -562,7 +565,7 @@ jobs:
           push-to-registry: true
 
       - name: Attest container provenance
-        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.push.outputs.digest }}


### PR DESCRIPTION
## What

Moves `release.yml`'s attestation path off Node 20 ahead of GitHub's deadline (Node 20 actions forced onto Node 24 from **2026-06-16**, Node 20 runtime removed **2026-09-16**). The v0.4.0 release run logged Node 20 deprecation warnings for three actions.

## Changes
- **`actions/attest-build-provenance`** `e8998f9` (v2) → `a2bbfa2` (**v4.1.0**), ×3 sites. v4.1.0 is a composite action pinning `actions/attest@59d8942` (v4.1.0) which is **`using: node24`** — one bump clears the `attest-build-provenance`, the transitive `actions/attest`, **and** the `attest-build-provenance/predicate` warnings. Inputs (`subject-path` / `subject-name` / `subject-digest` / `push-to-registry`) verified unchanged across v2→v4.1.0.
- **`mlugg/setup-zig`** `53fc45b` (v1) → `d1434d0` (**v2.2.1**), latest maintained; `version` input unchanged.

## Known limitation
`mlugg/setup-zig` has **no Node 24 release yet** (v2.2.1 and `main` are still `node20`), so its deprecation warning will persist until upstream migrates — documented inline. It runs forced-on-node24 in the meantime (works). All other flagged actions are now Node 24.

## Verification
- SHAs cross-checked against each action's published release tag via the GitHub API.
- `using:` confirmed: attest v4.1.0 = `node24`; attest-build-provenance v4.1.0 = `composite` → attest v4.1.0.
- Input names confirmed present in the new versions' `action.yml`.
- YAML parses; pins kept by full commit SHA per the repo's supply-chain convention.

Cannot be fully exercised without cutting a release (the attestation/zig path only runs on `v*` tags); validated by upstream cross-reference instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
