### PR TITLE
fix(config)+docs: surface max_body_mb-without-WAF footgun; formalize panic doctrine

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -774,6 +774,17 @@ pub fn build_router(config: &ZionConfig) -> Result<Router<Arc<ResolvedRoute>>, S
                 ..WafProfile::default()
             })
         } else {
+            // Footgun guard: `max_body_mb` is enforced by the WAF body gate, so
+            // on a WAF-off route it has no effect. Surface it at boot rather
+            // than silently dropping the operator's intended size cap (a no-WAF
+            // route otherwise streams the body to the upstream, hyper-framed).
+            if route.max_body_mb.is_some() {
+                eprintln!(
+                    "  ⚠ route '{}': max_body_mb is set but WAF is off (no waf=true / waf_profile) \
+                     — the body-size cap is NOT enforced; enable WAF or remove max_body_mb",
+                    route.path
+                );
+            }
             None
         };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -720,12 +720,25 @@ fn main() -> error::ZionResult<()> {
         }
     }
 
+    // ── PANIC DOCTRINE (release) ──
+    // The release profile is `panic = "abort"` (Cargo.toml): a panic aborts the
+    // process — it does NOT unwind, so `catch_unwind` is a no-op in release and
+    // a single reachable panic on the request path would drop every in-flight
+    // connection. The doctrine that makes this safe is therefore, in order:
+    //   1. NO reachable panic on the request/reload hot path — `unwrap`/`expect`/
+    //      indexing there is a bug to eliminate, not to catch (audited: none
+    //      reachable with attacker-controlled input as of the W2 hardening).
+    //   2. This boot panic hook: every panic emits a structured last-gasp JSON
+    //      (stderr + file) so a sidecar / next-boot probe self-reports the death.
+    // Switching to `panic = "unwind"` + a request-path catch_unwind→500 is a
+    // deliberate trade (binary size, unwind-safety across the unsafe libc/io_uring
+    // FFI) — a separate decision, not adopted here.
+    //
     // 0a-pre. Install the panic hook BEFORE any worker thread is spawned so
     //         every panic — boot, async worker, anywhere — emits a structured
     //         JSON record to stderr and to a last-gasp file (so a sidecar /
-    //         next-boot probe can self-report the previous death). The
-    //         release profile is `panic = "abort"`; this runs once before
-    //         abort. The path is overridable via ZION_LAST_GASP_PATH.
+    //         next-boot probe can self-report the previous death). This runs
+    //         once before abort. The path is overridable via ZION_LAST_GASP_PATH.
     let last_gasp = std::env::var_os("ZION_LAST_GASP_PATH")
         .map(std::path::PathBuf::from)
         .or_else(|| Some(std::path::PathBuf::from("/var/lib/zion/last_panic.jsonl")));

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -206,9 +206,14 @@ pub(crate) fn spawn_config_watcher(
                     // construction is microseconds, Aho-Corasick is
                     // already cached per-mode in OnceLock).
                     // `try_build` returns a structured error for routine
-                    // failures (bad pattern, unknown profile). The
-                    // catch_unwind around it stays as defense-in-depth
-                    // against any deeper panic that escapes validation.
+                    // failures (bad pattern, unknown profile). The catch_unwind
+                    // guards a deeper panic escaping validation — but note the
+                    // release profile sets `panic = "abort"` (Cargo.toml), under
+                    // which a panic aborts before unwinding, so this catch is a
+                    // no-op in release (it only fires in debug/test, panic=
+                    // unwind). The operative release doctrine is therefore "no
+                    // reachable panic on the reload path" + the boot panic hook.
+                    // See the PANIC DOCTRINE note in main.rs.
                     let previous = state_config.load_full();
                     let rebuild_result =
                         std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {


### PR DESCRIPTION
**Wave 2 finalization** — the two design-calls, scoped to the clean/honest versions after code investigation *revised the original recommendations* (the rigor-driven adjustment).

### 1. Body-cap footgun (config.rs)
`max_body_mb` is enforced by the **WAF body gate**, so on a route with WAF **off** it was **silently ignored** — the operator's intended size cap simply didn't apply. Now **warn loudly at boot**: *"route 'X': max_body_mb is set but WAF is off … the cap is NOT enforced"*. 

*Not* imposing a default cap on no-WAF routes: they stream the body (hyper-framed, memory-safe) **on purpose** for large uploads — a blanket cap would break that. The fix is surfacing the silent mismatch, not changing the streaming behavior.

### 2. Panic doctrine (main.rs + reload.rs)
`catch_unwind` is a **no-op under release `panic = "abort"`** (a panic aborts before unwinding), so reload.rs's *"defense-in-depth"* comment was misleading — corrected. Added a **PANIC DOCTRINE** note in main.rs: the release contract is **(1)** no reachable panic on the hot path (audited: none) + **(2)** the boot last-gasp panic hook. 

Switching to `panic = "unwind"` + a request-path `catch_unwind→500` is a deliberate trade (binary size, unwind-safety across the unsafe libc/io_uring FFI) — **flagged, not adopted** (no reachable panic makes the cost unjustified today).

No behavior change beyond the boot warning; otherwise docs/comments. Badge unchanged (639).

**Closes Wave 2.** Follows #240–#247.

🤖 Generated with [Claude Code](https://claude.com/claude-code)