### PR TITLE
fix(audit): surface audit-log flush/write failures instead of swallowing them

### DIFF
--- a/src/audit.rs
+++ b/src/audit.rs
@@ -446,12 +446,19 @@ async fn writer_loop(
     };
     if let Ok((signed, new_prev)) = sign_event(&key, init, prev_hash.clone()) {
         if let Ok(line) = serde_json::to_string(&signed) {
-            let _ = file.write_all(line.as_bytes()).await;
-            let _ = file.write_all(b"\n").await;
-            prev_hash = new_prev;
+            if file.write_all(line.as_bytes()).await.is_err()
+                || file.write_all(b"\n").await.is_err()
+                || file.flush().await.is_err()
+            {
+                crate::logging::error(
+                    "audit",
+                    "audit chain-init write/flush failed — the on-disk log may be unreliable",
+                );
+            } else {
+                prev_hash = new_prev;
+            }
         }
     }
-    let _ = file.flush().await;
 
     let mut seq: u64 = 1;
     while let Some(mut event) = rx.recv().await {
@@ -475,8 +482,16 @@ async fn writer_loop(
                     seq += 1;
                     // Flush each event — durability over throughput. Audit
                     // logs are low-rate; if this becomes a bottleneck we
-                    // can batch on a 100ms timer.
-                    let _ = file.flush().await;
+                    // can batch on a 100ms timer. A flush failure means the
+                    // event is NOT durable — surface it and stop, rather than
+                    // silently advancing the chain over un-persisted data.
+                    if file.flush().await.is_err() {
+                        crate::logging::error(
+                            "audit",
+                            "audit log flush failed — events may not be durable, exiting writer",
+                        );
+                        break;
+                    }
                 }
             }
             Err(e) => {
@@ -485,7 +500,9 @@ async fn writer_loop(
             }
         }
     }
-    let _ = file.flush().await;
+    if file.flush().await.is_err() {
+        crate::logging::warn("audit", "final audit log flush failed on writer shutdown");
+    }
 }
 
 fn now_iso8601() -> String {


### PR DESCRIPTION
**Wave 2 solidity** — audit's #3 risk (the tamper-evident log's integrity promise).

The audit writer's main event path already detected `write_all` errors (logs + exits), but the **per-event flush**, the **chain-init write**, and the **shutdown flush** all used `let _ =`. So a flush failure (disk full, read-only fs, revoked fd) left the writer **silently advancing the HMAC chain over data that never reached disk** — the audit log looks healthy while events are lost, with zero operator signal. That directly undermines the feature's durability + tamper-evidence promise.

## Fix
Every write/flush in `writer_loop` is now checked:
- **per-event flush** failure → `logging::error` + exit the writer (consistent with the existing write-failure path — don't pretend events are durable);
- **chain-init** write/flush failure → `logging::error` (log may be unreliable);
- **shutdown flush** failure → `logging::warn`.

Error-handling only; happy path unchanged (covered by the existing writer test). The failure path is IO-error logging — not unit-tested (would need filesystem fault injection); no new test, badge unchanged.

Wave 2. Follows #240, #241, #242.

🤖 Generated with [Claude Code](https://claude.com/claude-code)