### PR TITLE
feat(cache): X-Zion-Cache HIT/MISS/BYPASS header + cache purge endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to Zion Edge Gateway are documented here.
 
 ## [Unreleased]
 
+### Added
+
+- **`X-Zion-Cache: HIT|MISS|BYPASS` response header** ([`src/dispatch.rs`](src/dispatch.rs)).
+  A cache HIT was previously distinguishable only by the absence of upstream/shield
+  headers plus the rewritten `Cache-Control` and the `Age` value — which cost real
+  debugging time during a stale-content incident. The cache now states its decision
+  explicitly: `HIT` (served from RAM), `MISS` (fetched from upstream and cached as it
+  streams), `BYPASS` (not cacheable — content-negotiated, `no-store`/`private`,
+  already-stale-on-arrival, or `max-age=0`).
+- **Cache purge endpoint `POST /_zion/cache/purge`** ([`src/cache.rs`](src/cache.rs),
+  [`src/dispatch.rs`](src/dispatch.rs)). Flush the in-RAM cache so a deploy hook can
+  invalidate immediately instead of waiting out the TTL (previously only a pod restart
+  would do it, briefly dropping `:443`). `?prefix=/path` purges matching keys; no prefix
+  purges everything. Internal-only (same IP gate as `/metrics`) and POST-only; returns
+  `{"purged":N,"scope":...}`. L2 is cleared directly; the existing generation counter
+  lazily invalidates every thread-local L1 — no cross-thread iteration.
+
 ## [0.4.2] - 2026-06-25
 
 A cache-correctness patch fixing stale content served by the edge cache. The

--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ Client -> TLS 1.3 -> Security Gates -> Radix Router -> WAF Pipeline (5 gates) ->
 ```
 
 <!-- zion-stats:modules-lines (kept in sync by scripts/update-readme-stats.sh) -->
-40 modules, ~28,000 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
+40 modules, ~28,200 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
 
 ## Benchmarking
 
@@ -338,7 +338,7 @@ Results saved to `benchmarks/bench-history.json` with automatic delta comparison
 ## Testing
 
 ```bash
-# Unit tests (597) <!-- zion-stats:test-count (kept in sync by scripts/update-readme-stats.sh) -->
+# Unit tests (599) <!-- zion-stats:test-count (kept in sync by scripts/update-readme-stats.sh) -->
 cargo test
 
 # Integration tests (23 -- requires running Zion + backend)

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -539,6 +539,65 @@ impl StaticCache {
             LOCAL_L2.with(|m| m.borrow().len())
         }
     }
+
+    /// Purge the whole cache. Clears L2 (source of truth) and bumps the
+    /// generation so every thread-local L1 entry is treated as stale on its
+    /// next get — no cross-thread iteration needed. Returns the number of L2
+    /// entries dropped. Lets a deploy hook invalidate immediately instead of
+    /// waiting out the TTL.
+    pub fn purge_all(&self) -> usize {
+        let n = if let Some(l2) = &self.l2 {
+            let n = l2.len();
+            l2.clear();
+            n
+        } else {
+            LOCAL_L2.with(|m| {
+                let mut m = m.borrow_mut();
+                let n = m.len();
+                m.clear();
+                n
+            })
+        };
+        self.generation
+            .fetch_add(1, std::sync::atomic::Ordering::Release);
+        n
+    }
+
+    /// Purge L2 entries whose key (path+query) starts with `prefix`. Returns
+    /// the count removed. Bumps the generation, which lazily invalidates ALL
+    /// L1 entries (not just the prefix) — over-broad but safe: unaffected keys
+    /// simply re-promote from L2 on next get. The common deploy case
+    /// (invalidate `/assets/...`) is well served.
+    pub fn purge_prefix(&self, prefix: &str) -> usize {
+        let mut removed = 0;
+        if let Some(l2) = &self.l2 {
+            let keys: Vec<Arc<str>> = l2
+                .iter()
+                .filter(|e| e.key().starts_with(prefix))
+                .map(|e| e.key().clone())
+                .collect();
+            for k in &keys {
+                l2.remove(k);
+                removed += 1;
+            }
+        } else {
+            LOCAL_L2.with(|m| {
+                let mut m = m.borrow_mut();
+                let keys: Vec<Arc<str>> = m
+                    .keys()
+                    .filter(|k| k.starts_with(prefix))
+                    .cloned()
+                    .collect();
+                for k in &keys {
+                    m.remove(k);
+                    removed += 1;
+                }
+            });
+        }
+        self.generation
+            .fetch_add(1, std::sync::atomic::Ordering::Release);
+        removed
+    }
 }
 
 #[cfg(test)]
