### PR TITLE
fix(tls): surface swallowed TLS handshake errors (rate-limited)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1611,6 +1611,29 @@ async fn run_https_accept_loop(
     }
 }
 
+/// Rate-limit TLS-handshake failure logging to ~one line per second,
+/// process-wide. A failed handshake is per-connection — each runs on its own
+/// task, so there is no shared `last_log` instant like the accept loops keep;
+/// this gates on a shared timestamp instead. The `tls_handshake_errors` metric
+/// still counts *every* failure; only the stderr line is throttled, so a
+/// scanning/hostile client can't turn handshake failures into a log flood.
+/// Best-effort: a benign race may let two lines through in the same second.
+fn tls_handshake_log_allowed() -> bool {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static LAST_LOG_MS: AtomicU64 = AtomicU64::new(0);
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0);
+    let last = LAST_LOG_MS.load(Ordering::Relaxed);
+    if now_ms.saturating_sub(last) >= 1000 {
+        LAST_LOG_MS.store(now_ms, Ordering::Relaxed);
+        true
+    } else {
+        false
+    }
+}
+
 /// Common path for spawning a single HTTPS connection task: enforces
 /// the connection-limit semaphore, performs the TLS handshake, extracts
 /// 0-RTT and mTLS-fingerprint context, then drives `serve_connection_with_upgrades`.
@@ -1683,7 +1706,19 @@ fn spawn_https_handler(
                     .observe(tls_start.elapsed());
                 s
             }
-            _ => {
+            Ok(Err(e)) => {
+                if tls_handshake_log_allowed() {
+                    eprintln!("  tls handshake failed from {remote_addr}: {e}");
+                }
+                metrics::METRICS
+                    .tls_handshake_errors
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                return;
+            }
+            Err(_) => {
+                if tls_handshake_log_allowed() {
+                    eprintln!("  tls handshake timed out (10s) from {remote_addr}");
+                }
                 metrics::METRICS
                     .tls_handshake_errors
                     .fetch_add(1, std::sync::atomic::Ordering::Relaxed);


### PR DESCRIPTION
## What

`spawn_https_handler` swallowed the TLS handshake outcome: both the rustls **handshake error** and the **10s timeout** collapsed into one `_ =>` arm that bumped `tls_handshake_errors` and returned, discarding the error string.

That blind spot cost hours during the io_uring accept regression ([#195](https://github.com/fabriziosalmi/zion/pull/195)) — connections were being RST during the TLS ClientHello and the *why* was invisible; the rustls error would have pinpointed it in seconds.

## Change
- Split the `_ =>` arm into `Ok(Err(e))` (logs the rustls error + client addr) and `Err(_)` (logs the 10s timeout distinctly).
- **Rate-limited** to ~1 line/second process-wide via a shared timestamp (`tls_handshake_log_allowed`) — a handshake is per-connection (own task), so there's no per-loop `last_log` instant like the accept loops keep. A scanning/hostile client therefore can't turn handshake failures into a log flood; the `tls_handshake_errors` **metric still counts every failure**.
- The handler is shared by the tokio and io_uring accept paths → both benefit.

## Verification
- `cargo fmt --all --check`, `cargo clippy`, `cargo check`, full test suite (pre-commit) all clean.
- The logging mechanism itself was already proven during the #195 investigation (the temporary diagnostic that surfaced the rustls errors); this is the cleaned-up, rate-limited form.

Follow-up to the note in [#195](https://github.com/fabriziosalmi/zion/pull/195).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
