### PR TITLE
fix(cache): conservative 1h default freshness for header-less responses; immutable opt-in (RFC 9111 §4.2.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Client -> TLS 1.3 -> Security Gates -> Radix Router -> WAF Pipeline (5 gates) ->
 ```
 
 <!-- zion-stats:modules-lines (kept in sync by scripts/update-readme-stats.sh) -->
-40 modules, ~28,800 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
+40 modules, ~28,900 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
 
 ## Features
 
@@ -245,7 +245,7 @@ MODE=full bash benchmarks/baseline/run-baseline.sh   # → benchmarks/baseline/z
 ## Testing
 
 ```bash
-# Unit tests (631) <!-- zion-stats:test-count (kept in sync by scripts/update-readme-stats.sh) -->
+# Unit tests (632) <!-- zion-stats:test-count (kept in sync by scripts/update-readme-stats.sh) -->
 cargo test
 
 # Integration tests (23 — requires a running Zion + backend)

--- a/src/config.rs
+++ b/src/config.rs
@@ -450,8 +450,12 @@ fn default_max_entries() -> usize {
     10_000
 }
 fn default_ttl() -> u64 {
-    31_536_000
-} // 1 year
+    // Conservative heuristic-freshness default (RFC 9111 §4.2.2) for a
+    // static_cache route that names no explicit lifetime: cache for 1 hour, not
+    // a year. A header-less origin response must not be frozen (the audiolibri
+    // staleness root cause) — set `ttl_seconds` explicitly for longer/immutable.
+    3600
+} // 1 hour
 
 // ============================================================================
 // ROUTE CONFIG
@@ -752,7 +756,9 @@ pub fn build_router(config: &ZionConfig) -> Result<Router<Arc<ResolvedRoute>>, S
                     .clone(),
             )
         } else if route.mode == RouteMode::StaticCache {
-            // Legacy: create default immutable cache profile
+            // Default in-RAM profile for a profile-less static_cache route:
+            // conservative 1h TTL (default_ttl), NOT immutable. Name an explicit
+            // [cache_profile] with a longer ttl_seconds for content-hashed assets.
             Some(CacheProfile {
                 mode: CacheMode::Memory,
                 max_entries: default_max_entries(),
@@ -1459,7 +1465,9 @@ mode = "static_cache"
         let router = build_router(&config).unwrap();
         let route = router.at("/_next/static/chunk.js").unwrap();
         assert!(route.value.cache.is_some());
-        assert_eq!(route.value.cache.as_ref().unwrap().ttl_seconds, 31_536_000);
+        // Profile-less static_cache route → conservative 1h default (was 1 year;
+        // the audiolibri staleness fix). Operators set ttl_seconds for longer.
+        assert_eq!(route.value.cache.as_ref().unwrap().ttl_seconds, 3600);
     }
 
     #[test]

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -1455,7 +1455,9 @@ async fn handle_static_cache(
     // explicit profile uses the ~1-year content-hashed default).
     let (cache_ttl, cache_max) = match &rule.cache {
         Some(cp) => (cp.ttl_seconds, cp.max_entries),
-        None => (31_536_000, 10_000),
+        // Conservative fallback (1h) for a static_cache route with no resolved
+        // profile — never the old 1-year freeze. See config::default_ttl.
+        None => (3600, 10_000),
     };
 
     // RFC 9111 §3.5: capture whether the request is authenticated BEFORE `req`
@@ -2005,6 +2007,23 @@ mod tests {
                 "{m} outside early data must pass"
             );
         }
+    }
+
+    // ── RFC 9111 §4.2.2: conservative default freshness + immutable opt-in ──
+    #[test]
+    fn profile_cache_control_immutable_is_opt_in_via_explicit_year() {
+        // The conservative 1h default → plain max-age, NOT immutable (so a
+        // header-less response can't be frozen — the audiolibri staleness fix).
+        assert_eq!(
+            profile_cache_control(3600).to_str().unwrap(),
+            "public, max-age=3600"
+        );
+        // `immutable` is emitted ONLY when an operator explicitly sets a >= 1-year
+        // TTL — the deliberate "content-hashed, never revalidate" opt-in.
+        assert!(profile_cache_control(31_536_000)
+            .to_str()
+            .unwrap()
+            .contains("immutable"));
     }
 
     #[test]


### PR DESCRIPTION
**The audiolibri staleness root cause** — Wave 1 (the one cache-policy item you greenlit).

## The gap
A profile-less `static_cache` route got a **1-year** default TTL (`config::default_ttl` + the dispatch fallback), and any TTL ≥ 1y was stamped **`immutable`**. So a header-less origin response (origin sends no `Cache-Control`) was **frozen for a year and advertised never-revalidate** — a deploy's new content couldn't surface until the TTL or a manual purge. [RFC 9111 §4.2.2](https://www.rfc-editor.org/rfc/rfc9111#section-4.2.2) wants a *conservative* heuristic when the origin states no freshness.

## Fix (focused; honors explicit operator intent)
- `default_ttl` **1 year → 1 hour**. A profile-less `static_cache` route now caches header-less responses for 1h, not a year. Operators set an explicit `cache_profile` `ttl_seconds` for longer.
- dispatch fallback `31_536_000 → 3600` to match.
- **`immutable` is now opt-in**: `profile_cache_control` stamps `immutable` only at an explicit `ttl ≥ 1 year`, which only a deliberate operator config produces (the default no longer reaches that threshold). The content-hashed-asset use case is preserved via an explicit `ttl_seconds = 31536000` profile — see `zion.example.toml` `[cache_profile.immutable]`, which now perfectly illustrates the opt-in.
- Origin-stated freshness (`max-age`/`s-maxage`) is still honored exactly as before.

## Impact
A behavior change in a default, in the **safe** direction (no more accidental year-long freeze). Combined with the `POST /_zion/cache/purge` endpoint (v0.4.3) and `Age`/origin-TTL handling (v0.4.2), the staleness story is now closed at the zion layer.

Tests: `profile_cache_control` opt-in pinned; the static_cache default-profile test updated 1y→1h. README badge → 632.

Closes the Wave 1 cache-correctness item. Follows #235–#238.

🤖 Generated with [Claude Code](https://claude.com/claude-code)