### PR TITLE
feat(doctor): surface silently-off security defaults (rate-limit / WAF coverage)

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Client -> TLS 1.3 -> Security Gates -> Radix Router -> WAF Pipeline (5 gates) ->
 ```
 
 <!-- zion-stats:modules-lines (kept in sync by scripts/update-readme-stats.sh) -->
-40 modules, ~29,100 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
+40 modules, ~29,200 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
 
 ## Features
 
@@ -245,7 +245,7 @@ MODE=full bash benchmarks/baseline/run-baseline.sh   # → benchmarks/baseline/z
 ## Testing
 
 ```bash
-# Unit tests (638) <!-- zion-stats:test-count (kept in sync by scripts/update-readme-stats.sh) -->
+# Unit tests (639) <!-- zion-stats:test-count (kept in sync by scripts/update-readme-stats.sh) -->
 cargo test
 
 # Integration tests (23 — requires a running Zion + backend)

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -118,6 +118,7 @@ fn collect_checks(p: &crate::bootstrap::Platform) -> Vec<Check> {
             Ok(cfg) => {
                 checks.push(Check::ok("config", format!("{path} parses and validates")));
                 checks.push(check_upstreams_reachable(&cfg));
+                checks.push(check_security_posture(&cfg));
             }
             Err(e) => checks.push(Check::fail(
                 "config",
@@ -183,6 +184,42 @@ fn check_upstreams_reachable(cfg: &crate::config::ZionConfig) -> Check {
             "upstreams",
             format!("unreachable: {}", unreachable.join(", ")),
             "start the backend(s) or fix host:port — transient if they're still booting",
+        )
+    }
+}
+
+/// Surface the security-relevant defaults that are *silently off*, so they're
+/// a conscious operator choice rather than a surprise: per-IP request-rate
+/// limiting (`rate_limit_rps = 0` = disabled) and WAF coverage (no route with a
+/// `waf_profile` / `waf = true`). **Warn**, not fail — a gateway may legitimately
+/// run without either, but the operator should know.
+fn check_security_posture(cfg: &crate::config::ZionConfig) -> Check {
+    let rate_off = cfg.server.rate_limit_rps == 0;
+    let waf_routes = cfg
+        .route
+        .iter()
+        .filter(|r| r.waf_profile.is_some() || r.waf)
+        .count();
+    let total = cfg.route.len();
+
+    let mut notes = Vec::new();
+    if rate_off {
+        notes.push("per-IP request-rate limiting is OFF (server.rate_limit_rps = 0)".to_string());
+    }
+    if total > 0 && waf_routes == 0 {
+        notes.push("WAF is not assigned to any route".to_string());
+    }
+
+    if notes.is_empty() {
+        Check::ok(
+            "posture",
+            format!("rate-limit on; WAF on {waf_routes}/{total} routes"),
+        )
+    } else {
+        Check::warn(
+            "posture",
+            notes.join("; "),
+            "intentional? set server.rate_limit_rps and/or a route waf_profile to harden",
         )
     }
 }
@@ -620,6 +657,45 @@ mod tests {
         );
         // No host (malformed) → None; config validation reports it separately.
         assert_eq!(upstream_socket_addr("not a url"), None);
+    }
+
+    #[test]
+    fn security_posture_warns_when_protections_off() {
+        // rate-limit defaulted off + no WAF on any route → Warn.
+        let off = r#"
+[server]
+listen_http = "0.0.0.0:80"
+listen_https = "0.0.0.0:443"
+[tls]
+cert_path = "/c"
+key_path = "/k"
+[upstreams]
+be = "http://127.0.0.1:8000"
+[[route]]
+path = "/{*rest}"
+upstream = "be"
+"#;
+        let cfg: crate::config::ZionConfig = toml::from_str(off).unwrap();
+        assert_eq!(check_security_posture(&cfg).status, Status::Warn);
+
+        // rate-limit on + a WAF-protected route → Ok.
+        let hardened = r#"
+[server]
+listen_http = "0.0.0.0:80"
+listen_https = "0.0.0.0:443"
+rate_limit_rps = 100
+[tls]
+cert_path = "/c"
+key_path = "/k"
+[upstreams]
+be = "http://127.0.0.1:8000"
+[[route]]
+path = "/{*rest}"
+upstream = "be"
+waf = true
+"#;
+        let cfg2: crate::config::ZionConfig = toml::from_str(hardened).unwrap();
+        assert_eq!(check_security_posture(&cfg2).status, Status::Ok);
     }
 
     #[test]


### PR DESCRIPTION
**Wave 2 operability — the last quick win.** Two security-relevant defaults are *silently off*: per-IP request-rate limiting (`rate_limit_rps` defaults to `0` = disabled) and WAF coverage (a route can carry no `waf_profile`/`waf`). Both are legitimate choices — but an operator who assumes they're on gets no signal.

`check_security_posture()` now **WARNs** (not fails) in `zion doctor` when rate-limiting is off or no route has a WAF, with an `intentional?` fix hint — turning two silent-off defaults into a conscious choice. **OK** (with the WAF route count) when protections are on. Pure + unit-tested.

README badge → 639. Wave 2 (final quick win). Follows #240–#246.

🤖 Generated with [Claude Code](https://claude.com/claude-code)