### PR TITLE
feat(admin): read-only admin listener + GET /admin/config (#26 Phase 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Client -> TLS 1.3 -> Security Gates -> Radix Router -> WAF Pipeline (5 gates) ->
 ```
 
 <!-- zion-stats:modules-lines (kept in sync by scripts/update-readme-stats.sh) -->
-41 modules, ~29,600 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
+42 modules, ~29,900 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
 
 ## Features
 
@@ -245,7 +245,7 @@ MODE=full bash benchmarks/baseline/run-baseline.sh   # → benchmarks/baseline/z
 ## Testing
 
 ```bash
-# Unit tests (645) <!-- zion-stats:test-count (kept in sync by scripts/update-readme-stats.sh) -->
+# Unit tests (649) <!-- zion-stats:test-count (kept in sync by scripts/update-readme-stats.sh) -->
 cargo test
 
 # Integration tests (23 — requires a running Zion + backend)

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Admin API — a dedicated, loopback-by-default listener for runtime config
+//! inspection (and, in later #26 phases, push + reload).
+//!
+//! Phase 2 is **read-only**: `GET /admin/config` returns the live snapshot JSON
+//! — the SAME source of truth as `/_zion/snapshot.json` (`metrics::snapshot_json`)
+//! — gated to internal IPs (`auth = "internal-ip"`, the default). The listener
+//! is **physically separate** from the public `:443`, so a routing accident
+//! can't expose `/admin/*`. Absent `[admin]` section ⇒ no listener (zero
+//! overhead, zero attack surface).
+//!
+//! Deliberately NOT trusting `X-Forwarded-For` / `X-Client-Cert-*` here: admin
+//! authorization is not transitive through a forwarding proxy. Plain HTTP on
+//! loopback for now; mTLS is Phase 4.
+
+use crate::AppState;
+use bytes::Bytes;
+use http_body_util::Full;
+use hyper::service::service_fn;
+use hyper::{Method, Request, Response, StatusCode};
+use hyper_util::rt::TokioIo;
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+/// Spawn the admin listener. Returns immediately; the accept loop runs on a
+/// tokio task. A bind failure is logged and the task exits (the data plane is
+/// untouched — the admin listener is independent by design).
+pub(crate) fn spawn_admin_listener(state: Arc<AppState>, listen: SocketAddr) {
+    tokio::spawn(async move {
+        let listener = match tokio::net::TcpListener::bind(listen).await {
+            Ok(l) => l,
+            Err(e) => {
+                crate::logging::error(
+                    "admin",
+                    &format!("cannot bind admin listener on {listen}: {e} — admin API disabled"),
+                );
+                return;
+            }
+        };
+        crate::logging::info(
+            "admin",
+            &format!("admin API on {listen} (read-only; internal-ip auth)"),
+        );
+        loop {
+            match listener.accept().await {
+                Ok((stream, peer)) => {
+                    let st = state.clone();
+                    tokio::spawn(async move {
+                        let io = TokioIo::new(stream);
+                        // Connection-level idle bound so a stuck admin client
+                        // can't pin a task forever.
+                        let _ = tokio::time::timeout(
+                            std::time::Duration::from_secs(30),
+                            hyper::server::conn::http1::Builder::new().serve_connection(
+                                io,
+                                service_fn(move |req| handle(req, peer, st.clone())),
+                            ),
+                        )
+                        .await;
+                    });
+                }
+                Err(e) => crate::logging::warn("admin", &format!("admin accept error: {e}")),
+            }
+        }
+    });
+}
+
+/// Service handler: enforce internal-ip auth on the *connection peer* (never a
+/// forwarded header), then route. Infallible — always produces a response.
+async fn handle(
+    req: Request<hyper::body::Incoming>,
+    peer: SocketAddr,
+    state: Arc<AppState>,
+) -> Result<Response<Full<Bytes>>, std::convert::Infallible> {
+    let internal = crate::security::is_internal_ip(&peer.ip());
+    Ok(respond(req.method(), req.uri().path(), internal, || {
+        snapshot_body(&state)
+    }))
+}
+
+/// The auth + routing decision, pulled out so it's unit-testable without an
+/// `AppState`: the snapshot body is supplied lazily by the caller.
+fn respond(
+    method: &Method,
+    path: &str,
+    internal: bool,
+    snapshot: impl FnOnce() -> Bytes,
+) -> Response<Full<Bytes>> {
+    if !internal {
+        return json(StatusCode::FORBIDDEN, br#"{"error":"forbidden"}"#);
+    }
+    match (method, path) {
+        (&Method::GET, "/admin/config") => Response::builder()
+            .status(StatusCode::OK)
+            .header("Content-Type", "application/json; charset=utf-8")
+            .header("Cache-Control", "no-store")
+            .body(Full::new(snapshot()))
+            .unwrap(),
+        _ => json(StatusCode::NOT_FOUND, br#"{"error":"not found"}"#),
+    }
+}
+
+/// Build the live snapshot JSON from the current `ResolvedAppConfig` — identical
+/// construction to the `/_zion/snapshot.json` handler (same source of truth).
+fn snapshot_body(state: &AppState) -> Bytes {
+    let cfg = state.config.load();
+    let platform = crate::bootstrap::detect();
+    let mut rows: Vec<crate::metrics::UpstreamRow<'_>> = cfg
+        .health_map
+        .iter()
+        .map(|(url, h)| crate::metrics::UpstreamRow {
+            url: url.as_str(),
+            healthy: h.healthy.load(std::sync::atomic::Ordering::Relaxed),
+            latency_us: h.latency_us.load(std::sync::atomic::Ordering::Relaxed),
+        })
+        .collect();
+    rows.sort_by(|a, b| a.url.cmp(b.url));
+    crate::metrics::snapshot_json(platform, &rows)
+}
+
+fn json(status: StatusCode, body: &'static [u8]) -> Response<Full<Bytes>> {
+    Response::builder()
+        .status(status)
+        .header("Content-Type", "application/json; charset=utf-8")
+        .body(Full::new(Bytes::from_static(body)))
+        .unwrap()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn snap() -> Bytes {
+        Bytes::from_static(b"{\"snapshot\":true}")
+    }
+
+    #[test]
+    fn non_internal_peer_is_forbidden() {
+        let r = respond(&Method::GET, "/admin/config", false, snap);
+        assert_eq!(r.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[test]
+    fn internal_get_config_returns_snapshot() {
+        let r = respond(&Method::GET, "/admin/config", true, snap);
+        assert_eq!(r.status(), StatusCode::OK);
+        assert_eq!(
+            r.headers().get("Content-Type").unwrap(),
+            "application/json; charset=utf-8"
+        );
+        assert_eq!(r.headers().get("Cache-Control").unwrap(), "no-store");
+    }
+
+    #[test]
+    fn internal_unknown_route_is_404() {
+        assert_eq!(
+            respond(&Method::GET, "/admin/nope", true, snap).status(),
+            StatusCode::NOT_FOUND
+        );
+        // Wrong method on the known path → also 404 (no write endpoints yet).
+        assert_eq!(
+            respond(&Method::POST, "/admin/config", true, snap).status(),
+            StatusCode::NOT_FOUND
+        );
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -69,6 +69,33 @@ pub struct ZionConfig {
     // Legacy compat: flat upstreams map (just URLs)
     #[serde(default)]
     pub upstreams: HashMap<String, String>,
+
+    /// Admin API (#26). Absent block ⇒ no admin listener spawned (zero
+    /// overhead, zero attack surface). When present, a dedicated loopback
+    /// listener serves runtime config inspection / push.
+    #[serde(default)]
+    pub admin: Option<AdminConfig>,
+}
+
+/// `[admin]` block — the runtime admin API listener (#26). Loopback +
+/// internal-ip-gated by default; production turns on mTLS (Phase 4).
+#[derive(Deserialize, Clone, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct AdminConfig {
+    /// Listen address. Default `127.0.0.1:9180` (loopback only).
+    #[serde(default = "default_admin_listen")]
+    pub listen: String,
+    /// Auth mode: `"internal-ip"` (default — same gate as `/_zion/snapshot.json`)
+    /// or `"mtls"` (opt-in, Phase 4). Unknown values are rejected at validation.
+    #[serde(default = "default_admin_auth")]
+    pub auth: String,
+}
+
+fn default_admin_listen() -> String {
+    "127.0.0.1:9180".to_string()
+}
+fn default_admin_auth() -> String {
+    "internal-ip".to_string()
 }
 
 /// `[sovereign_aimp]` block — gossip control plane.
@@ -730,6 +757,22 @@ fn validate_config(config: &ZionConfig, path: &str) -> Result<(), String> {
             if let Some(e) = validate_upstream_url(&format!("upstream.{name}"), &url) {
                 errors.push(e);
             }
+        }
+    }
+
+    // [admin] — listen must be a real socket address; auth a known mode.
+    if let Some(ref admin) = config.admin {
+        if admin.listen.parse::<std::net::SocketAddr>().is_err() {
+            errors.push(format!(
+                "admin.listen '{}' is not a valid socket address (e.g. 127.0.0.1:9180)",
+                admin.listen
+            ));
+        }
+        if !matches!(admin.auth.as_str(), "internal-ip" | "mtls") {
+            errors.push(format!(
+                "admin.auth '{}' must be \"internal-ip\" or \"mtls\"",
+                admin.auth
+            ));
         }
     }
 
@@ -1469,6 +1512,30 @@ enabledd = true
         assert!(
             e.contains("enabledd") || e.contains("unknown field"),
             "error should name the unknown sub-table field, got: {e}"
+        );
+    }
+
+    #[test]
+    fn admin_config_defaults_and_validation() {
+        // Present-but-empty [admin] → loopback defaults.
+        let cfg: ZionConfig = toml::from_str(
+            "[server]\nlisten_http=\"0.0.0.0:80\"\nlisten_https=\"0.0.0.0:443\"\n\
+             [tls]\ncert_path=\"/c\"\nkey_path=\"/k\"\n[upstreams]\nbe=\"http://127.0.0.1:8000\"\n\
+             [[route]]\npath=\"/{*rest}\"\nupstream=\"be\"\n[admin]\n",
+        )
+        .unwrap();
+        let admin = cfg.admin.expect("[admin] present → Some");
+        assert_eq!(admin.listen, "127.0.0.1:9180");
+        assert_eq!(admin.auth, "internal-ip");
+
+        // A bogus auth mode is rejected by validate_str (semantic validation).
+        let bad = "[server]\nlisten_http=\"0.0.0.0:80\"\nlisten_https=\"0.0.0.0:443\"\n\
+             [tls]\ncert_path=\"/c\"\nkey_path=\"/k\"\n[upstreams]\nbe=\"http://127.0.0.1:8000\"\n\
+             [[route]]\npath=\"/{*rest}\"\nupstream=\"be\"\n[admin]\nauth=\"bogus\"\n";
+        let err = validate_str(bad, "test").err().unwrap_or_default();
+        assert!(
+            err.contains("admin.auth"),
+            "bad admin.auth must be rejected, got: {err}"
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,7 @@
 #![allow(clippy::needless_borrow)]
 
 mod acme;
+mod admin;
 mod audit;
 mod auth;
 mod bootstrap;
@@ -1100,6 +1101,27 @@ async fn async_main(platform: &'static bootstrap::Platform) -> error::ZionResult
         Some(config.tls.cert_path.clone()),
         Some(config.tls.key_path.clone()),
     );
+
+    // 5b. Admin API listener (#26 Phase 2) — read-only, loopback by default.
+    // listen + auth were validated at config load. Phase 2 only enforces the
+    // `internal-ip` gate; `mtls` is accepted by the schema but NOT yet enforced
+    // (Phase 4), so refuse to spawn rather than serve admin with an unenforced
+    // auth claim — fail safe.
+    if let Some(ref admin_cfg) = config.admin {
+        match admin_cfg.listen.parse::<std::net::SocketAddr>() {
+            Ok(addr) if admin_cfg.auth == "internal-ip" => {
+                admin::spawn_admin_listener(state.clone(), addr);
+            }
+            Ok(_) => logging::error(
+                "admin",
+                &format!(
+                    "admin.auth = '{}' is not yet enforced (mTLS lands in #26 Phase 4) — admin API NOT spawned",
+                    admin_cfg.auth
+                ),
+            ),
+            Err(e) => logging::error("admin", &format!("admin.listen invalid: {e}")),
+        }
+    }
 
     // 6. Spawn ACME auto-renewal task (if configured)
     if let Some(ref acme_config) = config.tls.acme {


### PR DESCRIPTION
**#26 Phase 2** — a dedicated, loopback-by-default admin listener for runtime config inspection, **physically separate** from the public `:443` so a routing accident can't expose `/admin/*`. Read-only in this phase.

```console
$ curl -s localhost:9180/admin/config | jq keys
["config_generation","metrics","platform","timestamp_ms","upstreams","uptime_secs","version"]
```

## What
- New optional **`[admin]`** section (`AdminConfig { listen = "127.0.0.1:9180", auth = "internal-ip" }`, `deny_unknown_fields`). **Absent ⇒ no listener** (zero overhead / attack surface). `validate_config` checks `listen` is a real socket address and `auth ∈ {internal-ip, mtls}`.
- New **`src/admin.rs`**: a simple accept loop (not the full `ListenerSupervisor` — loopback, single-purpose, plain HTTP; mTLS is Phase 4). `GET /admin/config` from an internal IP → 200 + the live snapshot JSON via **`metrics::snapshot_json`** (the SAME source of truth as `/_zion/snapshot.json`). Non-internal peer → 403; unknown route → 404.
- Auth is enforced on the **connection peer**, never a forwarded header (`X-Forwarded-For` / `X-Client-Cert-*` are **not trusted** — admin auth is not transitive through a proxy).
- `main.rs` spawns it at boot iff `[admin]` is configured. **Fail-safe**: `auth = "mtls"` is schema-valid but not yet enforced (Phase 4), so the listener **refuses to spawn** rather than serve admin under an unenforced auth claim.

## Verified
- Unit: `respond()` gate + routing (403 / 200 / 404) — pulled out so it's testable without an `AppState`; `[admin]` defaults + bad-`auth` rejection.
- **End-to-end smoke**: booted zion with `[admin]`; `GET /admin/config` → 200 + valid snapshot JSON (keys match `/_zion/snapshot.json`), unknown route → 404.

Roadmap: **Phase 3** = `POST /admin/config` + `/admin/reload` (via `reload_now`) → **Phase 4** = mTLS + audit + rate-limit + docs. Badge → 649. Part of #26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)