### PR TITLE
chore(release): v0.4.6 — correctness, conformance & operability (summer waves 1-2)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,7 +21,7 @@ A clear and concise description of what you expected to happen.
 **Environment (please complete the following information):**
  - OS: [e.g. Linux, macOS]
  - Architecture: [e.g. arm64, amd64]
- - Zion Version: [e.g. 0.4.5]
+ - Zion Version: [e.g. 0.4.6]
 
 **Additional context**
 Add any other context about the problem here (e.g. logs with `RUST_LOG=trace`, upstream backend type like Go/Node).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,44 @@ All notable changes to Zion Edge Gateway are documented here.
 
 ## [Unreleased]
 
+## [0.4.6] - 2026-06-26
+
+A correctness, conformance & operability release — the summer "diamond"
+program, waves 1-2 (14 PRs since 0.4.5), each gap verified in code and each
+security-relevant decision covered by a CI-run unit test.
+
+### Security
+- Shared cache no longer reuses a response to an **authenticated** request
+  (`Authorization`) without an explicit opt-in (`public`/`s-maxage`/
+  `must-revalidate`) — RFC 9111 §3.5, closes a cross-user disclosure on
+  cache-enabled routes (#235).
+
+### Conformance (HTTP RFC 9110/9111, TLS RFC 8446/8470)
+- `405` responses now carry `Allow`; `401` carry `WWW-Authenticate` — RFC 9110
+  MUSTs (#237).
+- Hop-by-hop headers (incl. any field named in `Connection`) are stripped from
+  upstream **responses**, not just requests — RFC 9110 §7.6.1 (#238).
+- Header-less responses get a **conservative 1-hour** heuristic freshness
+  instead of a 1-year `immutable` freeze; `immutable` is now opt-in via an
+  explicit long `ttl_seconds` — RFC 9111 §4.2.2, closes the cache-staleness
+  family (#239).
+- The 0-RTT **425** replay gate and the TLS version floor are now covered by
+  CI-run unit tests; the TLS-conformance doc no longer lists tests that never
+  existed (#236).
+
+### Operability & solidity
+- **Unknown config keys are rejected** (`deny_unknown_fields`) instead of
+  silently ignored — root and every sub-table (#244, #246).
+- `zion doctor` now validates the **deployment**: it parses+validates the
+  config, probes upstream reachability, and warns when rate-limiting or WAF
+  coverage is off (#245, #247).
+- Non-`http(s)` upstream URLs are rejected at startup (#241); audit-log
+  flush/write failures are surfaced, not swallowed (#243); request-path errors
+  go through structured logging instead of `eprintln!` (#242); a latent
+  process-abort (`unreachable!`) was removed from the cache hot path (#240).
+- `max_body_mb` set on a WAF-off route now warns at boot instead of silently
+  no-op'ing; the release panic doctrine is documented (#248).
+
 ## [0.4.5] - 2026-06-26
 
 A WAF detection-coverage patch, driven by a larger sourced corpus.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5540,7 +5540,7 @@ dependencies = [
 
 [[package]]
 name = "zion"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "aho-corasick",
  "aimp_node",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zion"
-version = "0.4.5"
+version = "0.4.6"
 edition = "2021"
 # MSRV is the *core* default-features build (TLS proxy + WAF + cache + metrics).
 # Opt-in features (acme, auth, init, http3) pull crypto/i18n crates that have

--- a/README.md
+++ b/README.md
@@ -272,12 +272,12 @@ Every release is signed and carries SLSA v1.0 build provenance — see
 
 ```bash
 # Binary release (Sigstore-backed provenance via gh CLI)
-gh release download v0.4.5 -R fabriziosalmi/zion -p '*x86_64-unknown-linux-musl*' -p 'SHA256SUMS'
+gh release download v0.4.6 -R fabriziosalmi/zion -p '*x86_64-unknown-linux-musl*' -p 'SHA256SUMS'
 sha256sum --check --ignore-missing SHA256SUMS
-gh attestation verify zion-v0.4.5-x86_64-unknown-linux-musl.tar.gz --owner fabriziosalmi
+gh attestation verify zion-v0.4.6-x86_64-unknown-linux-musl.tar.gz --owner fabriziosalmi
 
 # Container image (cosign keyless)
-cosign verify ghcr.io/fabriziosalmi/zion:v0.4.5 \
+cosign verify ghcr.io/fabriziosalmi/zion:v0.4.6 \
     --certificate-identity-regexp "^https://github.com/fabriziosalmi/zion/\\.github/workflows/release\\.yml@refs/tags/v" \
     --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ from their containing minor — i.e. the latest `0.4.x` is always patched.
 | Version | Supported |
 | ------- | --------- |
 | 0.4.x (latest minor) | Yes |
-| < 0.4.5 | No |
+| < 0.4.6 | No |
 
 ## Reporting a Vulnerability
 

--- a/deploy/helm/zion/Chart.yaml
+++ b/deploy/helm/zion/Chart.yaml
@@ -3,7 +3,7 @@ name: zion
 description: Zion Edge Gateway — high-performance Rust TLS reverse proxy with WAF
 type: application
 version: 0.2.2
-appVersion: "0.4.5"
+appVersion: "0.4.6"
 home: https://fabriziosalmi.github.io/zion
 sources:
   - https://github.com/fabriziosalmi/zion

--- a/docs/deploy/hot-reload.md
+++ b/docs/deploy/hot-reload.md
@@ -130,7 +130,7 @@ Two surfaces report the reload state:
 
   ```json
   {
-    "version": "0.4.5",
+    "version": "0.4.6",
     "timestamp_ms": 1714425600000,
     "uptime_secs": 3712,
     "config_generation": 5,

--- a/docs/security/supply-chain.md
+++ b/docs/security/supply-chain.md
@@ -46,8 +46,8 @@ You need the GitHub CLI (`gh >= 2.49`) and `cosign >= 2.2`.
 
 ```bash
 # 1. Download the artifact + SHA256SUMS from the release page.
-gh release download v0.4.5 -R fabriziosalmi/zion \
-    -p 'zion-v0.4.5-x86_64-unknown-linux-musl.tar.gz' \
+gh release download v0.4.6 -R fabriziosalmi/zion \
+    -p 'zion-v0.4.6-x86_64-unknown-linux-musl.tar.gz' \
     -p 'SHA256SUMS' \
     -p 'zion-sbom.cdx.json'
 
@@ -55,7 +55,7 @@ gh release download v0.4.5 -R fabriziosalmi/zion \
 sha256sum --check --ignore-missing SHA256SUMS
 
 # 3. Verify the SLSA build provenance bound to the artifact's hash.
-gh attestation verify zion-v0.4.5-x86_64-unknown-linux-musl.tar.gz \
+gh attestation verify zion-v0.4.6-x86_64-unknown-linux-musl.tar.gz \
     --owner fabriziosalmi
 
 # Step 3 fails if:
@@ -78,7 +78,7 @@ grype zion-sbom.cdx.json
 ## Verifying a container image
 
 ```bash
-IMAGE=ghcr.io/fabriziosalmi/zion:v0.4.5
+IMAGE=ghcr.io/fabriziosalmi/zion:v0.4.6
 
 # 1. Pin to the digest immediately — tags are mutable, digests are not.
 DIGEST=$(crane digest "$IMAGE")
@@ -120,7 +120,7 @@ deterministically, and pins the Rust toolchain via
 [`rust-toolchain.toml`](../../rust-toolchain.toml). To reproduce locally:
 
 ```bash
-git checkout v0.4.5
+git checkout v0.4.6
 export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)
 # Linux musl example — matches the release artifact byte-for-byte
 # (modulo strip's stable behavior on your distro).


### PR DESCRIPTION
Patch release cutting v0.4.5 -> v0.4.6. Bundles the summer 'diamond' program waves 1-2 (14 PRs #235-#248): RFC 9110/9111/8446/8470 conformance, the §3.5 cache cross-user-disclosure fix, deny_unknown_fields, doctor deploy checks, and the solidity hardening. +24 tests. Version SSOT swept; CHANGELOG [Unreleased] -> [0.4.6]. Tag v0.4.6 after merge fires release.yml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)