### PR TITLE
fix: address adversarial re-review findings (round 2) — config example, audit resilience, doctor DNS

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Client -> TLS 1.3 -> Security Gates -> Radix Router -> WAF Pipeline (5 gates) ->
 ```
 
 <!-- zion-stats:modules-lines (kept in sync by scripts/update-readme-stats.sh) -->
-40 modules, ~29,200 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
+40 modules, ~29,300 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
 
 ## Features
 

--- a/examples/multi-site.toml
+++ b/examples/multi-site.toml
@@ -75,11 +75,13 @@ max_entries = 10000
 ttl_seconds = 31536000
 
 # ── Routes ───────────────────────────────────────────────────────
-# API backend (with WAF)
+# API backend (with WAF + CORS)
 [[route]]
 path = "/api/{*rest}"
 upstream = "api"
 waf_profile = "strict"
+# CORS is configured PER ROUTE (there is no top-level [cors] table).
+cors = { allowed_origins = ["https://app.example.com"], allowed_headers = ["Content-Type", "Authorization"], max_age = 86400 }
 
 # Next.js static assets (cached in RAM)
 [[route]]
@@ -115,9 +117,3 @@ internal_only = true
 [[route]]
 path = "/{*rest}"
 upstream = "frontend"
-
-# ── CORS (for API) ───────────────────────────────────────────────
-[cors]
-allowed_origins = ["https://app.example.com"]
-allowed_headers = ["Content-Type", "Authorization"]
-max_age = 86400

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -445,11 +445,9 @@ async fn writer_loop(
         )),
     };
     if let Ok((signed, new_prev)) = sign_event(&key, init, prev_hash.clone()) {
-        if let Ok(line) = serde_json::to_string(&signed) {
-            if file.write_all(line.as_bytes()).await.is_err()
-                || file.write_all(b"\n").await.is_err()
-                || file.flush().await.is_err()
-            {
+        if let Ok(mut line) = serde_json::to_string(&signed) {
+            line.push('\n'); // one all-or-nothing record write (no orphaned line)
+            if file.write_all(line.as_bytes()).await.is_err() || file.flush().await.is_err() {
                 crate::logging::error(
                     "audit",
                     "audit chain-init write/flush failed — the on-disk log may be unreliable",
@@ -461,6 +459,9 @@ async fn writer_loop(
     }
 
     let mut seq: u64 = 1;
+    // Tracks whether flush is currently failing, so we log the degraded↔healthy
+    // transition once instead of per-event.
+    let mut flush_degraded = false;
     while let Some(mut event) = rx.recv().await {
         event.seq = seq;
         if event.ts.is_empty() {
@@ -468,29 +469,43 @@ async fn writer_loop(
         }
         match sign_event(&key, event, prev_hash.clone()) {
             Ok((signed, new_prev)) => {
-                if let Ok(line) = serde_json::to_string(&signed) {
-                    if file.write_all(line.as_bytes()).await.is_err()
-                        || file.write_all(b"\n").await.is_err()
-                    {
+                if let Ok(mut line) = serde_json::to_string(&signed) {
+                    line.push('\n'); // single all-or-nothing record write
+                    if file.write_all(line.as_bytes()).await.is_err() {
+                        // Terminal: the buffer can't even accept the record
+                        // (disk full / fd revoked). Stop rather than spin.
                         crate::logging::error(
                             "audit",
-                            "audit log write failed — disk full or fd revoked, exiting writer",
+                            "audit log write failed — buffer cannot accept data (disk full / fd revoked), exiting writer",
                         );
                         break;
                     }
                     prev_hash = new_prev;
                     seq += 1;
-                    // Flush each event — durability over throughput. Audit
-                    // logs are low-rate; if this becomes a bottleneck we
-                    // can batch on a 100ms timer. A flush failure means the
-                    // event is NOT durable — surface it and stop, rather than
-                    // silently advancing the chain over un-persisted data.
-                    if file.flush().await.is_err() {
-                        crate::logging::error(
-                            "audit",
-                            "audit log flush failed — events may not be durable, exiting writer",
-                        );
-                        break;
+                    // Flush each event — durability over throughput. A flush
+                    // failure (transient ENOSPC, slow network FS) does NOT kill
+                    // the writer: the record stays buffered and a later flush
+                    // retries it, so audit self-heals once the disk recovers.
+                    // Log the degraded↔healthy transition once, not per event.
+                    match file.flush().await {
+                        Ok(()) => {
+                            if flush_degraded {
+                                crate::logging::warn(
+                                    "audit",
+                                    "audit log flush recovered — durability restored",
+                                );
+                                flush_degraded = false;
+                            }
+                        }
+                        Err(e) => {
+                            if !flush_degraded {
+                                crate::logging::error(
+                                    "audit",
+                                    &format!("audit log flush failing ({e}) — records buffered, not yet durable; retrying (writer stays alive)"),
+                                );
+                                flush_degraded = true;
+                            }
+                        }
                     }
                 }
             }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1367,17 +1367,27 @@ mtls_fingerprint = false
 
     #[test]
     fn example_config_parses_with_deny_unknown_fields() {
-        // The documented reference config MUST always deserialize — this also
-        // guards `deny_unknown_fields` against drift between zion.example.toml
-        // and the config structs (a new TOML key without a struct field, or a
-        // renamed field, fails here loudly instead of in production).
-        let toml = include_str!("../zion.example.toml");
-        let parsed: Result<ZionConfig, _> = toml::from_str(toml);
-        assert!(
-            parsed.is_ok(),
-            "zion.example.toml failed to parse: {:?}",
-            parsed.err()
-        );
+        // Every shipped reference/example config MUST deserialize — this guards
+        // `deny_unknown_fields` against drift between the docs and the structs
+        // (a new/renamed/misplaced TOML key fails here loudly, not in prod).
+        // Covers zion.example.toml + all examples/*.toml so a new example can't
+        // silently ship un-loadable (this caught examples/multi-site.toml's
+        // top-level [cors] block).
+        let root = env!("CARGO_MANIFEST_DIR");
+        let mut files = vec![std::path::PathBuf::from(format!(
+            "{root}/zion.example.toml"
+        ))];
+        for entry in std::fs::read_dir(format!("{root}/examples")).expect("read examples/") {
+            let p = entry.unwrap().path();
+            if p.extension().and_then(|e| e.to_str()) == Some("toml") {
+                files.push(p);
+            }
+        }
+        for f in &files {
+            let toml = std::fs::read_to_string(f).unwrap_or_else(|e| panic!("read {f:?}: {e}"));
+            let parsed: Result<ZionConfig, _> = toml::from_str(&toml);
+            assert!(parsed.is_ok(), "{f:?} failed to parse: {:?}", parsed.err());
+        }
     }
 
     #[test]

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -147,11 +147,35 @@ fn upstream_socket_addr(url: &str) -> Option<String> {
     Some(format!("{host}:{port}"))
 }
 
+/// Resolve + TCP-connect `host:port`, BOUNDED end-to-end. `connect_timeout`
+/// only caps the connect; `to_socket_addrs` (blocking libc `getaddrinfo`) has no
+/// timeout and stalls for the OS resolver budget on a slow/blackholed DNS. Run
+/// the whole probe on a detached thread and cap it with a `recv_timeout` so
+/// `zion doctor` can't hang (a leaked thread on a hung resolver is fine for a
+/// short-lived CLI). Returns false on timeout / unresolved / refused.
+fn probe_reachable(addr: String) -> bool {
+    use std::net::ToSocketAddrs;
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let ok = addr
+            .to_socket_addrs()
+            .ok()
+            .and_then(|mut a| a.next())
+            .map(|sa| {
+                std::net::TcpStream::connect_timeout(&sa, std::time::Duration::from_millis(500))
+                    .is_ok()
+            })
+            .unwrap_or(false);
+        let _ = tx.send(ok);
+    });
+    rx.recv_timeout(std::time::Duration::from_secs(2))
+        .unwrap_or(false)
+}
+
 /// Probe each configured upstream with a short TCP connect. **Warn**, not fail,
 /// on unreachable — a backend may simply be booting — but surface it so a
 /// typo'd host:port or a down backend is visible before the first request.
 fn check_upstreams_reachable(cfg: &crate::config::ZionConfig) -> Check {
-    use std::net::ToSocketAddrs;
     let mut urls: Vec<String> = cfg.upstreams.values().cloned().collect();
     for up in cfg.upstream.values() {
         urls.extend(up.get_urls());
@@ -164,16 +188,7 @@ fn check_upstreams_reachable(cfg: &crate::config::ZionConfig) -> Check {
         let Some(addr) = upstream_socket_addr(url) else {
             continue; // malformed URL already reported by config validation
         };
-        let reachable = addr
-            .to_socket_addrs()
-            .ok()
-            .and_then(|mut a| a.next())
-            .map(|sa| {
-                std::net::TcpStream::connect_timeout(&sa, std::time::Duration::from_millis(500))
-                    .is_ok()
-            })
-            .unwrap_or(false);
-        if !reachable {
+        if !probe_reachable(addr) {
             unreachable.push(url.clone());
         }
     }

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -53,7 +53,7 @@ pub fn render_counters(out: &mut bytes::BytesMut) {
         ),
         (
             "zion_audit_events_dropped_total",
-            "Audit events dropped because the writer queue was full.",
+            "Audit events dropped: queue full (back-pressure) OR the writer task has terminally exited (write failure). A sustained non-zero rate with low traffic indicates a dead writer, not back-pressure.",
             AUDIT_EVENTS_DROPPED_TOTAL.load(Ordering::Relaxed),
         ),
         (


### PR DESCRIPTION
**Consolidation round 2** — the 3 remaining confirmed findings from the adversarial re-review of v0.4.6.

### 1. `examples/multi-site.toml` hard-failed to load (HIGH)
It carried a top-level `[cors]` table, but `ZionConfig` has no `cors` field (CORS is per-route). Pre-#244 the stray block was silently ignored; under `deny_unknown_fields` the **shipped example now refused to boot**. Moved CORS inline onto the `/api` route (keys match `CorsConfig`), and **extended `example_config_parses` to glob all `examples/*.toml`** so a new example can't ship un-loadable.

### 2. audit writer: transient flush failure no longer kills audit forever (MEDIUM-HIGH regression in #243)
A per-event `flush()` failure used to `break` the writer **permanently** — a single transient ENOSPC killed audit for the whole process lifetime (worse than the old swallow-and-continue, which self-healed). Now a flush failure **logs once and keeps the writer alive** (records stay buffered, a later flush retries → self-heals); only a *write* failure (buffer can't accept data) is terminal. Chain-init + per-event records are now single all-or-nothing `line+\n` writes (no orphaned `chain_init` line on a partial write). Clarified the dropped-events metric help text (queue-full vs dead-writer).

### 3. `zion doctor` could hang on slow DNS (MEDIUM)
The upstream probe used blocking `to_socket_addrs()` with no timeout (only the connect was bounded). New `probe_reachable()` runs resolve+connect on a detached thread bounded by a 2s `recv_timeout`.

No new tests (behavior/IO changes; the multi-site fix is covered by the now-globbing example test). README line count → ~29,300 (test badge 639 unchanged).

Closes the post-v0.4.6 consolidation re-review. Follows #250.

🤖 Generated with [Claude Code](https://claude.com/claude-code)