@@ -740,6 +799,56 @@ mod tests {
             hit.age_secs >= 120,
             "Age must include the upstream age, got {}",
             hit.age_secs
+        );
+    }
+
+    #[test]
+    fn purge_all_empties_and_invalidates() {
+        let cache = StaticCache::new();
+        cache.insert("/a.css", Bytes::from("a"), default_meta(), 3600, 0, 100);
+        cache.insert("/b.css", Bytes::from("b"), default_meta(), 3600, 0, 100);
+        assert!(cache.get("/a.css").is_some()); // promote into L1
+        let n = cache.purge_all();
+        assert_eq!(n, 2);
+        assert_eq!(cache.len(), 0);
+        // L1 entry must be treated as stale after the generation bump
+        assert!(cache.get("/a.css").is_none());
+        assert!(cache.get("/b.css").is_none());
+    }
+
+    #[test]
+    fn purge_prefix_removes_only_matching() {
+        let cache = StaticCache::new();
+        cache.insert(
+            "/assets/x.js",
+            Bytes::from("x"),
+            default_meta(),
+            3600,
+            0,
+            100,
+        );
+        cache.insert(
+            "/assets/y.js",
+            Bytes::from("y"),
+            default_meta(),
+            3600,
+            0,
+            100,
+        );
+        cache.insert(
+            "/index.html",
+            Bytes::from("h"),
+            default_meta(),
+            3600,
+            0,
+            100,
+        );
+        let n = cache.purge_prefix("/assets/");
+        assert_eq!(n, 2);
+        assert!(cache.get("/assets/x.js").is_none());
+        assert!(
+            cache.get("/index.html").is_some(),
+            "non-matching key survives"
         );
     }
 

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -410,6 +410,34 @@ async fn process_request_inner(
                 .body(Full::new(body).map_err(|never| match never {}).boxed())
                 .unwrap());
         }
+        // Cache purge — flush the in-RAM cache so a deploy can invalidate
+        // immediately instead of waiting out the TTL. Internal-only + POST
+        // (mutating). `?prefix=/path` purges matching keys; no prefix = all.
+        if path == "/_zion/cache/purge" {
+            if !is_internal_ip(&client_ip) {
+                return Ok(empty_response(StatusCode::FORBIDDEN));
+            }
+            if *req.method() != hyper::Method::POST {
+                return Ok(empty_response(StatusCode::METHOD_NOT_ALLOWED));
+            }
+            let prefix = req.uri().query().and_then(|q| {
+                q.split('&')
+                    .find_map(|kv| kv.strip_prefix("prefix="))
+                    .map(|p| p.to_string())
+            });
+            let (removed, scope) = match &prefix {
+                Some(p) => (state.static_cache.purge_prefix(p), format!("{p:?}")),
+                None => (state.static_cache.purge_all(), "\"all\"".to_string()),
+            };
+            crate::logging::info("cache", &format!("purge scope={scope} removed={removed}"));
+            let body = Bytes::from(format!("{{\"purged\":{removed},\"scope\":{scope}}}\n"));
+            return Ok(Response::builder()
+                .status(StatusCode::OK)
+                .header("Content-Type", "application/json; charset=utf-8")
+                .header("Cache-Control", "no-store")
+                .body(Full::new(body).map_err(|never| match never {}).boxed())
+                .unwrap());
+        }
     }
 
     // ── Route lookup (thread-local LRU + radix tree fallback) ──
