### PR TITLE
fix(proxy): scrub hop-by-hop on the WebSocket non-101 path too (review finding)

### DIFF
--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -1287,9 +1287,9 @@ async fn process_request_inner(
 /// because nosniff was set).
 #[inline]
 /// Cache-Control to emit for a cached asset when the upstream did not set one:
-/// the profile TTL as a public max-age, or `immutable` for the ~1-year default
-/// (which marks content-hashed assets). Replaces the old blanket "immutable"
-/// stamp that ignored the profile TTL and clobbered the origin's policy.
+/// the profile TTL as a public max-age, or `immutable` ONLY when the operator
+/// explicitly set a ttl >= 1 year (content-hashed assets opt in). The default
+/// is now a conservative 1h, so a header-less response is never frozen.
 fn profile_cache_control(ttl_seconds: u64) -> hyper::header::HeaderValue {
     if ttl_seconds >= 31_536_000 {
         hyper::header::HeaderValue::from_static(CACHE_CONTROL_IMMUTABLE)
@@ -1452,7 +1452,7 @@ async fn handle_static_cache(
     }
 
     // Cache TTL / capacity from the profile (mode=StaticCache without an
-    // explicit profile uses the ~1-year content-hashed default).
+    // explicit profile uses the conservative 1h default; see config::default_ttl).
     let (cache_ttl, cache_max) = match &rule.cache {
         Some(cp) => (cp.ttl_seconds, cp.max_entries),
         // Conservative fallback (1h) for a static_cache route with no resolved

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -245,10 +245,6 @@ pub async fn proxy_pass(
     send_request(client, req).await
 }
 
-/// Like [`send_request`] but surfaces the transport error to the caller
-/// instead of collapsing it into a 502, so [`proxy_pass_ha`] can decide
-/// whether to fail over to another upstream.
-#[inline]
 /// Strip hop-by-hop headers from an upstream RESPONSE before relaying it to the
 /// client (RFC 9110 §7.6.1). These are meaningful only on the upstream→zion hop;
 /// hyper frames the client connection itself, so forwarding the upstream's
@@ -285,6 +281,10 @@ fn scrub_response_hop_by_hop(headers: &mut hyper::HeaderMap) {
     headers.remove("Keep-Alive");
 }
 
+/// Like [`send_request`] but surfaces the transport error to the caller
+/// instead of collapsing it into a 502, so [`proxy_pass_ha`] can decide
+/// whether to fail over to another upstream.
+#[inline]
 async fn send_request_try(
     client: &HttpClient,
     req: Request<ZionBody>,
@@ -692,9 +692,13 @@ async fn send_ws_upgrade(
         }
     };
 
-    // If upstream didn't 101, return that response as-is
+    // If upstream didn't 101, return that response as-is — but still strip
+    // hop-by-hop headers (RFC 9110 §7.6.1), same as the normal proxy return
+    // paths. A declined WS upgrade is a normal HTTP response and must not leak
+    // the upstream's Connection/Keep-Alive/Transfer-Encoding to the client.
     if upstream_resp.status() != StatusCode::SWITCHING_PROTOCOLS {
-        let (parts, body) = upstream_resp.into_parts();
+        let (mut parts, body) = upstream_resp.into_parts();
+        scrub_response_hop_by_hop(&mut parts.headers);
         return Ok(Response::from_parts(parts, body.boxed()));
     }
 


### PR DESCRIPTION
**Consolidation — adversarial re-review of v0.4.6** caught a 4th return path the #238 hop-by-hop scrub missed.

When a client sends a WebSocket `Upgrade` and the upstream **declines** with a normal HTTP response (200/302/401/426/502…), `send_ws_upgrade` relayed it **as-is** — leaking the upstream's `Connection` / `Keep-Alive` / `Transfer-Encoding` (and any `Connection`-nominated field) to the client on a kept-alive connection. That's the exact desync / response-smuggling surface #238 set out to close, on a path it didn't reach. Now `scrub_response_hop_by_hop` runs there too.

Also in this review-fixes batch (cosmetic):
- The scrub fn's insertion had displaced `send_request_try`'s doc + `#[inline]` onto it — reattached.
- Corrected two stale "one-year default" comments in dispatch.rs left from #239 (the default is now a conservative 1h).

No new test (`scrub_response_hop_by_hop` is already unit-tested; the WS-decline path is integration-only); no behavior change beyond the added scrub call. Badge unchanged.

First of the post-review consolidation fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)