### PR TITLE
feat(admin): rate-limit + audit + docs (#26 Phase 4a)

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Client -> TLS 1.3 -> Security Gates -> Radix Router -> WAF Pipeline (5 gates) ->
 ```
 
 <!-- zion-stats:modules-lines (kept in sync by scripts/update-readme-stats.sh) -->
-42 modules, ~30,100 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
+42 modules, ~30,200 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
 
 ## Features
 
@@ -245,7 +245,7 @@ MODE=full bash benchmarks/baseline/run-baseline.sh   # → benchmarks/baseline/z
 ## Testing
 
 ```bash
-# Unit tests (652) <!-- zion-stats:test-count (kept in sync by scripts/update-readme-stats.sh) -->
+# Unit tests (653) <!-- zion-stats:test-count (kept in sync by scripts/update-readme-stats.sh) -->
 cargo test
 
 # Integration tests (23 — requires a running Zion + backend)

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -100,6 +100,7 @@ export default defineConfig({
           { text: 'Deployment', link: '/deploy/' },
           { text: 'Observability', link: '/deploy/observability' },
           { text: 'Hot-reload', link: '/deploy/hot-reload' },
+          { text: 'Admin API', link: '/deploy/admin-api' },
         ]
       }
     ],

--- a/docs/deploy/admin-api.md
+++ b/docs/deploy/admin-api.md
@@ -1,0 +1,112 @@
+# Admin API
+
+The admin API is the **programmatic counterpart to [hot-reload](/deploy/hot-reload)**: instead of editing `zion.toml` on disk and letting the file watcher pick it up, an orchestrator can `POST` a new config (or trigger a disk re-read) over HTTP and get back the new config generation synchronously. Same validation, same atomic swap, same in-flight-safe semantics — just a different trigger.
+
+It is **off by default**. With no `[admin]` block, no listener is spawned: zero overhead, zero attack surface. It runs on a **dedicated, loopback-by-default listener**, physically separate from the public `:443`, so a routing accident on the data plane can never expose `/admin/*`.
+
+## Enabling it
+
+```toml
+[admin]
+listen = "127.0.0.1:9180"   # default — loopback only
+auth = "internal-ip"        # default — see Authentication
+rate_limit_rps = 10         # default — global req/s ceiling
+```
+
+Every field has the default shown, so a bare `[admin]` block is enough to turn it on with safe defaults. The block is validated at load: `listen` must be a real socket address, `auth` must be `internal-ip` or `mtls`, `rate_limit_rps` must be `> 0`. A typo fails fast at startup, exactly like the rest of `zion.toml`.
+
+## Endpoints
+
+| Method | Path | Effect |
+|---|---|---|
+| `GET`  | `/admin/config` | Return the live runtime snapshot (the same JSON as [`/_zion/snapshot.json`](/deploy/observability) — config generation, upstream health, metrics). Read-only. |
+| `POST` | `/admin/config` | Push a full new config body (TOML). Validate → atomic-swap → bump generation. |
+| `POST` | `/admin/reload` | Re-read `zion.toml` from disk (skips the watcher's 2 s debounce). |
+
+Any other method/path returns `404`.
+
+### Read the live config
+
+```console
+$ curl -s localhost:9180/admin/config | jq '{generation: .config_generation, upstreams}'
+{
+  "generation": 7,
+  "upstreams": [ { "url": "http://127.0.0.1:9090", "healthy": true, "latency_us": 412 } ]
+}
+```
+
+### Push a new config
+
+The body is the **complete** `zion.toml` (not a patch), capped at **1 MiB**, UTF-8. It flows through the same `validate → rebuild → atomic-swap → notify` path as a file edit — including a full validation pass (real cert paths and all: a pushed config must be deployable, not just parseable).
+
+```console
+$ curl -sX POST --data-binary @zion.toml localhost:9180/admin/config
+{"generation":8}
+```
+
+On rejection nothing swaps — the previous config keeps serving — and you get the diagnostic plus a `400`:
+
+```console
+$ curl -sX POST --data-binary 'not [ valid toml' localhost:9180/admin/config
+{"error":"Invalid TOML in admin push: TOML parse error at line 1, column 5 ..."}
+```
+
+A rejected push also increments the `zion_admin_rejects_total` metric.
+
+### Reload from disk
+
+Equivalent to editing-and-saving the file, but synchronous and immediate (no 2 s debounce):
+
+```console
+$ curl -sX POST localhost:9180/admin/reload
+{"generation":9}
+```
+
+The `generation` in every success response is the new value of the `config_generation` counter — the same one surfaced on `/_zion/snapshot.json` and in metrics — so a deploy can confirm its change landed.
+
+## Authentication
+
+| Mode | Status | Behaviour |
+|---|---|---|
+| `internal-ip` | **default, enforced** | The connection **peer** must be a loopback / private-range IP (the same gate as `/_zion/snapshot.json`). |
+| `mtls` | **planned (not yet enforced)** | Reserved. Until it ships, a listener configured with `auth = "mtls"` **refuses to spawn** rather than serve under an auth mode it doesn't yet enforce — fail-safe. |
+
+Authorization is checked on the **TCP connection peer**, never on a forwarded header. `X-Forwarded-For` and `X-Client-Cert-*` are deliberately **not trusted** here: admin auth is not transitive through a proxy. If you put the admin listener behind something, that something owns the authentication.
+
+::: warning
+`internal-ip` trusts every host in the loopback and private ranges. On a shared network, bind to `127.0.0.1` (the default) and reach it via an SSH tunnel or a sidecar — do not bind the admin listener to a routable interface until `mtls` lands.
+:::
+
+## Rate limiting
+
+The listener enforces a **global** fixed-window limit of `rate_limit_rps` requests per second (default 10) across all admin requests. Over the limit returns `429`. It is defense-in-depth — the listener is loopback and single-tenant — that bounds the (relatively expensive) reload path against a runaway deploy loop or a misbehaving client. Requests that fail the auth gate are not counted, so a rejected flood can't starve a real operator's budget.
+
+## Auditing
+
+When [`[audit]`](/security/hardening) is enabled, every **write** (`POST /admin/config`, `POST /admin/reload`) emits one `config_reload` audit event into the tamper-evident log:
+
+```json
+{ "kind": "config_reload", "remote_ip": "127.0.0.1", "method": "POST",
+  "path": "/admin/reload", "detail": "admin config reload accepted → generation 9" }
+```
+
+Rejected pushes are recorded too (`detail: "admin config push rejected: ..."`). Reads are not audited. A request rejected by the rate limiter or the auth gate never reaches the write path, so it produces no audit event.
+
+## Metrics
+
+| Metric | Meaning |
+|---|---|
+| `zion_admin_rejects_total` | Admin config pushes rejected (invalid TOML / failed validation). A non-zero, climbing value means a deploy pipeline is pushing configs the daemon won't accept. |
+| `config_generation` | Current config generation (on `/_zion/snapshot.json`). Bumps once per accepted reload, from any source — file edit, push, or disk reload. |
+
+## Security model in one breath
+
+* **Off unless configured.** No `[admin]` ⇒ no listener.
+* **Loopback by default**, on its own port, physically separate from `:443`.
+* **Peer-IP authorization**, never a forwarded header.
+* **Full validation** before swap — a bad push is a `400`, never a half-applied config.
+* **Rate-limited and audited.**
+
+## Relationship to hot-reload
+
+The admin API and the [file watcher](/deploy/hot-reload) are two triggers for **one** reload engine. Everything the watcher reloads, a push reloads identically; everything that survives a file reload (cache entries, connection-limit semaphore, in-flight requests) survives a push. The only differences are the trigger (HTTP vs. file event) and the timing (synchronous, no debounce). Use the file watcher for hand edits and GitOps-style file sync; use the admin API when an orchestrator wants a synchronous acknowledgement that its config landed.

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -1,18 +1,23 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Admin API — a dedicated, loopback-by-default listener for runtime config
-//! inspection (and, in later #26 phases, push + reload).
+//! inspection, push, and reload. The programmatic counterpart to the file
+//! watcher: same reload engine, a different trigger. See `docs/deploy/admin-api.md`.
 //!
-//! Phase 2 is **read-only**: `GET /admin/config` returns the live snapshot JSON
-//! — the SAME source of truth as `/_zion/snapshot.json` (`metrics::snapshot_json`)
-//! — gated to internal IPs (`auth = "internal-ip"`, the default). The listener
-//! is **physically separate** from the public `:443`, so a routing accident
-//! can't expose `/admin/*`. Absent `[admin]` section ⇒ no listener (zero
-//! overhead, zero attack surface).
+//! - `GET  /admin/config` → live snapshot JSON (same source as `/_zion/snapshot.json`).
+//! - `POST /admin/config` → push a full TOML body → validate + atomic-swap (`reload_now`).
+//! - `POST /admin/reload` → re-read `zion.toml` from disk.
+//!
+//! Gated to internal IPs (`auth = "internal-ip"`, the default), rate-limited,
+//! and — writes only — audited. The listener is **physically separate** from
+//! the public `:443`, so a routing accident can't expose `/admin/*`. Absent
+//! `[admin]` section ⇒ no listener (zero overhead, zero attack surface).
 //!
 //! Deliberately NOT trusting `X-Forwarded-For` / `X-Client-Cert-*` here: admin
 //! authorization is not transitive through a forwarding proxy. Plain HTTP on
-//! loopback for now; mTLS is Phase 4.
+//! loopback for now; mTLS (`auth = "mtls"`) is a planned follow-up and currently
+//! refuses to spawn rather than serve under an unenforced auth mode.
 
+use crate::audit::{self, AuditEvent};
 use crate::reload::{reload_now, ConfigSource};
 use crate::AppState;
 use bytes::Bytes;
@@ -22,23 +27,69 @@ use hyper::{Method, Request, Response, StatusCode};
 use hyper_util::rt::TokioIo;
 use std::net::SocketAddr;
 use std::path::PathBuf;
-use std::sync::atomic::Ordering;
+use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 /// A pushed config body is capped — a `zion.toml` is small; anything larger is
 /// almost certainly a mistake or an attack, not a config.
 const MAX_ADMIN_BODY: usize = 1 << 20; // 1 MiB
 
+/// A tiny global fixed-window rate limiter for the admin listener. Loopback +
+/// single-tenant, so a per-IP table would be overkill — one global window
+/// bounds the expensive reload path against accidental loops / abuse (defense
+/// in depth on top of the internal-ip gate). Approximate by design.
+pub(crate) struct AdminRateLimiter {
+    limit: u32,
+    window_sec: AtomicU64,
+    count: AtomicU32,
+}
+
+impl AdminRateLimiter {
+    pub(crate) fn new(limit: u32) -> Self {
+        Self {
+            limit,
+            window_sec: AtomicU64::new(0),
+            count: AtomicU32::new(0),
+        }
+    }
+
+    /// Consume one token for the current 1 s window; `false` ⇒ over the limit.
+    fn allow(&self) -> bool {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        let start = self.window_sec.load(Ordering::Acquire);
+        if now > start
+            && self
+                .window_sec
+                .compare_exchange(start, now, Ordering::AcqRel, Ordering::Acquire)
+                .is_ok()
+        {
+            // We claimed the new window; this request is its first.
+            self.count.store(1, Ordering::Release);
+            return true;
+        }
+        // Same window (or another thread just rolled it): count this request.
+        // fetch_add returns the PREVIOUS count `p`; the new count is `p + 1`, so
+        // "new count <= limit" is exactly `p < limit`.
+        self.count.fetch_add(1, Ordering::AcqRel) < self.limit
+    }
+}
+
 /// Everything `reload_now` needs that isn't in `AppState`, captured at boot and
 /// shared with the admin handler so `POST /admin/config` / `/admin/reload` flow
 /// through the EXACT same reload path as the file watcher (atomic swap, health
-/// preservation, generation bump, notify).
+/// preservation, generation bump, notify). Also carries the listener's rate
+/// limiter.
 pub(crate) struct AdminReloadCtx {
     pub(crate) conn_limit_max: usize,
     pub(crate) change_notifier: Option<tokio::sync::watch::Sender<u64>>,
     pub(crate) config_path: PathBuf,
     pub(crate) boot_tls_cert: Option<String>,
     pub(crate) boot_tls_key: Option<String>,
+    pub(crate) rate_limiter: AdminRateLimiter,
 }
 
 /// Spawn the admin listener. Returns immediately; the accept loop runs on a
@@ -98,6 +149,14 @@ async fn handle(
     ctx: Arc<AdminReloadCtx>,
 ) -> Result<Response<Full<Bytes>>, std::convert::Infallible> {
     let internal = crate::security::is_internal_ip(&peer.ip());
+    // Rate-limit only requests that pass the gate (a non-internal flood gets the
+    // cheap 403 below and shouldn't be able to starve a real operator's tokens).
+    if internal && !ctx.rate_limiter.allow() {
+        return Ok(json(
+            StatusCode::TOO_MANY_REQUESTS,
+            br#"{"error":"rate limited"}"#,
+        ));
+    }
     // Write endpoints (async + stateful) are handled here; the auth gate, the
     // read (GET /admin/config) and 404 stay in the pure, unit-tested `respond`.
     if internal && req.method() == Method::POST {
@@ -108,12 +167,15 @@ async fn handle(
                     Ok(toml) => reload_via(ConfigSource::Body(toml), &state, &ctx).await,
                     Err(e) => Err(e),
                 };
+                audit_write(&state, peer, "/admin/config", "config push", &result);
                 return Ok(reload_response(result));
             }
             // Re-read zion.toml from disk (skip the watcher's 2s debounce).
             "/admin/reload" => {
                 let src = ConfigSource::File(ctx.config_path.clone());
-                return Ok(reload_response(reload_via(src, &state, &ctx).await));
+                let result = reload_via(src, &state, &ctx).await;
+                audit_write(&state, peer, "/admin/reload", "config reload", &result);
+                return Ok(reload_response(result));
             }
             _ => {}
         }
@@ -121,6 +183,32 @@ async fn handle(
     Ok(respond(req.method(), req.uri().path(), internal, || {
         snapshot_body(&state)
     }))
+}
+
+/// Emit one audit event per admin write — who (connection peer), what (action +
+/// endpoint), outcome (new generation, or the rejection reason). This is the
+/// tamper-evident record of every config change made through the API.
+fn audit_write(
+    state: &AppState,
+    peer: SocketAddr,
+    path: &str,
+    action: &str,
+    result: &Result<u64, String>,
+) {
+    let detail = match result {
+        Ok(gen) => format!("admin {action} accepted → generation {gen}"),
+        Err(e) => format!("admin {action} rejected: {e}"),
+    };
+    state.audit.emit(AuditEvent {
+        seq: 0,
+        ts: String::new(),
+        kind: audit::kind::CONFIG_RELOAD,
+        trace_id: None,
+        remote_ip: Some(peer.ip().to_string()),
+        method: Some("POST".to_string()),
+        path: Some(path.to_string()),
+        detail: Some(detail),
+    });
 }
 
 /// Read the request body as a UTF-8 string, capped at `MAX_ADMIN_BODY`. The Err
@@ -260,6 +348,16 @@ mod tests {
     fn non_internal_peer_is_forbidden() {
         let r = respond(&Method::GET, "/admin/config", false, snap);
         assert_eq!(r.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[test]
+    fn rate_limiter_enforces_limit_within_window() {
+        // Three rapid calls land in the same 1 s window (nanoseconds apart):
+        // the first two are allowed, the third is over the limit.
+        let rl = AdminRateLimiter::new(2);
+        assert!(rl.allow());
+        assert!(rl.allow());
+        assert!(!rl.allow());
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -89,6 +89,11 @@ pub struct AdminConfig {
     /// or `"mtls"` (opt-in, Phase 4). Unknown values are rejected at validation.
     #[serde(default = "default_admin_auth")]
     pub auth: String,
+    /// Global request rate limit (req/s) for the admin listener — defense in
+    /// depth that bounds the expensive reload path against loops / abuse. Must
+    /// be > 0. Default 10.
+    #[serde(default = "default_admin_rate_limit")]
+    pub rate_limit_rps: u32,
 }
 
 fn default_admin_listen() -> String {
@@ -96,6 +101,9 @@ fn default_admin_listen() -> String {
 }
 fn default_admin_auth() -> String {
     "internal-ip".to_string()
+}
+fn default_admin_rate_limit() -> u32 {
+    10
 }
 
 /// `[sovereign_aimp]` block — gossip control plane.
@@ -773,6 +781,9 @@ fn validate_config(config: &ZionConfig, path: &str) -> Result<(), String> {
                 "admin.auth '{}' must be \"internal-ip\" or \"mtls\"",
                 admin.auth
             ));
+        }
+        if admin.rate_limit_rps == 0 {
+            errors.push("admin.rate_limit_rps must be > 0".to_string());
         }
     }
 
@@ -1527,6 +1538,7 @@ enabledd = true
         let admin = cfg.admin.expect("[admin] present → Some");
         assert_eq!(admin.listen, "127.0.0.1:9180");
         assert_eq!(admin.auth, "internal-ip");
+        assert_eq!(admin.rate_limit_rps, 10);
 
         // A bogus auth mode is rejected by validate_str (semantic validation).
         let bad = "[server]\nlisten_http=\"0.0.0.0:80\"\nlisten_https=\"0.0.0.0:443\"\n\
@@ -1536,6 +1548,16 @@ enabledd = true
         assert!(
             err.contains("admin.auth"),
             "bad admin.auth must be rejected, got: {err}"
+        );
+
+        // rate_limit_rps = 0 is rejected too.
+        let zero = "[server]\nlisten_http=\"0.0.0.0:80\"\nlisten_https=\"0.0.0.0:443\"\n\
+             [tls]\ncert_path=\"/c\"\nkey_path=\"/k\"\n[upstreams]\nbe=\"http://127.0.0.1:8000\"\n\
+             [[route]]\npath=\"/{*rest}\"\nupstream=\"be\"\n[admin]\nrate_limit_rps=0\n";
+        let err = validate_str(zero, "test").err().unwrap_or_default();
+        assert!(
+            err.contains("admin.rate_limit_rps"),
+            "rate_limit_rps=0 must be rejected, got: {err}"
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1118,6 +1118,7 @@ async fn async_main(platform: &'static bootstrap::Platform) -> error::ZionResult
                     config_path: config_path.clone().into(),
                     boot_tls_cert: Some(config.tls.cert_path.clone()),
                     boot_tls_key: Some(config.tls.key_path.clone()),
+                    rate_limiter: admin::AdminRateLimiter::new(admin_cfg.rate_limit_rps),
                 });
                 admin::spawn_admin_listener(state.clone(), addr, ctx);
             }


### PR DESCRIPTION
**#26 Phase 4a** — the operability layer that makes the admin API production-usable on loopback. Completes everything in #26 **except mTLS** (the separate Phase 4b hardening).

```console
# limit = 3/s
$ for i in $(seq 6); do curl -so/dev/null -w "%{http_code} " -XPOST localhost:9180/admin/reload; done
200 200 200 429 429 429
# audit log — one config_reload line per accepted reload:
{"kind":"config_reload","remote_ip":"127.0.0.1","path":"/admin/reload","detail":"admin config reload accepted → generation 3"}
```

## What
- **Rate limit**: new `admin.rate_limit_rps` (default 10, validated `> 0`). A tiny **global fixed-window** limiter on the listener — loopback + single-tenant, so a per-IP table would be overkill — bounds the expensive reload path against a runaway deploy loop. Over → `429`. Gate-failing requests aren't counted, so a rejected flood can't starve a real operator's budget.
- **Audit**: every write (`POST /admin/config`, `/admin/reload`) emits one `config_reload` audit event (peer IP, method, path, outcome incl. new generation or rejection reason) into the tamper-evident log. Reads aren't audited; rate-limited / gated requests never reach the write path → no event.
- **Docs**: `docs/deploy/admin-api.md` — the full contract (endpoints, curl examples, auth model, rate-limit, audit, metrics, security model, relationship to hot-reload) + sidebar entry. mTLS documented honestly as *planned / not-yet-enforced*. `admin.rs` module docs refreshed to the current surface.

## Verified
- Unit: `AdminRateLimiter` enforces the per-window limit; config rejects `rate_limit_rps = 0`.
- **End-to-end smoke**: 6 rapid `POST /admin/reload` at limit 3 → `3×200` then `3×429`; exactly **3** `config_reload` audit lines written (one per accepted reload), none for the throttled requests.

After this, #26 is complete bar **Phase 4b: mTLS** (`auth = "mtls"` — dedicated TLS acceptor + client-cert verification; currently refuses to spawn, fail-safe). Badge → 653. Part of #26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)