### PR TITLE
chore(release): v0.4.5 — WAF coverage patch (corpus-v2 round)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,7 +21,7 @@ A clear and concise description of what you expected to happen.
 **Environment (please complete the following information):**
  - OS: [e.g. Linux, macOS]
  - Architecture: [e.g. arm64, amd64]
- - Zion Version: [e.g. 0.4.4]
+ - Zion Version: [e.g. 0.4.5]
 
 **Additional context**
 Add any other context about the problem here (e.g. logs with `RUST_LOG=trace`, upstream backend type like Go/Node).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to Zion Edge Gateway are documented here.
 
 ## [Unreleased]
 
+## [0.4.5] - 2026-06-26
+
+A WAF detection-coverage patch, driven by a larger sourced corpus.
+
+### Added
+- WAF **corpus-v2** (`benchmarks/waf-corpus/corpus-v2.json`): ~1,060 malicious
+  payloads sourced from OWASP CRS + PayloadsAllTheThings, plus 136 benign — the
+  honest regression set. `build-corpus-v2.py` regenerates it; `run.py` takes
+  `WAF_CORPUS=<file>`.
+
+### Changed
+- WAF aggressive pattern set: a corpus-v2-driven round (PHP tags/funcs, Java
+  gadget classes, SSRF schemes, Windows command injection, ORM lookups, PHP
+  stream wrappers, Perl SSTI) lifts aggressive recall vs corpus-v2 from 30.9%
+  to 40.6% at an unchanged **0% false-positive rate** (0/136). balanced
+  unchanged. Guarded by new `denies_/allows_corpus_v2_round` unit tests.
+
 ## [0.4.4] - 2026-06-25
 
 A WAF-coverage patch. Adds a measured detection/false-positive regression

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5540,7 +5540,7 @@ dependencies = [
 
 [[package]]
 name = "zion"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "aho-corasick",
  "aimp_node",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zion"
-version = "0.4.4"
+version = "0.4.5"
 edition = "2021"
 # MSRV is the *core* default-features build (TLS proxy + WAF + cache + metrics).
 # Opt-in features (acme, auth, init, http3) pull crypto/i18n crates that have

--- a/README.md
+++ b/README.md
@@ -272,12 +272,12 @@ Every release is signed and carries SLSA v1.0 build provenance — see
 
 ```bash
 # Binary release (Sigstore-backed provenance via gh CLI)
-gh release download v0.4.4 -R fabriziosalmi/zion -p '*x86_64-unknown-linux-musl*' -p 'SHA256SUMS'
+gh release download v0.4.5 -R fabriziosalmi/zion -p '*x86_64-unknown-linux-musl*' -p 'SHA256SUMS'
 sha256sum --check --ignore-missing SHA256SUMS
-gh attestation verify zion-v0.4.4-x86_64-unknown-linux-musl.tar.gz --owner fabriziosalmi
+gh attestation verify zion-v0.4.5-x86_64-unknown-linux-musl.tar.gz --owner fabriziosalmi
 
 # Container image (cosign keyless)
-cosign verify ghcr.io/fabriziosalmi/zion:v0.4.4 \
+cosign verify ghcr.io/fabriziosalmi/zion:v0.4.5 \
     --certificate-identity-regexp "^https://github.com/fabriziosalmi/zion/\\.github/workflows/release\\.yml@refs/tags/v" \
     --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ from their containing minor — i.e. the latest `0.4.x` is always patched.
 | Version | Supported |
 | ------- | --------- |
 | 0.4.x (latest minor) | Yes |
-| < 0.4.4 | No |
+| < 0.4.5 | No |
 
 ## Reporting a Vulnerability
 

--- a/deploy/helm/zion/Chart.yaml
+++ b/deploy/helm/zion/Chart.yaml
@@ -3,7 +3,7 @@ name: zion
 description: Zion Edge Gateway — high-performance Rust TLS reverse proxy with WAF
 type: application
 version: 0.2.2
-appVersion: "0.4.4"
+appVersion: "0.4.5"
 home: https://fabriziosalmi.github.io/zion
 sources:
   - https://github.com/fabriziosalmi/zion

--- a/docs/deploy/hot-reload.md
+++ b/docs/deploy/hot-reload.md
@@ -130,7 +130,7 @@ Two surfaces report the reload state:
 
   ```json
   {
-    "version": "0.4.4",
+    "version": "0.4.5",
     "timestamp_ms": 1714425600000,
     "uptime_secs": 3712,
     "config_generation": 5,

--- a/docs/security/supply-chain.md
+++ b/docs/security/supply-chain.md
@@ -46,8 +46,8 @@ You need the GitHub CLI (`gh >= 2.49`) and `cosign >= 2.2`.
 
 ```bash
 # 1. Download the artifact + SHA256SUMS from the release page.
-gh release download v0.4.4 -R fabriziosalmi/zion \
-    -p 'zion-v0.4.4-x86_64-unknown-linux-musl.tar.gz' \
+gh release download v0.4.5 -R fabriziosalmi/zion \
+    -p 'zion-v0.4.5-x86_64-unknown-linux-musl.tar.gz' \
     -p 'SHA256SUMS' \
     -p 'zion-sbom.cdx.json'
 
@@ -55,7 +55,7 @@ gh release download v0.4.4 -R fabriziosalmi/zion \
 sha256sum --check --ignore-missing SHA256SUMS
 
 # 3. Verify the SLSA build provenance bound to the artifact's hash.
-gh attestation verify zion-v0.4.4-x86_64-unknown-linux-musl.tar.gz \
+gh attestation verify zion-v0.4.5-x86_64-unknown-linux-musl.tar.gz \
     --owner fabriziosalmi
 
 # Step 3 fails if:
@@ -78,7 +78,7 @@ grype zion-sbom.cdx.json
 ## Verifying a container image
 
 ```bash
-IMAGE=ghcr.io/fabriziosalmi/zion:v0.4.4
+IMAGE=ghcr.io/fabriziosalmi/zion:v0.4.5
 
 # 1. Pin to the digest immediately — tags are mutable, digests are not.
 DIGEST=$(crane digest "$IMAGE")
@@ -120,7 +120,7 @@ deterministically, and pins the Rust toolchain via
 [`rust-toolchain.toml`](../../rust-toolchain.toml). To reproduce locally:
 
 ```bash
-git checkout v0.4.4
+git checkout v0.4.5
 export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)
 # Linux musl example — matches the release artifact byte-for-byte
 # (modulo strip's stable behavior on your distro).


### PR DESCRIPTION
Patch release cutting v0.4.4 -> v0.4.5. Ships the WAF corpus-v2 round (#233): ~1k real-world payloads from OWASP CRS + PayloadsAllTheThings, and the FP-checked aggressive pattern round it drove — aggressive recall vs corpus-v2 30.9% -> 40.6% at an unchanged 0% false positives (0/136). Version SSOT swept; CHANGELOG [Unreleased] -> [0.4.5]. Tag v0.4.5 after merge fires release.yml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)