### PR TITLE
docs: fix drift vs codebase (mesh metrics, /metrics gate, ZION_CONFIG, auth algorithm)

### DIFF
--- a/docs/deploy/observability.md
+++ b/docs/deploy/observability.md
@@ -2,15 +2,20 @@
 
 ## Health Endpoints
 
-Zion exposes three built-in endpoints that bypass routing and upstream forwarding:
+Zion exposes built-in endpoints that bypass routing and upstream forwarding:
 
-| Endpoint | Response | Purpose |
-|---|---|---|
-| `GET /healthz` | `200 ok` | Liveness probe (is the process alive?) |
-| `GET /readyz` | `200 ready` | Readiness probe (is the process ready to serve?) |
-| `GET /metrics` | Prometheus text format | Metrics scraping |
+| Endpoint | Response | Access | Purpose |
+|---|---|---|---|
+| `GET /healthz` | `200 ok` | public | Liveness probe (is the process alive?) |
+| `GET /readyz` | `200 ready` | public | Readiness probe (is the process ready to serve?) |
+| `GET /metrics` | Prometheus text format | **internal IPs only** (`403` otherwise) | Metrics scraping |
+| `GET /_zion/snapshot.json` | JSON (metrics + quantiles + platform) | **internal IPs only** | `zion top` / dashboards |
+| `POST /_zion/cache/purge` | `{"purged":N,"scope":...}` | **internal IPs only**, POST-only (`405` on GET) | Flush the RAM cache on deploy; `?prefix=/path` for scoped purge |
 
-These endpoints are handled before rate limiting and routing, ensuring they always respond even under load.
+`/healthz` and `/readyz` are handled before rate limiting and routing, so they
+always respond even under load. `/metrics`, `/_zion/snapshot.json`, and
+`/_zion/cache/purge` are restricted to internal source IPs (external clients get
+`403`).
 
 ## Prometheus Metrics
 

