### PR TITLE
fix(config): extend deny_unknown_fields to cross-module sub-tables (audit/auth/sovereign)

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ MODE=full bash benchmarks/baseline/run-baseline.sh   # → benchmarks/baseline/z
 ## Testing
 
 ```bash
-# Unit tests (637) <!-- zion-stats:test-count (kept in sync by scripts/update-readme-stats.sh) -->
+# Unit tests (638) <!-- zion-stats:test-count (kept in sync by scripts/update-readme-stats.sh) -->
 cargo test
 
 # Integration tests (23 — requires a running Zion + backend)

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -37,7 +37,7 @@ use crate::observability;
 
 /// `[audit]` block in zion.toml.
 #[derive(Deserialize, Clone, Debug, Default)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct AuditConfig {
     /// Enable the writer task. Disabled by default — operator must opt in.
     pub enabled: bool,
@@ -66,7 +66,7 @@ fn default_queue_depth() -> usize {
 
 /// `[redact]` block. Lists are case-insensitive. Empty = no redaction.
 #[derive(Deserialize, Clone, Debug, Default)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct RedactConfig {
     /// HTTP header names whose value should be replaced with `<redacted:N>`.
     /// Compared lowercase per RFC 9110 §5.1 (header names are case-insensitive).

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -46,6 +46,7 @@ pub struct Claims {
 /// are only consumed by code under `#[cfg(feature = "auth")]`.
 #[allow(dead_code)]
 #[derive(Deserialize, Clone, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct AuthProfileConfig {
     /// Expected issuer (validated against token's `iss` claim).
     #[serde(default)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1397,6 +1397,38 @@ upstream = "be"
     }
 
     #[test]
+    fn unknown_key_in_cross_module_subtable_is_rejected() {
+        // deny_unknown_fields reaches the cross-module sub-tables too (here
+        // [audit], whose struct lives in audit.rs) — a typo there is no longer
+        // silently ignored either.
+        let toml = r#"
+[server]
+listen_http = "0.0.0.0:80"
+listen_https = "0.0.0.0:443"
+[tls]
+cert_path = "/c"
+key_path = "/k"
+[upstreams]
+be = "http://127.0.0.1:8000"
+[[route]]
+path = "/{*rest}"
+upstream = "be"
+[audit]
+enabledd = true
+"#;
+        let parsed: Result<ZionConfig, _> = toml::from_str(toml);
+        assert!(
+            parsed.is_err(),
+            "an unknown key in [audit] must be rejected"
+        );
+        let e = parsed.err().unwrap().to_string();
+        assert!(
+            e.contains("enabledd") || e.contains("unknown field"),
+            "error should name the unknown sub-table field, got: {e}"
+        );
+    }
+
+    #[test]
     fn parse_named_upstream() {
         let config: ZionConfig = toml::from_str(profile_toml()).unwrap();
         let api = config.upstream.get("api").unwrap();

--- a/src/sovereign/mod.rs
+++ b/src/sovereign/mod.rs
@@ -320,6 +320,7 @@ fn lookup6(ip: u128, ranges: &[CidrEntry6]) -> IpClass {
 /// the sovereign gate is never invoked — zero overhead.
 #[allow(dead_code)] // region/signals/signal_listen reserved for Phase 2/3
 #[derive(Debug, Clone, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct SovereignConfig {
     /// Master switch. Default: false.
     #[serde(default)]
@@ -356,6 +357,7 @@ pub struct SovereignConfig {
 /// by default. The local WAF / rate-limiter / auth gates stay
 /// authoritative; this only adds a deny on top.
 #[derive(Debug, Clone, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct EnforceConfig {
     /// Master switch. Default: false (signals-only).
     #[serde(default)]
@@ -394,6 +396,7 @@ impl Default for EnforceConfig {
 /// Bounded by `max_concurrent`: at the ceiling the tarpit sheds back to an
 /// immediate `403`, so it can never become a self-inflicted resource sink.
 #[derive(Debug, Clone, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct TarpitConfig {
     /// Master switch. Default: false (denies stay immediate 403s). Only
     /// takes effect when `[sovereign.enforce] enabled = true`.


### PR DESCRIPTION
**Wave 2 follow-up, completing #244.** The `config.rs` structs got `deny_unknown_fields` in #244, but the sub-table structs defined in *other modules* did not — so a typo inside `[audit]`, `[redact]`, `[auth_profile.X]`, `[sovereign]`, `[sovereign.enforce]`, or `[sovereign.tarpit]` was **still silently ignored**.

## Fix
`#[serde(deny_unknown_fields)]` on `AuditConfig`, `RedactConfig` (audit.rs), `AuthProfileConfig` (auth.rs), and `SovereignConfig` / `EnforceConfig` / `TarpitConfig` (sovereign/mod.rs). None use `#[serde(flatten)]` (incompatible with deny_unknown_fields — verified). 

New test `unknown_key_in_cross_module_subtable_is_rejected` proves a typo in `[audit]` now fails to load. Full suite green — config typo-coverage is now **end-to-end** (root + all sub-tables, in every module). README badge → 638.

Wave 2. Follows #240–#245.

🤖 Generated with [Claude Code](https://claude.com/claude-code)