### PR TITLE
fix(waf): plug SSRF / deserialization / SQLi-error / shellshock gaps — 73→85% recall, 0% FP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@ All notable changes to Zion Edge Gateway are documented here.
   recall **33% → 100%** (aggressive) / 27% → 44% (balanced), overall **64.7% →
   73.3%** (aggressive), **at an unchanged 0% false-positive rate** on the benign
   set. New unit tests lock in both the detections and the no-false-positive guard.
+- **WAF SSRF / deserialization / SQLi-error-based / shellshock coverage**
+  ([`src/waf.rs`](src/waf.rs)). Continuing against the corpus: internal SSRF
+  schemes `gopher://`/`dict://` and error-based SQLi (`extractvalue(` ·
+  `updatexml(` · `xp_cmdshell` · `||(select`) to balanced; loopback/decimal-IP
+  SSRF (`http://localhost:` · `http://127.0.0.1:` · `http://2130706433`),
+  deserialization / prototype-pollution (java `rO0AB`, PHP `O:8:"`, `__proto__`,
+  `constructor[prototype`, YAML `!!python/`), shellshock (`() { :` — *not* bare
+  `() {`, which is a legit empty function) and quote-paren SQLi OR-variants to
+  aggressive. Corpus delta (aggressive): SSRF **33% → 100%**, deserialization
+  **33% → 100%**, SQLi **68% → 90%**, overall **73.3% → 85.3%** — still **0%
+  false positives**. New unit tests incl. an empty-function precision guard.
 
 ## [0.4.3] - 2026-06-25
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Client -> TLS 1.3 -> Security Gates -> Radix Router -> WAF Pipeline (5 gates) ->
 ```
 
 <!-- zion-stats:modules-lines (kept in sync by scripts/update-readme-stats.sh) -->
-40 modules, ~28,300 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
+40 modules, ~28,400 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
 
 ## Features
 
@@ -245,7 +245,7 @@ MODE=full bash benchmarks/baseline/run-baseline.sh   # → benchmarks/baseline/z
 ## Testing
 
 ```bash
-# Unit tests (605) <!-- zion-stats:test-count (kept in sync by scripts/update-readme-stats.sh) -->
+# Unit tests (613) <!-- zion-stats:test-count (kept in sync by scripts/update-readme-stats.sh) -->
 cargo test
 
 # Integration tests (23 — requires a running Zion + backend)