--- a/docs/mesh/integration.md
+++ b/docs/mesh/integration.md
@@ -163,11 +163,13 @@ tracked at [#69](https://github.com/fabriziosalmi/zion/issues/69):
 
 `/metrics` exposes:
 
-* `zion_mesh_claims_published_total{kind=...}` — outbound claim count.
-* `zion_mesh_claims_received_total{kind=...}` — inbound count.
-* `zion_mesh_claims_rejected_total{reason=...}` — verification failures
-  bucketed by reason (`signature`, `unknown_peer`, `replay`, etc.).
-* `zion_mesh_peers` — current peer-set size.
+* `zion_mesh_claims_emitted_total` — outbound claim count.
+* `zion_mesh_claims_received_total` — inbound count.
+* `zion_mesh_claims_dropped_total{reason=...}` — verification / admission
+  failures bucketed by reason (`signature`, `replay`, `rate`, `other`).
+* `zion_mesh_score_lookups_total` — reputation lookups on the request path.
+* `zion_mesh_gossip_bytes_in_total` / `zion_mesh_gossip_bytes_out_total` —
+  gossip wire volume.
 
 ## Debugging
 
@@ -177,9 +179,9 @@ Common diagnostic commands once the mesh is up:
 # Verify the gossip listener is bound.
 sudo ss -uap | grep ':7777'
 
-# Dump the local reputation map (read-only HTTP endpoint, when
-# [observability].mesh_dump_enabled = true).
-curl -s https://node-a.example.com/admin/mesh/dump | jq
+# Inspect mesh counters (claims emitted/received/dropped, gossip bytes).
+# There is no HTTP reputation-map dump endpoint; use /metrics + the audit log.
+curl -s http://127.0.0.1:80/metrics | grep '^zion_mesh_'
 
 # Observe live publish/receive events from the audit log.
 tail -f /var/log/zion/audit.jsonl | jq 'select(.kind | startswith("mesh_"))'
@@ -219,5 +221,5 @@ Items listed in ADR-0008 "Negative consequences" or referenced above:
   [#67](https://github.com/fabriziosalmi/zion/issues/67).
 * **Chaos coverage (split-brain, claim flood, slow gossip)** —
   [#71](https://github.com/fabriziosalmi/zion/issues/71).
-* **Bench: --features mesh idle vs saturation cost** —
+* **Bench: --features sovereign-aimp idle vs saturation cost** —
   [#72](https://github.com/fabriziosalmi/zion/issues/72).

--- a/docs/perf/mesh-overhead.md
+++ b/docs/perf/mesh-overhead.md
@@ -87,7 +87,7 @@ cargo build --release --features sovereign-aimp
 #    with the mesh enabled but no peers. publish_block is never
 #    called; mesh_score_lookups is exercised on every request.
 ZION_AIMP_LISTEN=127.0.0.1:7777 ZION_AIMP_PEERS= \
-  ./target/release/zion --config benchmarks/zion-bench-tls.toml &
+  ZION_CONFIG=benchmarks/zion-bench-tls.toml ./target/release/zion &
 
 # 3. wrk a 100k rps burst against /api/v1/data, scrape /metrics, and
 #    confirm `zion_mesh_score_lookups_total` ticks at the expected

--- a/docs/perf/roadmap.md
+++ b/docs/perf/roadmap.md
@@ -10,7 +10,7 @@ estimates from the original gap analysis — measure, don't trust.
 
 Previously [`src/dispatch.rs`](../../src/dispatch.rs) called
 `format!("ip={…} class={…}")` on every classified request when
-`sovereign_log_classification = true`. That's one heap allocation per
+`[sovereign].log_classification = true`. That's one heap allocation per
 request, on the hot path, with no opt-out short of disabling the log.
 
 The new path:

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -317,8 +317,8 @@ with no record.
 - **ACME**: HTTP-01 challenges land in an in-memory store and are served
   *only* under `/.well-known/acme-challenge/<token>`. The store auto-
   expires entries and the renewal task is the sole writer.
-- **Auth**: JWT signature verification uses pinned algorithms via
-  `[auth_profile.<name>.algorithms]`; JWKS fetch is rate-limited and
+- **Auth**: JWT signature verification uses a pinned algorithm via
+  `[auth_profile.<name>.algorithm]`; JWKS fetch is rate-limited and
   cached.
 
 Both expand the threat surface; operators opting in must re-read the
@@ -370,8 +370,8 @@ from a trusted peer (a corrupted WAF reputation, a fake
   `aimp_node::crypto::SecurityFirewall` before any merge. Pubkeys
   are TOFU-logged on first sight + persisted under
   `[sovereign_aimp].identity_path` with `chmod 600`. An unknown-pubkey
-  envelope is dropped with `zion_mesh_claims_rejected_total{reason="unknown_peer"}`
-  ticked. Identity rotation is documented in
+  envelope fails signature verification and is dropped with
+  `zion_mesh_claims_dropped_total{reason="signature"}` ticked. Identity rotation is documented in
   [docs/mesh/integration.md](../mesh/integration.md) §"Identity management".
 - **Residual**: TOFU has the standard "first-contact spoof" caveat —
   a network attacker on the path between two nodes' first exchange


### PR DESCRIPTION
A 1:1 audit of `docs/` against `src/` (Cargo.toml features, src/cli.rs, src/metrics.rs, src/config.rs, src/auth.rs, src/dispatch.rs) found **12 mismatches** — 7 high, 2 medium, 3 low. The rest of the docs (all config key/default tables, observability counters, CLI flags, feature matrix) verified accurate.

### High — wrong/fabricated (would mislead operators)
- **`docs/mesh/integration.md`** — the Metrics + Debugging blocks were written against a mesh API that **never shipped**: `zion_mesh_claims_published_total{kind}`, `…_rejected_total{reason=…,unknown_peer}`, `zion_mesh_peers`, a `/admin/mesh/dump` endpoint, and an `[observability].mesh_dump_enabled` key — **none exist in code**. Aligned to the real metrics: `zion_mesh_claims_{emitted,received,dropped}_total` (`dropped` reasons `signature|replay|rate|other`), `zion_mesh_score_lookups_total`, `zion_mesh_gossip_bytes_{in,out}_total`. Replaced the fake dump endpoint with `/metrics` + audit log.
- **`zion --config <path>`** (ISO.md, mesh-overhead.md) — there is no `--config` flag (no clap); the arg is silently ignored and `./zion.toml` loads instead. → `ZION_CONFIG=<path>`.
- **`threat-model.md`** mesh metric → `zion_mesh_claims_dropped_total{reason="signature"}`.

### Medium
- **`deploy/observability.md`** — `/metrics` was listed as a public always-on endpoint; it is **internal-IP-only** (`403` otherwise). Clarified + added `/_zion/snapshot.json` and `/_zion/cache/purge` rows.
- **`threat-model.md`** — auth `[auth_profile.*].algorithms` → `algorithm` (singular; matches `src/auth.rs`).

### Low
- `docs/mesh/integration.md` bench label `--features mesh` → `--features sovereign-aimp`.
- `docs/perf/roadmap.md` `sovereign_log_classification` → `[sovereign].log_classification`.

Every fix was verified against the cited code site. No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)