### PR TITLE
feat(doctor): validate the deployment — config parse + upstream reachability

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Client -> TLS 1.3 -> Security Gates -> Radix Router -> WAF Pipeline (5 gates) ->
 ```
 
 <!-- zion-stats:modules-lines (kept in sync by scripts/update-readme-stats.sh) -->
-40 modules, ~29,000 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
+40 modules, ~29,100 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
 
 ## Features
 
@@ -245,7 +245,7 @@ MODE=full bash benchmarks/baseline/run-baseline.sh   # → benchmarks/baseline/z
 ## Testing
 
 ```bash
-# Unit tests (636) <!-- zion-stats:test-count (kept in sync by scripts/update-readme-stats.sh) -->
+# Unit tests (637) <!-- zion-stats:test-count (kept in sync by scripts/update-readme-stats.sh) -->
 cargo test
 
 # Integration tests (23 — requires a running Zion + backend)

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -85,7 +85,9 @@ pub fn run() -> i32 {
     }
 }
 
-fn collect_checks(p: &crate::bootstrap::Platform) -> Vec<Check> {
+/// The host/environment checks — deterministic, no config or network I/O, so
+/// they're stable to unit-test. Always present regardless of deployment.
+fn host_checks(p: &crate::bootstrap::Platform) -> Vec<Check> {
     vec![
         check_fd_limit(),
         check_memory_introspection(),
@@ -96,6 +98,93 @@ fn collect_checks(p: &crate::bootstrap::Platform) -> Vec<Check> {
         check_hardware_crypto(p),
         check_aes_calibration(p),
     ]
+}
+
+fn collect_checks(p: &crate::bootstrap::Platform) -> Vec<Check> {
+    let mut checks = host_checks(p);
+
+    // ── Deploy-time checks ──
+    // The checks above validate the host; these validate the actual deployment,
+    // so a bad config or an unreachable backend is caught by `zion doctor`
+    // BEFORE start, not at first request.
+    let path = std::env::var("ZION_CONFIG").unwrap_or_else(|_| "zion.toml".to_string());
+    if !std::path::Path::new(&path).exists() {
+        checks.push(Check::skip(
+            "config",
+            format!("no config at {path} — run `zion init` or set ZION_CONFIG"),
+        ));
+    } else {
+        match crate::config::load_config(&path) {
+            Ok(cfg) => {
+                checks.push(Check::ok("config", format!("{path} parses and validates")));
+                checks.push(check_upstreams_reachable(&cfg));
+            }
+            Err(e) => checks.push(Check::fail(
+                "config",
+                format!("{path}: {e}"),
+                "fix the config error above, then re-run `zion doctor`",
+            )),
+        }
+    }
+
+    checks
+}
+
+/// Derive the `host:port` to probe from an upstream URL, defaulting the port by
+/// scheme (https→443, else 80). Pure + unit-tested. `None` when the URL has no
+/// host (already reported by config validation).
+fn upstream_socket_addr(url: &str) -> Option<String> {
+    let uri = url.parse::<hyper::Uri>().ok()?;
+    let host = uri.host()?;
+    let port = uri
+        .port_u16()
+        .unwrap_or(if uri.scheme_str() == Some("https") {
+            443
+        } else {
+            80
+        });
+    Some(format!("{host}:{port}"))
+}
+
+/// Probe each configured upstream with a short TCP connect. **Warn**, not fail,
+/// on unreachable — a backend may simply be booting — but surface it so a
+/// typo'd host:port or a down backend is visible before the first request.
+fn check_upstreams_reachable(cfg: &crate::config::ZionConfig) -> Check {
+    use std::net::ToSocketAddrs;
+    let mut urls: Vec<String> = cfg.upstreams.values().cloned().collect();
+    for up in cfg.upstream.values() {
+        urls.extend(up.get_urls());
+    }
+    if urls.is_empty() {
+        return Check::skip("upstreams", "no upstreams configured");
+    }
+    let mut unreachable = Vec::new();
+    for url in &urls {
+        let Some(addr) = upstream_socket_addr(url) else {
+            continue; // malformed URL already reported by config validation
+        };
+        let reachable = addr
+            .to_socket_addrs()
+            .ok()
+            .and_then(|mut a| a.next())
+            .map(|sa| {
+                std::net::TcpStream::connect_timeout(&sa, std::time::Duration::from_millis(500))
+                    .is_ok()
+            })
+            .unwrap_or(false);
+        if !reachable {
+            unreachable.push(url.clone());
+        }
+    }
+    if unreachable.is_empty() {
+        Check::ok("upstreams", format!("{} reachable", urls.len()))
+    } else {
+        Check::warn(
+            "upstreams",
+            format!("unreachable: {}", unreachable.join(", ")),
+            "start the backend(s) or fix host:port — transient if they're still booting",
+        )
+    }
 }
 
 // ─────────────────────────────────────────────────────────────────────────
@@ -512,6 +601,28 @@ mod tests {
     }
 
     #[test]
+    fn upstream_socket_addr_defaults_port_by_scheme() {
+        assert_eq!(
+            upstream_socket_addr("http://127.0.0.1:8000").as_deref(),
+            Some("127.0.0.1:8000")
+        );
+        assert_eq!(
+            upstream_socket_addr("http://backend").as_deref(),
+            Some("backend:80")
+        );
+        assert_eq!(
+            upstream_socket_addr("https://backend").as_deref(),
+            Some("backend:443")
+        );
+        assert_eq!(
+            upstream_socket_addr("https://backend:9443").as_deref(),
+            Some("backend:9443")
+        );
+        // No host (malformed) → None; config validation reports it separately.
+        assert_eq!(upstream_socket_addr("not a url"), None);
+    }
+
+    #[test]
     fn fd_limit_returns_some_status() {
         let c = check_fd_limit();
         assert_eq!(c.name, "fd limit");
@@ -602,9 +713,11 @@ mod tests {
     #[test]
     fn collect_checks_returns_all_categories() {
         let p = synth_platform();
-        let checks = collect_checks(&p);
-        // Eight canonical checks: fd, memory-introspection, port80, port443,
-        // somaxconn, kernel, hwcrypto, aes-cal.
+        // Test the host checks (deterministic, no config/network I/O). The
+        // eight canonical checks: fd, memory-introspection, port80, port443,
+        // somaxconn, kernel, hwcrypto, aes-cal. (collect_checks() also appends
+        // deploy-time config/upstream checks, which depend on the environment.)
+        let checks = host_checks(&p);
         assert_eq!(checks.len(), 8);
         for c in &checks {
             assert!(!c.name.is_empty());


### PR DESCRIPTION
**Wave 2 operability.** `zion doctor` checked the *host* (fd limit, ports, kernel, crypto) but not the actual *deployment* — so a bad config or a down/typo'd backend surfaced only at (or after) startup. A Swiss watch you can run means `doctor` catches a bad deploy *before* start.

## Added
- **config**: load + validate `$ZION_CONFIG` (or `zion.toml`) via `config::load_config`. **OK** if it parses+validates, **FAIL** with the exact error if not, **SKIP** if absent (doctor still runs pre-`init`).
- **upstreams**: a short TCP connect (500ms) to each configured upstream (legacy `[upstreams]` + structured `[upstream.X]`). **WARN** (not fail) on unreachable — a backend may be booting — but surfaces a typo'd `host:port` or a down backend before the first request.

## Structure
Split the 8 deterministic `host_checks()` (unit-tested, no I/O) from the I/O-bearing deploy checks in `collect_checks()`. New pure helper `upstream_socket_addr()` (scheme → default port 443/80) is unit-tested. 

`cert-expiry` is **deferred** — it needs an x509 parser dependency (only `rustls-pemfile` is present, which doesn't expose `notAfter`), and adding a dep is a supply-chain decision, not an autonomous one.

README badge → 637. Wave 2. Follows #240–#244.

🤖 Generated with [Claude Code](https://claude.com/claude-code)