--- a/src/waf.rs
+++ b/src/waf.rs
@@ -177,6 +177,11 @@ const BALANCED_PATTERNS: &[&str] = &[
     "' and '1'='1",
     "waitfor delay",
     "pg_sleep(",
+    // Error-based + stacked SQLi: specific function/proc names, ~0 FP.
+    "extractvalue(",
+    "updatexml(",
+    "xp_cmdshell",
+    "||(select",
     "'; shutdown",
     // ── XSS: Tags (anchored on `<`) ──
     "<script",
@@ -255,6 +260,9 @@ const BALANCED_PATTERNS: &[&str] = &[
     "169.254.169.254/metadata",
     "http://192.0.0.192",
     "kubernetes.default.svc",
+    // SSRF: internal-only URI schemes — never legitimate in user input.
+    "gopher://",
+    "dict://",
     // ── Windows Path Traversal ──
     "c:\\windows\\",
     "c:\\inetpub\\",
@@ -429,6 +437,27 @@ const AGGRESSIVE_EXTRA_PATTERNS: &[&str] = &[
     "__schema",
     "__type",
     "mutation{",
+    // ── SSRF: loopback / internal targets (FP on legit localhost dev URLs) ──
+    "http://localhost:",
+    "https://localhost:",
+    "://127.0.0.1",
+    "http://0.0.0.0",
+    "http://2130706433",
+    "file:///proc",
+    "ftp://127.0.0.1",
+    // ── Deserialization / prototype pollution / YAML (FP on code/serialized) ──
+    "o:8:\"",
+    "ro0ab",
+    "__proto__",
+    "constructor[prototype",
+    "[prototype][",
+    "!!python/",
+    // ── Shellshock (`() { :` — not bare `() {`, which is a legit empty fn) ──
+    "() { :",
+    // ── SQLi: quote-paren OR variants + comment-terminated injection ──
+    "\") or (\"",
+    "') or ('",
+    "'--",
 ];
 
 static BALANCED_SCANNER: OnceLock<AhoCorasick> = OnceLock::new();
@@ -1504,6 +1533,71 @@ mod tests {
                 String::from_utf8_lossy(body)
             );
         }
+    }
+
+    #[test]
+    fn denies_ssrf_internal_schemes_balanced() {
+        for body in [
+            br#"{"u":"gopher://127.0.0.1:11211/_stats"}"#.as_slice(),
+            br#"{"u":"dict://127.0.0.1:11211/stat"}"#.as_slice(),
+        ] {
+            assert_eq!(
+                validate_request("POST", Some("application/json"), body, &strict_profile()),
+                WafVerdict::Deny("injection pattern detected"),
+                "missed: {}",
+                String::from_utf8_lossy(body)
+            );
+        }
+    }
+
+    #[test]
+    fn denies_ssrf_loopback_and_deser_aggressive() {
+        for body in [
+            br#"{"u":"http://localhost:6379/"}"#.as_slice(),
+            br#"{"u":"http://127.0.0.1:22"}"#.as_slice(),
+            br#"{"u":"http://2130706433/"}"#.as_slice(),
+            br#"{"x":"rO0ABXNyAA=="}"#.as_slice(),
+            br#"{"x":"constructor[prototype][isAdmin]=true"}"#.as_slice(),
+            br#"{"x":"!!python/object/apply:os.system ['id']"}"#.as_slice(),
+        ] {
+            assert_eq!(
+                validate_request(
+                    "POST",
+                    Some("application/json"),
+                    body,
+                    &aggressive_profile()
+                ),
+                WafVerdict::Deny("injection pattern detected"),
+                "missed: {}",
+                String::from_utf8_lossy(body)
+            );
+        }
+    }
+
+    #[test]
+    fn denies_sqli_error_based_balanced() {
+        let body = br#"{"q":"1 AND extractvalue(1,concat(0x7e,version()))"}"#;
+        assert_eq!(
+            validate_request("POST", Some("application/json"), body, &strict_profile()),
+            WafVerdict::Deny("injection pattern detected")
+        );
+    }
+
+    #[test]
+    fn allows_empty_function_aggressive() {
+        // Precision guard: an empty JS function `() {` must NOT trip the
+        // shellshock pattern (`() { :`). A regression here is a false positive.
+        let body = br#"{"code":"const f = () => {}; function g() { return 1; }"}"#;
+        assert_eq!(
+            validate_request(
+                "POST",
+                Some("application/json"),
+                body,
+                &aggressive_profile()
+            ),
+            WafVerdict::Allow,
+            "false positive on empty function"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Round 2 of corpus-driven hole-plugging (after #229's command injection), measured against `benchmarks/waf-corpus/`.

## Added (split by false-positive risk)
- **balanced** (~0 real-traffic FP): internal SSRF schemes `gopher://` · `dict://`; error-based SQLi `extractvalue(` · `updatexml(` · `xp_cmdshell` · `||(select`
- **aggressive** (FP-prone → strict routes): loopback/decimal-IP SSRF (`http://localhost:` · `http://127.0.0.1:` · `http://2130706433` · `file:///proc` · `ftp://127.0.0.1`); deserialization / prototype-pollution (java `rO0AB`, PHP `O:8:"`, `__proto__`, `constructor[prototype`, YAML `!!python/`); shellshock (`() { :`); quote-paren SQLi OR variants

## Measured (aggressive, vs corpus)
| class | before | after |
|---|--:|--:|
| SSRF | 33% | **100%** |
| deserialization | 33% | **100%** |
| SQLi | 68% | **90%** |
| header | 33% | 66% |
| **overall** | 73.3% | **85.3%** |
| **false positives** | 0% | **0%** (unchanged) |

Balanced: 50% → 55.3%, 0% FP. The 3 remaining misses (`admin' #`, hex-encoded quote, an XFF-spoof example) are too FP-prone to chase — precision over the tail.

## Precision discipline
Shellshock uses `() { :`, **not** bare `() {` — the latter would false-positive on a legit empty JS function. Locked in by `allows_empty_function_aggressive`. Every new pattern was checked against the 50 benign payloads → zero false positives in both profiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)