### PR TITLE
ci(fuzz): fix cargo-fuzz build red on master (rust-toolchain.toml shadowed nightly)

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -49,6 +49,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      # rust-toolchain.toml pins the dev compiler to 1.88, which shadows the
+      # nightly default *inside the checkout* — so `cargo install cargo-fuzz`
+      # would build under 1.88 and fail (cargo-fuzz's cargo-platform dep now
+      # needs rustc >= 1.91). This whole job is a nightly job, so drop the pin
+      # and let the nightly installed below apply to every cargo invocation.
+      # Same pattern as release.yml's "Drop dev toolchain pin" step.
+      - name: Drop dev toolchain pin (this job builds on nightly)
+        run: rm -f rust-toolchain.toml
+
       # cargo-fuzz requires nightly because libfuzzer-sys uses unstable
       # rustc internals for its #[no_main] runtime. We don't run fuzz
       # campaigns here — only verify the harness compiles.


### PR DESCRIPTION
## Problem

`cargo-fuzz build` has been red on master (and on every recent PR) since cargo-fuzz's transitive dep `cargo-platform` raised its MSRV. The failing step was **Install cargo-fuzz**, not the fuzz build:

```
error: failed to compile `cargo-fuzz v0.13.2`
  rustc 1.88.0 is not supported by the following package:
    cargo-platform@0.3.3 requires rustc 1.91
```

## Root cause

`dtolnay/rust-toolchain@…# nightly` installs nightly (1.98) and sets it as the default — but `rust-toolchain.toml` in the repo root pins the dev compiler to **1.88** and shadows that default for any `cargo` command run *inside the checkout*. So `cargo install --locked cargo-fuzz` built under 1.88 and tripped cargo-platform's 1.91 floor. It passed before only because the floor used to be ≤ 1.88 — not a nightly regression.

## Fix

This is a nightly-only job (libfuzzer-sys needs unstable rustc internals), so the 1.88 pin shouldn't apply. Drop `rust-toolchain.toml` right after checkout — the **same pattern release.yml already uses** ("Drop dev toolchain pin for release builds") — so the installed nightly governs both `cargo install cargo-fuzz` and `cargo +nightly fuzz build`.

- Toolchain stays SHA-pinned (`dtolnay@5b84223 # nightly`); only the in-repo channel override is removed for this job.
- No code change; `actionlint` clean.

Closes the cargo-fuzz-red item flagged during the dependabot triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)