### PR TITLE
deps: bump matchit 0.8.6 -> 0.9.2 + vet exemption (supersedes #198)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2353,9 +2353,9 @@ checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "matchit"
-version = "0.8.6"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f926ade0c4e170215ae43342bf13b9310a437609c81f29f86c5df6657582ef9"
+checksum = "8863b587001c1b9a8a4e36008cebc6b3612cb1226fe2de94858e06092687b608"
 
 [[package]]
 name = "matrixmultiply"
@@ -5449,7 +5449,7 @@ dependencies = [
  "jsonwebtoken",
  "ktls",
  "libc",
- "matchit 0.8.6",
+ "matchit 0.9.2",
  "memchr",
  "mimalloc",
  "notify",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ http-body-util = "0.1"
 bytes = "1"
 
 # Radix tree routing (same engine as Axum)
-matchit = "0.8"
+matchit = "0.9"
 
 # TLS + hot-reload
 rustls = "0.23"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -695,7 +695,7 @@ version = "0.7.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.matchit]]
-version = "0.8.6"
+version = "0.9.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.matrixmultiply]]


### PR DESCRIPTION
Dependabot's matchit bump (#198) was code-green (clippy/test pass) but red on `cargo-vet` — there was no exemption for 0.9.2. Rebased the bump onto current master (post-Node24) and added the supply-chain entry.

- matchit `0.8.6` -> `0.9.2` (dependabot's commit, rebased)
- `supply-chain/config.toml`: repointed the `0.8.6` exemption to `0.9.2` (safe-to-deploy, unchanged criteria). After the bump the lockfile carries matchit 0.7.3 (transitive) + 0.9.2 (direct); 0.8.6 is gone.

Full test suite green locally. Supersedes #198 (closing it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)