@@ -1304,6 +1332,7 @@ fn cache_hit_response(hit: cache::CacheHit) -> Response<ZionBody> {
     let mut builder = Response::builder()
         .status(hit.meta.status)
         .header("Cache-Control", profile_cache_control(hit.max_age_secs))
+        .header("X-Zion-Cache", "HIT")
         .header(hyper::header::AGE, hit.age_secs);
     if let Some(ct) = &hit.meta.content_type {
         builder = builder.header(hyper::header::CONTENT_TYPE, ct.clone());
@@ -1472,7 +1501,11 @@ async fn handle_static_cache(
             // Drop the inflight sender (no `true` sent): waiters fall through
             // to a fresh fetch, since cache will not be populated for this key.
             state.inflight.remove(&path_owned);
-            let resp = Response::from_parts(parts, body.map_err(hyper::Error::from).boxed());
+            let mut resp = Response::from_parts(parts, body.map_err(hyper::Error::from).boxed());
+            resp.headers_mut().insert(
+                "X-Zion-Cache",
+                hyper::header::HeaderValue::from_static("BYPASS"),
+            );
             return Ok(resp);
         }
 
@@ -1563,6 +1596,12 @@ async fn handle_static_cache(
         });
 
         let mut resp = Response::from_parts(parts, stream_body.boxed());
+        // This response was fetched from upstream and is being populated into
+        // the cache as it streams — a MISS that fills the cache for next time.
+        resp.headers_mut().insert(
+            "X-Zion-Cache",
+            hyper::header::HeaderValue::from_static("MISS"),
+        );
         // Preserve the upstream Cache-Control if it set one; otherwise supply
         // the profile-derived default — don't blanket-stamp 1-year immutable.
         if !resp.headers().contains_key(hyper::header::CACHE_CONTROL) {


### PR DESCRIPTION
## Why

Two operational cheap-wins identified in a real audiolibri.org **stale-after-deploy** incident (the same incident that motivated v0.4.2). During debugging:
- a cache **HIT was only distinguishable** by the *absence* of shield headers + the rewritten `Cache-Control` + the `Age` value — costing real time;
- there was **no way to flush** zion's in-RAM cache short of waiting out the TTL or restarting the pod (which briefly drops `:443`).

These are suggestions ①+② from the incident write-up.

## ① `X-Zion-Cache` response header

The cache now states its decision explicitly on every static-cache response:

| value | meaning |
|---|---|
| `HIT` | served from RAM ([`cache_hit_response`](src/dispatch.rs)) |
| `MISS` | fetched from upstream and cached as it streams |
| `BYPASS` | not cacheable — content-negotiated `Vary`, `no-store`/`private`/`no-cache`, already-stale-on-arrival, or `max-age=0` |

## ② `POST /_zion/cache/purge`

Flush the in-RAM cache so a deploy hook can invalidate immediately.

- **Internal-only** (same IP gate as `/metrics` / `/_zion/snapshot.json`) and **POST-only** (`GET` → 405).
- `?prefix=/assets/` purges matching keys; no prefix purges everything.
- Returns `{"purged":N,"scope":...}`.
- Implementation leans on the **existing generation counter**: `purge_all()` clears the shared L2 `DashMap` and bumps the generation so every thread-local L1 entry is treated as stale on its next get — no cross-thread iteration. `purge_prefix()` removes matching L2 keys (the generation bump lazily invalidates L1).

## Tests / verification

- New unit tests: `purge_all_empties_and_invalidates`, `purge_prefix_removes_only_matching` (cache 18/18).
- `cargo test` + `clippy --all-targets` clean.
- Verified end-to-end on the lab: `MISS → HIT (+Age) → POST purge {"purged":1} → MISS`; `GET /_zion/cache/purge → 405`.

Part of the "cache hardening" follow-up; remaining items (opt-in for implicit caching of header-less responses; HEAD served from the cached GET object) are separate, larger changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)