### PR TITLE
feat(admin): write endpoints — POST /admin/config + /admin/reload (#26 Phase 3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Client -> TLS 1.3 -> Security Gates -> Radix Router -> WAF Pipeline (5 gates) ->
 ```
 
 <!-- zion-stats:modules-lines (kept in sync by scripts/update-readme-stats.sh) -->
-42 modules, ~29,900 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
+42 modules, ~30,100 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
 
 ## Features
 
@@ -245,7 +245,7 @@ MODE=full bash benchmarks/baseline/run-baseline.sh   # → benchmarks/baseline/z
 ## Testing
 
 ```bash
-# Unit tests (649) <!-- zion-stats:test-count (kept in sync by scripts/update-readme-stats.sh) -->
+# Unit tests (652) <!-- zion-stats:test-count (kept in sync by scripts/update-readme-stats.sh) -->
 cargo test
 
 # Integration tests (23 — requires a running Zion + backend)

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -13,19 +13,42 @@
 //! authorization is not transitive through a forwarding proxy. Plain HTTP on
 //! loopback for now; mTLS is Phase 4.
 
+use crate::reload::{reload_now, ConfigSource};
 use crate::AppState;
 use bytes::Bytes;
-use http_body_util::Full;
+use http_body_util::{BodyExt, Full, Limited};
 use hyper::service::service_fn;
 use hyper::{Method, Request, Response, StatusCode};
 use hyper_util::rt::TokioIo;
 use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
+
+/// A pushed config body is capped — a `zion.toml` is small; anything larger is
+/// almost certainly a mistake or an attack, not a config.
+const MAX_ADMIN_BODY: usize = 1 << 20; // 1 MiB
+
+/// Everything `reload_now` needs that isn't in `AppState`, captured at boot and
+/// shared with the admin handler so `POST /admin/config` / `/admin/reload` flow
+/// through the EXACT same reload path as the file watcher (atomic swap, health
+/// preservation, generation bump, notify).
+pub(crate) struct AdminReloadCtx {
+    pub(crate) conn_limit_max: usize,
+    pub(crate) change_notifier: Option<tokio::sync::watch::Sender<u64>>,
+    pub(crate) config_path: PathBuf,
+    pub(crate) boot_tls_cert: Option<String>,
+    pub(crate) boot_tls_key: Option<String>,
+}
 
 /// Spawn the admin listener. Returns immediately; the accept loop runs on a
 /// tokio task. A bind failure is logged and the task exits (the data plane is
 /// untouched — the admin listener is independent by design).
-pub(crate) fn spawn_admin_listener(state: Arc<AppState>, listen: SocketAddr) {
+pub(crate) fn spawn_admin_listener(
+    state: Arc<AppState>,
+    listen: SocketAddr,
+    ctx: Arc<AdminReloadCtx>,
+) {
     tokio::spawn(async move {
         let listener = match tokio::net::TcpListener::bind(listen).await {
             Ok(l) => l,
@@ -39,12 +62,13 @@ pub(crate) fn spawn_admin_listener(state: Arc<AppState>, listen: SocketAddr) {
         };
         crate::logging::info(
             "admin",
-            &format!("admin API on {listen} (read-only; internal-ip auth)"),
+            &format!("admin API on {listen} (GET/POST /admin/config, POST /admin/reload; internal-ip auth)"),
         );
         loop {
             match listener.accept().await {
                 Ok((stream, peer)) => {
                     let st = state.clone();
+                    let cx = ctx.clone();
                     tokio::spawn(async move {
                         let io = TokioIo::new(stream);
                         // Connection-level idle bound so a stuck admin client
@@ -53,7 +77,7 @@ pub(crate) fn spawn_admin_listener(state: Arc<AppState>, listen: SocketAddr) {
                             std::time::Duration::from_secs(30),
                             hyper::server::conn::http1::Builder::new().serve_connection(
                                 io,
-                                service_fn(move |req| handle(req, peer, st.clone())),
+                                service_fn(move |req| handle(req, peer, st.clone(), cx.clone())),
                             ),
                         )
                         .await;
@@ -71,11 +95,109 @@ async fn handle(
     req: Request<hyper::body::Incoming>,
     peer: SocketAddr,
     state: Arc<AppState>,
+    ctx: Arc<AdminReloadCtx>,
 ) -> Result<Response<Full<Bytes>>, std::convert::Infallible> {
     let internal = crate::security::is_internal_ip(&peer.ip());
+    // Write endpoints (async + stateful) are handled here; the auth gate, the
+    // read (GET /admin/config) and 404 stay in the pure, unit-tested `respond`.
+    if internal && req.method() == Method::POST {
+        match req.uri().path() {
+            // Push a full new config body → validate + atomic-swap via reload_now.
+            "/admin/config" => {
+                let result = match read_body_string(req).await {
+                    Ok(toml) => reload_via(ConfigSource::Body(toml), &state, &ctx).await,
+                    Err(e) => Err(e),
+                };
+                return Ok(reload_response(result));
+            }
+            // Re-read zion.toml from disk (skip the watcher's 2s debounce).
+            "/admin/reload" => {
+                let src = ConfigSource::File(ctx.config_path.clone());
+                return Ok(reload_response(reload_via(src, &state, &ctx).await));
+            }
+            _ => {}
+        }
+    }
     Ok(respond(req.method(), req.uri().path(), internal, || {
         snapshot_body(&state)
     }))
+}
+
+/// Read the request body as a UTF-8 string, capped at `MAX_ADMIN_BODY`. The Err
+/// is a human message routed to a 400.
+async fn read_body_string(req: Request<hyper::body::Incoming>) -> Result<String, String> {
+    let collected = Limited::new(req.into_body(), MAX_ADMIN_BODY)
+        .collect()
+        .await
+        .map_err(|_| format!("request body exceeds {MAX_ADMIN_BODY} bytes (or stream error)"))?;
+    String::from_utf8(collected.to_bytes().to_vec())
+        .map_err(|_| "request body is not valid UTF-8".to_string())
+}
+
+/// Apply a config (file or body) through the shared `reload_now`, off the async
+/// worker (it does a file read + a CPU rebuild).
+async fn reload_via(
+    source: ConfigSource,
+    state: &Arc<AppState>,
+    ctx: &Arc<AdminReloadCtx>,
+) -> Result<u64, String> {
+    let sc = state.config.clone();
+    let clm = ctx.conn_limit_max;
+    let cn = ctx.change_notifier.clone();
+    let bc = ctx.boot_tls_cert.clone();
+    let bk = ctx.boot_tls_key.clone();
+    tokio::task::spawn_blocking(move || {
+        reload_now(source, &sc, clm, cn.as_ref(), bc.as_deref(), bk.as_deref())
+    })
+    .await
+    .unwrap_or_else(|e| Err(format!("reload task panicked: {e}")))
+}
+
+/// Turn a reload outcome into the HTTP response: 200 + `{"generation":N}` on
+/// success; 400 + `{"error":...}` on rejection (+ bump the reject counter).
+fn reload_response(result: Result<u64, String>) -> Response<Full<Bytes>> {
+    match result {
+        Ok(gen) => Response::builder()
+            .status(StatusCode::OK)
+            .header("Content-Type", "application/json; charset=utf-8")
+            .header("Cache-Control", "no-store")
+            .body(Full::new(Bytes::from(format!(
+                "{{\"generation\":{gen}}}\n"
+            ))))
+            .unwrap(),
+        Err(e) => {
+            crate::observability::ADMIN_REJECTS_TOTAL.fetch_add(1, Ordering::Relaxed);
+            crate::logging::warn("admin", &format!("config push rejected: {e}"));
+            Response::builder()
+                .status(StatusCode::BAD_REQUEST)
+                .header("Content-Type", "application/json; charset=utf-8")
+                .body(Full::new(Bytes::from(format!(
+                    "{{\"error\":{}}}\n",
+                    json_string(&e)
+                ))))
+                .unwrap()
+        }
+    }
+}
+
+/// Minimal JSON string literal (quoted + escaped) for embedding an arbitrary
+/// error message (TOML errors carry quotes + newlines) in a JSON body.
+fn json_string(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
 }
 
 /// The auth + routing decision, pulled out so it's unit-testable without an
@@ -138,6 +260,30 @@ mod tests {
     fn non_internal_peer_is_forbidden() {
         let r = respond(&Method::GET, "/admin/config", false, snap);
         assert_eq!(r.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[test]
+    fn reload_response_ok_is_200() {
+        let r = reload_response(Ok(7));
+        assert_eq!(r.status(), StatusCode::OK);
+        assert_eq!(r.headers().get("Cache-Control").unwrap(), "no-store");
+    }
+
+    #[test]
+    fn reload_response_err_is_400_and_bumps_counter() {
+        let before = crate::observability::ADMIN_REJECTS_TOTAL.load(Ordering::Relaxed);
+        let r = reload_response(Err("bad config".to_string()));
+        assert_eq!(r.status(), StatusCode::BAD_REQUEST);
+        assert!(
+            crate::observability::ADMIN_REJECTS_TOTAL.load(Ordering::Relaxed) > before,
+            "a rejected push must bump zion_admin_rejects_total"
+        );
+    }
+
+    #[test]
+    fn json_string_escapes_quotes_and_newlines() {
+        // TOML errors carry quotes + newlines; the JSON body must stay valid.
+        assert_eq!(json_string("a\"b\\c\nd"), "\"a\\\"b\\\\c\\nd\"");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1097,20 +1097,29 @@ async fn async_main(platform: &'static bootstrap::Platform) -> error::ZionResult
         config_path.clone().into(),
         state.config.clone(),
         platform.conn_limit,
-        Some(config_change_tx),
+        // Cloned: the admin API (below) shares the SAME change channel so an
+        // admin push notifies the listener supervisor exactly like a file edit.
+        Some(config_change_tx.clone()),
         Some(config.tls.cert_path.clone()),
         Some(config.tls.key_path.clone()),
     );
 
-    // 5b. Admin API listener (#26 Phase 2) — read-only, loopback by default.
-    // listen + auth were validated at config load. Phase 2 only enforces the
+    // 5b. Admin API listener (#26 Phase 2/3) — loopback by default.
+    // listen + auth were validated at config load. Phases 2-3 only enforce the
     // `internal-ip` gate; `mtls` is accepted by the schema but NOT yet enforced
     // (Phase 4), so refuse to spawn rather than serve admin with an unenforced
     // auth claim — fail safe.
     if let Some(ref admin_cfg) = config.admin {
         match admin_cfg.listen.parse::<std::net::SocketAddr>() {
             Ok(addr) if admin_cfg.auth == "internal-ip" => {
-                admin::spawn_admin_listener(state.clone(), addr);
+                let ctx = std::sync::Arc::new(admin::AdminReloadCtx {
+                    conn_limit_max: platform.conn_limit,
+                    change_notifier: Some(config_change_tx.clone()),
+                    config_path: config_path.clone().into(),
+                    boot_tls_cert: Some(config.tls.cert_path.clone()),
+                    boot_tls_key: Some(config.tls.key_path.clone()),
+                });
+                admin::spawn_admin_listener(state.clone(), addr, ctx);
             }
             Ok(_) => logging::error(
                 "admin",

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -35,6 +35,7 @@ pub static AUDIT_EVENTS_TOTAL: AtomicU64 = AtomicU64::new(0);
 pub static AUDIT_EVENTS_DROPPED_TOTAL: AtomicU64 = AtomicU64::new(0);
 pub static TRACES_EMITTED_TOTAL: AtomicU64 = AtomicU64::new(0);
 pub static TRACES_INVALID_TOTAL: AtomicU64 = AtomicU64::new(0);
+pub static ADMIN_REJECTS_TOTAL: AtomicU64 = AtomicU64::new(0);
 
 /// Render the observability counters in Prometheus text format. Called from
 /// `metrics::render`. Keeps the metrics module unaware of tracing internals.
@@ -65,6 +66,11 @@ pub fn render_counters(out: &mut bytes::BytesMut) {
             "zion_traces_invalid_total",
             "Inbound traceparent headers rejected as malformed.",
             TRACES_INVALID_TOTAL.load(Ordering::Relaxed),
+        ),
+        (
+            "zion_admin_rejects_total",
+            "Admin API config pushes rejected (invalid TOML / failed validation).",
+            ADMIN_REJECTS_TOTAL.load(Ordering::Relaxed),
         ),
     ] {
         out.extend_from_slice(b"# HELP ");


### PR DESCRIPTION
**#26 Phase 3** — the core of the admin API: push a new config (or trigger a disk re-read) over HTTP, flowing through the **same `reload_now` path as the file watcher** (validate → rebuild → atomic-swap → bump generation → notify). An admin push behaves *exactly* like an edited `zion.toml`, including notifying the listener supervisor.

```console
$ curl -sX POST --data-binary @zion.toml localhost:9180/admin/config
{"generation":1}
$ curl -sX POST --data-binary 'not [ valid' localhost:9180/admin/config
{"error":"Invalid TOML in admin push: TOML parse error at line 1, column 5 ..."}   # HTTP 400
$ curl -sX POST localhost:9180/admin/reload
{"generation":2}
```

## What
- **`POST /admin/config`**: body = full TOML (capped at **1 MiB**, UTF-8). Success → `200 {"generation":N}`; rejection (bad TOML / failed validation) → `400 {"error":...}` + bump `zion_admin_rejects_total`. Fully validated via `reload_now(Body)` → `config::validate_str` (real cert paths and all — a pushed config must be deployable).
- **`POST /admin/reload`**: re-read `zion.toml` from disk (`reload_now(File)`), skipping the watcher's 2 s debounce → `200 {"generation":N}`.
- `AdminReloadCtx` carries what `reload_now` needs beyond `AppState` (conn-limit, change-notifier **cloned to share the watcher's channel**, config path, boot TLS paths). New `zion_admin_rejects_total` metric.
- Same `internal-ip` gate as the read endpoint; auth is on the **connection peer**, never a forwarded header.

## Verified
- Unit: `reload_response` (200 / 400 + counter bump), `json_string` escaping (TOML errors carry quotes + newlines → still-valid JSON body).
- **End-to-end smoke**: GET gen=0 → POST valid → `{"generation":1}` → GET gen=1 (push took effect) → POST invalid → 400 + escaped error (snapshot untouched) → `POST /admin/reload` → `{"generation":2}`.

Phase 4 next: mTLS + audit log line + per-listener rate-limit + `docs/deploy/admin-api.md`. Badge → 652. Part of #26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)