### PR TITLE
deps(bench): bump rand 0.9 -> 0.10 in benchmarks/backend (supersedes #32)

### DIFF
--- a/benchmarks/backend/Cargo.toml
+++ b/benchmarks/backend/Cargo.toml
@@ -9,7 +9,7 @@ hyper-util = { version = "0.1", features = ["tokio", "http1", "server", "server-
 http-body-util = "0.1"
 tokio = { version = "1.38.2", features = ["rt-multi-thread", "macros", "net", "signal"] }
 bytes = "1"
-rand = "0.9.3"
+rand = "0.10"
 mimalloc = "0.1.39"
 
 [profile.release]

--- a/benchmarks/backend/src/main.rs
+++ b/benchmarks/backend/src/main.rs
@@ -44,7 +44,7 @@ static PAYLOADS: OnceLock<Payloads> = OnceLock::new();
 
 fn payloads() -> &'static Payloads {
     PAYLOADS.get_or_init(|| {
-        use rand::Rng;
+        use rand::RngExt;
         let mut rng = rand::rng();
 
         // 1KB JSON


### PR DESCRIPTION
benchmarks/backend is a standalone crate (excluded from the zion workspace), so this is bench-only — #32's stale main-crate CI failures were unrelated.

rand 0.10 moved the slice-fill `fill` method from `Rng` to the new `RngExt` trait (`Rng`/`RngCore` now re-exported from rand_core, without it). Fix: `use rand::Rng` → `use rand::RngExt`; the three `rng.fill(&mut buf)` payload-gen calls are unchanged. `cargo check` on the backend: clean.

Supersedes #32 (stale: based on rand 0.9; master already moved to 0.9.3 via #183).

🤖 Generated with [Claude Code](https://claude.com/claude-code)