### PR TITLE
test(tls): CI-run unit tests for the 425 0-RTT gate + TLS version floor; honest conformance doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Client -> TLS 1.3 -> Security Gates -> Radix Router -> WAF Pipeline (5 gates) ->
 ```
 
 <!-- zion-stats:modules-lines (kept in sync by scripts/update-readme-stats.sh) -->
-40 modules, ~28,600 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
+40 modules, ~28,700 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
 
 ## Features
 
@@ -245,7 +245,7 @@ MODE=full bash benchmarks/baseline/run-baseline.sh   # → benchmarks/baseline/z
 ## Testing
 
 ```bash
-# Unit tests (623) <!-- zion-stats:test-count (kept in sync by scripts/update-readme-stats.sh) -->
+# Unit tests (628) <!-- zion-stats:test-count (kept in sync by scripts/update-readme-stats.sh) -->
 cargo test
 
 # Integration tests (23 — requires a running Zion + backend)

--- a/docs/security/tls-conformance.md
+++ b/docs/security/tls-conformance.md
@@ -72,24 +72,36 @@ regressed conformance, caught on the PR that bumps it.
 > tracked as a possible follow-up. Since Zion builds on rustls's
 > defaults, the version-pinned suite above is the high-value coverage.
 
-## Internal smoke + soak tests
+## Internal unit tests (CI-run)
 
-Zion's [`tests/integration.rs`](../../tests/integration.rs) runs a
-small subset of TLS behaviours end-to-end against a live daemon. The
-suite is `--ignored` by default (it requires a backend running). The
-relevant cases:
+Zion's TLS-relevant *decisions* are pinned by pure-function unit tests that run
+in CI on every push (`cargo test`) — not by an external harness. Because they
+test the decision logic directly, a refactor that silently weakened the version
+floor or re-enabled non-idempotent 0-RTT replay fails CI.
 
-| Test | RFC reference |
-|---|---|
-| `tls_handshake_succeeds_with_default_cert` | RFC 8446 §4.1 |
-| `early_data_replayed_state_changing_method_returns_425` | RFC 8470 §5.2 |
-| `client_cert_required_when_optional_provided_accepts` | RFC 8446 §4.4.2 |
-| `mtls_fingerprint_header_emitted` | Zion-specific |
+| Test (`src/…`) | What it pins | RFC |
+|---|---|---|
+| `tls::protocol_versions_fail_safe_to_tls13_only`, `…_floor_opens_only_on_exact_1_2` | the version floor is fail-safe: only the literal `"1.2"` opens TLS 1.2, any other value (typo, empty, `"1.3"`) collapses to 1.3-only | RFC 8446 |
+| `dispatch::early_data_rejects_state_changing_methods`, `early_data_allows_safe_methods`, `no_early_data_never_rejects` | 0-RTT early data carries only GET/HEAD; a state-changing method in early data gets **425 Too Early** | RFC 8470 §5.2 |
+| `tls::fingerprint_format_is_sha256_prefix_plus_64_hex`, `…_matches_known_sha256_vector`, `…_is_deterministic_for_same_input`, `…_diffuses_single_bit_flips` | the mTLS client-cert fingerprint wire format `sha256:<64-hex>` | — |
 
-Run with:
+## End-to-end behaviours (manual / e2e — not CI-gated)
+
+Full-stack TLS behaviours are exercised by the `--ignored` integration suite
+([`tests/integration.rs`](../../tests/integration.rs), which needs a running
+daemon + backend) and the e2e rig — **not** by CI unit tests:
+
+- **Handshake with the default cert** — every integration case connects to
+  Zion over TLS, so a broken default-cert handshake fails the whole suite.
+- **mTLS client-cert *header emission*** (injecting `sha256:<hex>` into the
+  upstream request) — the fingerprint *format* is unit-tested (above); the
+  end-to-end emission on an mTLS route is **not yet covered by an automated
+  test** (tracked in Gaps below).
+- **ALPN negotiation** (h2/http1.1) — cross-checked by the baseline harness
+  (`benchmarks/baseline/`, h2load/wrk legs).
 
 ```bash
-cd benchmarks/backend && cargo run --release &
+cd benchmarks/backend && go run test-server.go &
 ZION_CONFIG=tests/zion-test.toml ./target/release/zion &
 cargo test --test integration -- --ignored --test-threads=1
 ```
