### PR TITLE
ci(supply-chain): cargo-geiger as prebuilt binary (fix from-source flake)

### DIFF
--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -128,8 +128,13 @@ jobs:
             sudo apt-get install -y cmake pkg-config build-essential libssl-dev || \
             echo "::warning::could not apt-get build deps; relying on pre-installed toolchain"
           fi
+      # Prebuilt binary, not `cargo install` from source: building the tool on
+      # the self-hosted runners is the flaky step (intermittent "No such file or
+      # directory (os error 2)" mid-compile). Mirrors the cargo-audit/cargo-vet jobs.
       - name: Install cargo-geiger
-        run: cargo install --locked cargo-geiger
+        uses: taiki-e/install-action@873c7452cadb7c034694a1282227095d93fbdf92 # v2.79.14
+        with:
+          tool: cargo-geiger
       - name: Geiger report
         run: cargo geiger --all-features --output-format Json > geiger.json || true
       - name: Upload geiger report


### PR DESCRIPTION
The `cargo-geiger (unsafe surface)` job installed the tool via `cargo install --locked cargo-geiger` (from source). On the self-hosted runners that build intermittently dies mid-compile with `No such file or directory (os error 2)` — the same recurring flake already fixed for `cargo-audit` and `cargo-vet`. It blocked a README-only PR (#222) twice and had to be admin-merged.

Fix: install cargo-geiger as a **prebuilt binary** via `taiki-e/install-action` (same pinned SHA the audit/vet jobs use). No more from-source compile of the tool on the runner. The job stays `continue-on-error: true` (geiger is an informational report, not a gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)