### PR TITLE
fix(http): 405 carries Allow, 401 carries WWW-Authenticate (RFC 9110 MUSTs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Client -> TLS 1.3 -> Security Gates -> Radix Router -> WAF Pipeline (5 gates) ->
 ```
 
 <!-- zion-stats:modules-lines (kept in sync by scripts/update-readme-stats.sh) -->
-40 modules, ~28,700 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
+40 modules, ~28,800 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
 
 ## Features
 
@@ -245,7 +245,7 @@ MODE=full bash benchmarks/baseline/run-baseline.sh   # → benchmarks/baseline/z
 ## Testing
 
 ```bash
-# Unit tests (628) <!-- zion-stats:test-count (kept in sync by scripts/update-readme-stats.sh) -->
+# Unit tests (630) <!-- zion-stats:test-count (kept in sync by scripts/update-readme-stats.sh) -->
 cargo test
 
 # Integration tests (23 — requires a running Zion + backend)

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -24,8 +24,12 @@ use crate::{
     cache, config, health, logging, metrics, observability, proxy, security, waf, AppState,
 };
 use crate::{
-    empty_response, generate_request_id, inject_security_headers, text_response, REQUEST_COUNTER,
+    empty_response, generate_request_id, inject_security_headers, method_not_allowed,
+    text_response, REQUEST_COUNTER,
 };
+// `unauthorized` is only referenced from the JWT/OIDC auth gate.
+#[cfg(feature = "auth")]
+use crate::unauthorized;
 use bytes::Bytes;
 use http_body_util::{BodyExt, Full};
 use hyper::{Request, Response, StatusCode};
@@ -228,7 +232,9 @@ async fn process_request_inner(
             | hyper::Method::HEAD
             | hyper::Method::OPTIONS
     ) {
-        return Ok(empty_response(StatusCode::METHOD_NOT_ALLOWED));
+        return Ok(method_not_allowed(
+            "GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS",
+        ));
     }
 
     // Gate: 0-RTT replay protection (RFC 8470 — 425 Too Early).
@@ -430,7 +436,7 @@ async fn process_request_inner(
                 return Ok(empty_response(StatusCode::FORBIDDEN));
             }
             if *req.method() != hyper::Method::POST {
-                return Ok(empty_response(StatusCode::METHOD_NOT_ALLOWED));
+                return Ok(method_not_allowed("POST"));
             }
             let prefix = req.uri().query().and_then(|q| {
                 q.split('&')
@@ -613,9 +619,9 @@ async fn process_request_inner(
                                 }
                             }
                             Err(auth::AuthError::Expired) => {
-                                return Ok(text_response(
-                                    StatusCode::UNAUTHORIZED,
+                                return Ok(unauthorized(
                                     "token expired",
+                                    "Bearer error=\"invalid_token\", error_description=\"token expired\"",
                                 ));
                             }
                             Err(_) => {
@@ -624,18 +630,15 @@ async fn process_request_inner(
                         }
                     }
                     None => {
-                        return Ok(text_response(
-                            StatusCode::UNAUTHORIZED,
+                        return Ok(unauthorized(
                             "invalid authorization",
+                            "Bearer error=\"invalid_token\"",
                         ));
                     }
                 }
             }
             None => {
-                return Ok(text_response(
-                    StatusCode::UNAUTHORIZED,
-                    "authorization required",
-                ));
+                return Ok(unauthorized("authorization required", "Bearer"));
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -597,6 +597,41 @@ pub(crate) fn text_response(status: StatusCode, text: &'static str) -> Response<
         .unwrap()
 }
 
+/// 405 Method Not Allowed with the mandatory `Allow` header (RFC 9110 §15.5.6:
+/// "The origin server MUST generate an Allow header field in a 405"). `allow`
+/// is the comma-separated method list valid at that resource, e.g.
+/// `"GET, HEAD, POST"`. Static value → header parse is infallible.
+pub(crate) fn method_not_allowed(allow: &'static str) -> Response<ZionBody> {
+    Response::builder()
+        .status(StatusCode::METHOD_NOT_ALLOWED)
+        .header(hyper::header::ALLOW, allow)
+        .body(
+            Full::new(EMPTY_BYTES.clone())
+                .map_err(|never| match never {})
+                .boxed(),
+        )
+        .unwrap()
+}
+
+/// 401 Unauthorized with the mandatory `WWW-Authenticate` challenge (RFC 9110
+/// §15.5.2: "The server generating a 401 response MUST send a WWW-Authenticate
+/// header field"). `challenge` is the scheme + optional params, e.g. `"Bearer"`
+/// or `Bearer error="invalid_token"` (RFC 6750 §3). Static values → infallible.
+// Only the `--features auth` gate emits 401s today; keep it building (and
+// unit-tested) without the feature.
+#[cfg_attr(not(feature = "auth"), allow(dead_code))]
+pub(crate) fn unauthorized(text: &'static str, challenge: &'static str) -> Response<ZionBody> {
+    Response::builder()
+        .status(StatusCode::UNAUTHORIZED)
+        .header(hyper::header::WWW_AUTHENTICATE, challenge)
+        .body(
+            Full::new(Bytes::from_static(text.as_bytes()))
+                .map_err(|never| match never {})
+                .boxed(),
+        )
+        .unwrap()
+}
+
 fn main() -> error::ZionResult<()> {
     // ── Subcommand dispatch ──
     // Default (no args) → run the daemon, preserving every existing
@@ -1999,6 +2034,33 @@ fn check_rate_limit(state: &AppState, ip: std::net::IpAddr) -> bool {
 /// Inject security headers — delegates to security module.
 pub(crate) fn inject_security_headers(resp: &mut Response<ZionBody>) {
     security::inject_security_headers(resp);
+}
+
+#[cfg(test)]
+mod response_header_tests {
+    use super::*;
+
+    #[test]
+    fn method_not_allowed_carries_allow_header() {
+        // RFC 9110 §15.5.6 MUST: a 405 carries the Allow header.
+        let resp = method_not_allowed("GET, HEAD, POST");
+        assert_eq!(resp.status(), StatusCode::METHOD_NOT_ALLOWED);
+        assert_eq!(
+            resp.headers().get(hyper::header::ALLOW).unwrap(),
+            "GET, HEAD, POST"
+        );
+    }
+
+    #[test]
+    fn unauthorized_carries_www_authenticate() {
+        // RFC 9110 §15.5.2 MUST: a 401 carries the WWW-Authenticate challenge.
+        let resp = unauthorized("authorization required", "Bearer");
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+        assert_eq!(
+            resp.headers().get(hyper::header::WWW_AUTHENTICATE).unwrap(),
+            "Bearer"
+        );
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
**Wave 1 conformance** — two normative MUST violations in zion's *own* error responses, from the fresh-eyes audit.

- [RFC 9110 §15.5.6](https://www.rfc-editor.org/rfc/rfc9110#section-15.5.6): *"the origin server MUST generate an `Allow` header field in a 405 response"*. zion's two 405s (global method whitelist; cache-purge on non-POST) sent none.
- [RFC 9110 §15.5.2](https://www.rfc-editor.org/rfc/rfc9110#section-15.5.2): *"the server generating a 401 response MUST send a `WWW-Authenticate` header field"*. zion's three auth-gate 401s (token expired / invalid / missing) sent none.

## Fix
New helpers in `main.rs` that build the response **with** the mandatory header:
- `method_not_allowed(allow)` → `Allow: <list>`
- `unauthorized(text, challenge)` → `WWW-Authenticate: <challenge>`

Call sites:
| Response | Header added |
|---|---|
| global 405 | `Allow: GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS` |
| cache-purge 405 | `Allow: POST` |
| 401 token expired / invalid | `WWW-Authenticate: Bearer error="invalid_token"` (RFC 6750 §3) |
| 401 no credentials | `WWW-Authenticate: Bearer` |

`unauthorized` is only reached under `--features auth`, so it + its import are feature-gated / dead-code-allowed without it. 2 unit tests assert the headers are present; **default and `--features auth` both build clean** (no `-D warnings` regression). No behavior change beyond the added headers. README badge → 630.

Part of the summer quality program (Wave 1: correctness & integrity). Follows #235 (cache §3.5), #236 (TLS test integrity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)