@@ -118,6 +130,7 @@ For deployments that need third-party attestation:
 |---|---|
 | Run BoGo as a CI job | **Done** (#56) — [`tls-conformance.yml`](../../.github/workflows/tls-conformance.yml) runs the suite against the rustls release Zion pins, weekly + on dependency-pin PRs |
 | BoGo against Zion's own `ServerConfig` (shim mode) | Possible follow-up — needs a `zion`-side BoGo shim; low marginal value while Zion uses rustls defaults |
+| mTLS fingerprint header-emission e2e test | Gap — the fingerprint *format* is unit-tested; the end-to-end injection of `X-Client-Cert-Fingerprint` on an mTLS route needs a client-cert fixture + an mTLS route in `tests/zion-test.toml` |
 | Wycheproof crypto vectors for HMAC/ECDSA | Inherited from aws-lc-rs CI; not re-run inside Zion |
 | ACME staging-environment soak | Manual today — `--features acme` against Let's Encrypt staging |
 | Public-internet TLS scan in release pipeline | Out of scope — operator-side concern |

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -176,6 +176,18 @@ pub(crate) async fn process_request(
     Ok(resp)
 }
 
+/// RFC 8470 §5.2: TLS 1.3 early data (0-RTT) is replay-vulnerable — a network
+/// adversary who captures the ClientHello + early data can replay it. Only
+/// safe/idempotent methods may ride in 0-RTT; a state-changing method replayed
+/// from early data could duplicate effects, so it gets **425 Too Early** and
+/// the client retries once the handshake completes. Returns `true` when the
+/// request MUST be rejected. Pure + unit-tested — guards the otherwise
+/// untestable `main.rs → dispatch.rs` `was_early` plumbing against a silent
+/// regression that would re-enable non-idempotent 0-RTT replay.
+fn early_data_rejected(is_early_data: bool, method: &hyper::Method) -> bool {
+    is_early_data && !matches!(*method, hyper::Method::GET | hyper::Method::HEAD)
+}
+
 async fn process_request_inner(
     mut req: Request<ZionBody>,
     state: Arc<AppState>,
@@ -223,7 +235,7 @@ async fn process_request_inner(
     // TLS 1.3 early data is inherently replay-vulnerable. Only idempotent
     // methods (GET/HEAD) are safe — state-changing methods could be replayed
     // by a network adversary capturing the ClientHello + early data.
-    if is_early_data && !matches!(*req.method(), hyper::Method::GET | hyper::Method::HEAD) {
+    if early_data_rejected(is_early_data, req.method()) {
         // SAFETY: 425 "Too Early" (RFC 8470) is a valid HTTP status code in
         // the 100..1000 range that hyper accepts. The literal `425` is a
         // compile-time constant; `from_u16` rejects only out-of-range u16s.
@@ -1948,6 +1960,48 @@ mod tests {
         // Content-Encoding, so it isn't a path-key collision.
         let h = hdr(hyper::header::VARY, "Accept-Encoding");
         assert!(is_shared_cacheable(false, &h, TTL, 0));
+    }
+
+    // ── RFC 8470 §5.2: 0-RTT early-data replay gate (early_data_rejected) ──
+    // CI-run coverage for the 425 behavior the docs claimed via a
+    // (nonexistent) integration test; guards the main.rs `was_early` plumbing.
+    #[test]
+    fn early_data_allows_safe_methods() {
+        // GET/HEAD are safe to carry in 0-RTT → not rejected.
+        assert!(!early_data_rejected(true, &hyper::Method::GET));
+        assert!(!early_data_rejected(true, &hyper::Method::HEAD));
+    }
+
+    #[test]
+    fn early_data_rejects_state_changing_methods() {
+        // Non-idempotent / unsafe methods replayed from 0-RTT → 425 Too Early.
+        for m in [
+            hyper::Method::POST,
+            hyper::Method::PUT,
+            hyper::Method::PATCH,
+            hyper::Method::DELETE,
+            hyper::Method::OPTIONS,
+        ] {
+            assert!(
+                early_data_rejected(true, &m),
+                "{m} in early data must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn no_early_data_never_rejects() {
+        // Handshake complete (not 0-RTT) → every method passes the gate.
+        for m in [
+            hyper::Method::GET,
+            hyper::Method::POST,
+            hyper::Method::DELETE,
+        ] {
+            assert!(
+                !early_data_rejected(false, &m),
+                "{m} outside early data must pass"
+            );
+        }
     }
 
     #[test]

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -161,6 +161,19 @@ fn load_certified_key(cert_path: &str, key_path: &str) -> Result<Arc<CertifiedKe
     Ok(Arc::new(CertifiedKey::new(certs, signing_key)))
 }
 
+/// Map the configured `min_version` to the rustls protocol-version list.
+/// **Fail-safe by design (RFC 8446):** only the exact literal `"1.2"` opens the
+/// TLS 1.2 floor; ANY other value — a typo, an empty string, `"1.3"`, `"tls1.2"`
+/// — collapses to TLS-1.3-only. A misconfiguration can therefore never silently
+/// *weaken* the floor, only fail closed to the stronger setting. Pure +
+/// unit-tested.
+fn protocol_versions(min_version: &str) -> Vec<&'static rustls::SupportedProtocolVersion> {
+    match min_version {
+        "1.2" => vec![&rustls::version::TLS12, &rustls::version::TLS13],
+        _ => vec![&rustls::version::TLS13],
+    }
+}
+
 /// Build a ServerConfig from TlsConfig.
 /// Automatically selects single-cert or multi-SNI resolver based on config.
 /// Returns Err on cert/key load failure so callers can handle gracefully.
@@ -197,11 +210,8 @@ pub fn load_tls_config(tls: &TlsConfig) -> Result<ServerConfig, String> {
         })
     };
 
-    // TLS version selection
-    let versions: Vec<&'static rustls::SupportedProtocolVersion> = match tls.min_version.as_str() {
-        "1.2" => vec![&rustls::version::TLS12, &rustls::version::TLS13],
-        _ => vec![&rustls::version::TLS13],
-    };
+    // TLS version selection (fail-safe: only "1.2" opens the 1.2 floor).
+    let versions = protocol_versions(tls.min_version.as_str());
 
     // mTLS: client certificate verification (downstream)
     let client_auth_mode = tls.client_auth.as_str();
@@ -703,6 +713,31 @@ mod tests {
         let mode = "optional";
         assert_ne!(mode, "none");
         assert_ne!(mode, "required");
+    }
+
+    // ── TLS version floor (protocol_versions) — RFC 8446 fail-safe ──
+    #[test]
+    fn protocol_versions_floor_opens_only_on_exact_1_2() {
+        let v = super::protocol_versions("1.2");
+        assert_eq!(v.len(), 2, "the 1.2 floor enables TLS 1.2 + 1.3");
+        assert!(v
+            .iter()
+            .any(|p| p.version == rustls::ProtocolVersion::TLSv1_2));
+        assert!(v
+            .iter()
+            .any(|p| p.version == rustls::ProtocolVersion::TLSv1_3));
+    }
+
+    #[test]
+    fn protocol_versions_fail_safe_to_tls13_only() {
+        // Anything that isn't EXACTLY "1.2" — "1.3", empty, a typo, trailing
+        // space — must collapse to TLS-1.3-only. A misconfig can never silently
+        // weaken the floor; it fails closed to the stronger setting.
+        for s in ["1.3", "", "tls1.2", "1.2 ", "TLS1.2", "1", "1.30"] {
+            let v = super::protocol_versions(s);
+            assert_eq!(v.len(), 1, "min_version {s:?} must yield 1.3-only");
+            assert_eq!(v[0].version, rustls::ProtocolVersion::TLSv1_3);
+        }
     }
 
     // ── Client cert fingerprint (X-Client-Cert-Fingerprint) ──


### PR DESCRIPTION
**Wave 1 / test-integrity item** from the fresh-eyes audit.

## The problem
`docs/security/tls-conformance.md` listed **four TLS tests with RFC references that DO NOT EXIST** in `tests/integration.rs` — documentation describing a suite that was never written. Worst consequence: the security-critical **0-RTT 425 replay gate** (RFC 8470) was *flying blind* — a refactor dropping the `was_early` plumbing would silently re-enable duplicate-POST replay, undetected.

## The fix — cover the *decisions* with CI-run unit tests
A manual `#[ignore]`d integration test wouldn't protect against regression (it skips when zion isn't running). So the security-relevant TLS decisions are extracted into **pure, CI-run unit tests**, and the doc is made honest.

- **`dispatch::early_data_rejected(is_early, method)`** — extracted from the inline 425 gate. 3 tests (RFC 8470 §5.2): GET/HEAD ride 0-RTT; POST/PUT/PATCH/DELETE/OPTIONS → **425**; non-early-data always passes. Guards the `main.rs → dispatch.rs` `was_early` plumbing.
- **`tls::protocol_versions(min_version)`** — extracted from the inline match. 2 tests pinning the **RFC 8446 fail-safe**: only the literal `"1.2"` opens the 1.2 floor; any other value (typo, empty, `"1.3"`) collapses to **1.3-only** — a misconfig can never silently weaken it.
- **`tls-conformance.md`** — the 4 fabricated names replaced with the **real CI-run tests** (`early_data_rejected_*`, `protocol_versions_*`, the existing `fingerprint_*` format tests), honestly split into *CI-unit* vs *manual-e2e*. The mTLS header-emission e2e test is recorded as a tracked gap (needs a client-cert fixture).

## Result
5 new tests, full suite green. **No behavior change** (pure extraction — the gate/match logic is identical, now testable). README badge → 628.

Part of the summer quality program (Wave 1: correctness & integrity). Follows #235 (RFC 9111 §3.5 cache fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)