### PR TITLE
feat(admin): mTLS auth for the admin listener (#26 Phase 4b)

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Client -> TLS 1.3 -> Security Gates -> Radix Router -> WAF Pipeline (5 gates) ->
 ```
 
 <!-- zion-stats:modules-lines (kept in sync by scripts/update-readme-stats.sh) -->
-42 modules, ~30,200 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
+42 modules, ~30,300 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
 
 ## Features
 
@@ -245,7 +245,7 @@ MODE=full bash benchmarks/baseline/run-baseline.sh   # → benchmarks/baseline/z
 ## Testing
 
 ```bash
-# Unit tests (653) <!-- zion-stats:test-count (kept in sync by scripts/update-readme-stats.sh) -->
+# Unit tests (654) <!-- zion-stats:test-count (kept in sync by scripts/update-readme-stats.sh) -->
 cargo test
 
 # Integration tests (23 — requires a running Zion + backend)

--- a/docs/deploy/admin-api.md
+++ b/docs/deploy/admin-api.md
@@ -66,15 +66,34 @@ The `generation` in every success response is the new value of the `config_gener
 
 ## Authentication
 
-| Mode | Status | Behaviour |
-|---|---|---|
-| `internal-ip` | **default, enforced** | The connection **peer** must be a loopback / private-range IP (the same gate as `/_zion/snapshot.json`). |
-| `mtls` | **planned (not yet enforced)** | Reserved. Until it ships, a listener configured with `auth = "mtls"` **refuses to spawn** rather than serve under an auth mode it doesn't yet enforce — fail-safe. |
+| Mode | Behaviour |
+|---|---|
+| `internal-ip` (default) | Plain HTTP. The connection **peer** must be a loopback / private-range IP (the same gate as `/_zion/snapshot.json`). |
+| `mtls` | TLS with a **required** client certificate chaining to `tls.client_ca_path`. A completed handshake **is** the authorization — only CA-signed clients ever reach the HTTP layer, so the peer's IP no longer matters and the listener can safely bind a routable interface. Requires `tls.client_ca_path` (validated at load). |
 
-Authorization is checked on the **TCP connection peer**, never on a forwarded header. `X-Forwarded-For` and `X-Client-Cert-*` are deliberately **not trusted** here: admin auth is not transitive through a proxy. If you put the admin listener behind something, that something owns the authentication.
+For `internal-ip`, authorization is checked on the **TCP connection peer**, never on a forwarded header — `X-Forwarded-For` and `X-Client-Cert-*` are deliberately **not trusted** (admin auth is not transitive through a proxy). For `mtls`, the client cert is verified by rustls against the configured CA during the handshake; a missing or untrusted cert drops the connection before any request is served.
+
+### Enabling mTLS
+
+```toml
+[tls]
+cert_path = "/etc/ssl/zion/server.crt"   # the admin listener reuses the daemon's server cert
+key_path  = "/etc/ssl/zion/server.key"
+client_ca_path = "/etc/ssl/zion/admin-ca.crt"   # CA that signs operator client certs
+
+[admin]
+listen = "0.0.0.0:9180"   # safe to expose: the handshake is the gate
+auth = "mtls"
+```
+
+```console
+# A client cert signed by admin-ca is mandatory; without it the handshake fails.
+$ curl --cert operator.crt --key operator.key -k https://zion-host:9180/admin/config
+{"config_generation":7, ...}
+```
 
 ::: warning
-`internal-ip` trusts every host in the loopback and private ranges. On a shared network, bind to `127.0.0.1` (the default) and reach it via an SSH tunnel or a sidecar — do not bind the admin listener to a routable interface until `mtls` lands.
+With `internal-ip`, `127.0.0.1` (the default) is the safe bind: it trusts every host in the loopback and private ranges, so on a shared network reach it via an SSH tunnel or a sidecar rather than binding a routable interface. Use `mtls` when you need the admin API reachable across the network.
 :::
 
 ## Rate limiting

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -13,9 +13,15 @@
 //! `[admin]` section ⇒ no listener (zero overhead, zero attack surface).
 //!
 //! Deliberately NOT trusting `X-Forwarded-For` / `X-Client-Cert-*` here: admin
-//! authorization is not transitive through a forwarding proxy. Plain HTTP on
-//! loopback for now; mTLS (`auth = "mtls"`) is a planned follow-up and currently
-//! refuses to spawn rather than serve under an unenforced auth mode.
+//! authorization is not transitive through a forwarding proxy.
+//!
+//! Two auth modes (`[admin].auth`):
+//! - `internal-ip` (default): plain HTTP; each request is authorized iff the
+//!   connection peer is an internal IP.
+//! - `mtls`: TLS with a **required** client cert chaining to `tls.client_ca_path`.
+//!   A completed handshake IS the authorization — only CA-signed clients ever
+//!   reach the HTTP layer, so the peer's IP no longer matters and the listener
+//!   can safely bind a routable interface.
 
 use crate::audit::{self, AuditEvent};
 use crate::reload::{reload_now, ConfigSource};
@@ -30,6 +36,8 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio_rustls::TlsAcceptor;
 
 /// A pushed config body is capped — a `zion.toml` is small; anything larger is
 /// almost certainly a mistake or an attack, not a config.
@@ -92,6 +100,14 @@ pub(crate) struct AdminReloadCtx {
     pub(crate) rate_limiter: AdminRateLimiter,
 }
 
+/// How the admin listener authorizes connections.
+pub(crate) enum AdminAuth {
+    /// Plain HTTP; authorize per-request on the peer being an internal IP.
+    InternalIp,
+    /// TLS with a required client cert — a completed handshake is authorization.
+    Mtls(Arc<TlsAcceptor>),
+}
+
 /// Spawn the admin listener. Returns immediately; the accept loop runs on a
 /// tokio task. A bind failure is logged and the task exits (the data plane is
 /// untouched — the admin listener is independent by design).
@@ -99,6 +115,7 @@ pub(crate) fn spawn_admin_listener(
     state: Arc<AppState>,
     listen: SocketAddr,
     ctx: Arc<AdminReloadCtx>,
+    auth: AdminAuth,
 ) {
     tokio::spawn(async move {
         let listener = match tokio::net::TcpListener::bind(listen).await {
@@ -111,28 +128,39 @@ pub(crate) fn spawn_admin_listener(
                 return;
             }
         };
+        let mode = match auth {
+            AdminAuth::InternalIp => "internal-ip auth",
+            AdminAuth::Mtls(_) => "mTLS (required client cert)",
+        };
         crate::logging::info(
             "admin",
-            &format!("admin API on {listen} (GET/POST /admin/config, POST /admin/reload; internal-ip auth)"),
+            &format!("admin API on {listen} (GET/POST /admin/config, POST /admin/reload; {mode})"),
         );
         loop {
             match listener.accept().await {
                 Ok((stream, peer)) => {
                     let st = state.clone();
                     let cx = ctx.clone();
-                    tokio::spawn(async move {
-                        let io = TokioIo::new(stream);
-                        // Connection-level idle bound so a stuck admin client
-                        // can't pin a task forever.
-                        let _ = tokio::time::timeout(
-                            std::time::Duration::from_secs(30),
-                            hyper::server::conn::http1::Builder::new().serve_connection(
-                                io,
-                                service_fn(move |req| handle(req, peer, st.clone(), cx.clone())),
-                            ),
-                        )
-                        .await;
-                    });
+                    match &auth {
+                        AdminAuth::InternalIp => {
+                            tokio::spawn(serve_admin(stream, peer, st, cx, false));
+                        }
+                        AdminAuth::Mtls(acceptor) => {
+                            let acc = acceptor.clone();
+                            tokio::spawn(async move {
+                                // The handshake performs client-cert verification;
+                                // failure (missing / untrusted cert) drops the
+                                // connection before any request is served.
+                                match acc.accept(stream).await {
+                                    Ok(tls) => serve_admin(tls, peer, st, cx, true).await,
+                                    Err(e) => crate::logging::warn(
+                                        "admin",
+                                        &format!("admin mTLS handshake failed from {peer}: {e}"),
+                                    ),
+                                }
+                            });
+                        }
+                    }
                 }
                 Err(e) => crate::logging::warn("admin", &format!("admin accept error: {e}")),
             }
@@ -140,18 +168,43 @@ pub(crate) fn spawn_admin_listener(
     });
 }
 
-/// Service handler: enforce internal-ip auth on the *connection peer* (never a
-/// forwarded header), then route. Infallible — always produces a response.
+/// Serve one admin connection over any stream (plain TCP or a TLS stream). The
+/// 30 s timeout bounds a stuck client so it can't pin a task forever.
+async fn serve_admin<S>(
+    stream: S,
+    peer: SocketAddr,
+    state: Arc<AppState>,
+    ctx: Arc<AdminReloadCtx>,
+    is_mtls: bool,
+) where
+    S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+{
+    let io = TokioIo::new(stream);
+    let _ = tokio::time::timeout(
+        std::time::Duration::from_secs(30),
+        hyper::server::conn::http1::Builder::new().serve_connection(
+            io,
+            service_fn(move |req| handle(req, peer, state.clone(), ctx.clone(), is_mtls)),
+        ),
+    )
+    .await;
+}
+
+/// Service handler. Authorization: in `mtls` mode the completed TLS handshake
+/// already verified the client cert, so the connection is authorized regardless
+/// of peer IP; otherwise the peer must be an internal IP (never a forwarded
+/// header). Infallible — always produces a response.
 async fn handle(
     req: Request<hyper::body::Incoming>,
     peer: SocketAddr,
     state: Arc<AppState>,
     ctx: Arc<AdminReloadCtx>,
+    is_mtls: bool,
 ) -> Result<Response<Full<Bytes>>, std::convert::Infallible> {
-    let internal = crate::security::is_internal_ip(&peer.ip());
-    // Rate-limit only requests that pass the gate (a non-internal flood gets the
-    // cheap 403 below and shouldn't be able to starve a real operator's tokens).
-    if internal && !ctx.rate_limiter.allow() {
+    let authorized = is_mtls || crate::security::is_internal_ip(&peer.ip());
+    // Rate-limit only authorized requests (an unauthorized flood gets the cheap
+    // 403 below and shouldn't be able to starve a real operator's tokens).
+    if authorized && !ctx.rate_limiter.allow() {
         return Ok(json(
             StatusCode::TOO_MANY_REQUESTS,
             br#"{"error":"rate limited"}"#,
@@ -159,7 +212,7 @@ async fn handle(
     }
     // Write endpoints (async + stateful) are handled here; the auth gate, the
     // read (GET /admin/config) and 404 stay in the pure, unit-tested `respond`.
-    if internal && req.method() == Method::POST {
+    if authorized && req.method() == Method::POST {
         match req.uri().path() {
             // Push a full new config body → validate + atomic-swap via reload_now.
             "/admin/config" => {
@@ -180,7 +233,7 @@ async fn handle(
             _ => {}
         }
     }
-    Ok(respond(req.method(), req.uri().path(), internal, || {
+    Ok(respond(req.method(), req.uri().path(), authorized, || {
         snapshot_body(&state)
     }))
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -785,6 +785,13 @@ fn validate_config(config: &ZionConfig, path: &str) -> Result<(), String> {
         if admin.rate_limit_rps == 0 {
             errors.push("admin.rate_limit_rps must be > 0".to_string());
         }
+        // mTLS needs a client CA to verify presented certs against.
+        if admin.auth == "mtls" && config.tls.client_ca_path.is_none() {
+            errors.push(
+                "admin.auth = \"mtls\" requires tls.client_ca_path (the CA that signs admin client certs)"
+                    .to_string(),
+            );
+        }
     }
 
     if errors.is_empty() {
@@ -1558,6 +1565,17 @@ enabledd = true
         assert!(
             err.contains("admin.rate_limit_rps"),
             "rate_limit_rps=0 must be rejected, got: {err}"
+        );
+
+        // auth = "mtls" without tls.client_ca_path is rejected (nothing to
+        // verify client certs against).
+        let mtls_no_ca = "[server]\nlisten_http=\"0.0.0.0:80\"\nlisten_https=\"0.0.0.0:443\"\n\
+             [tls]\ncert_path=\"/c\"\nkey_path=\"/k\"\n[upstreams]\nbe=\"http://127.0.0.1:8000\"\n\
+             [[route]]\npath=\"/{*rest}\"\nupstream=\"be\"\n[admin]\nauth=\"mtls\"\n";
+        let err = validate_str(mtls_no_ca, "test").err().unwrap_or_default();
+        assert!(
+            err.contains("client_ca_path"),
+            "auth=mtls without client_ca_path must be rejected, got: {err}"
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1104,31 +1104,52 @@ async fn async_main(platform: &'static bootstrap::Platform) -> error::ZionResult
         Some(config.tls.key_path.clone()),
     );
 
-    // 5b. Admin API listener (#26 Phase 2/3) — loopback by default.
-    // listen + auth were validated at config load. Phases 2-3 only enforce the
-    // `internal-ip` gate; `mtls` is accepted by the schema but NOT yet enforced
-    // (Phase 4), so refuse to spawn rather than serve admin with an unenforced
-    // auth claim — fail safe.
+    // 5b. Admin API listener (#26) — loopback by default. listen + auth were
+    // validated at config load (auth ∈ {internal-ip, mtls}; mtls ⇒ client_ca_path
+    // is set). `internal-ip` gates on the peer IP over plain HTTP; `mtls` requires
+    // a client cert chaining to `tls.client_ca_path` (the handshake is the auth).
     if let Some(ref admin_cfg) = config.admin {
         match admin_cfg.listen.parse::<std::net::SocketAddr>() {
-            Ok(addr) if admin_cfg.auth == "internal-ip" => {
-                let ctx = std::sync::Arc::new(admin::AdminReloadCtx {
-                    conn_limit_max: platform.conn_limit,
-                    change_notifier: Some(config_change_tx.clone()),
-                    config_path: config_path.clone().into(),
-                    boot_tls_cert: Some(config.tls.cert_path.clone()),
-                    boot_tls_key: Some(config.tls.key_path.clone()),
-                    rate_limiter: admin::AdminRateLimiter::new(admin_cfg.rate_limit_rps),
-                });
-                admin::spawn_admin_listener(state.clone(), addr, ctx);
+            Ok(addr) => {
+                let auth = match admin_cfg.auth.as_str() {
+                    "mtls" => match config.tls.client_ca_path.as_deref() {
+                        Some(ca) => match tls::admin_mtls_acceptor(
+                            &config.tls.cert_path,
+                            &config.tls.key_path,
+                            ca,
+                        ) {
+                            Ok(acc) => Some(admin::AdminAuth::Mtls(std::sync::Arc::new(acc))),
+                            Err(e) => {
+                                logging::error(
+                                    "admin",
+                                    &format!("mTLS acceptor: {e} — admin API NOT spawned"),
+                                );
+                                None
+                            }
+                        },
+                        // Guarded by validation; defensive.
+                        None => {
+                            logging::error(
+                                "admin",
+                                "admin.auth=mtls requires tls.client_ca_path — admin API NOT spawned",
+                            );
+                            None
+                        }
+                    },
+                    _ => Some(admin::AdminAuth::InternalIp),
+                };
+                if let Some(auth) = auth {
+                    let ctx = std::sync::Arc::new(admin::AdminReloadCtx {
+                        conn_limit_max: platform.conn_limit,
+                        change_notifier: Some(config_change_tx.clone()),
+                        config_path: config_path.clone().into(),
+                        boot_tls_cert: Some(config.tls.cert_path.clone()),
+                        boot_tls_key: Some(config.tls.key_path.clone()),
+                        rate_limiter: admin::AdminRateLimiter::new(admin_cfg.rate_limit_rps),
+                    });
+                    admin::spawn_admin_listener(state.clone(), addr, ctx, auth);
+                }
             }
-            Ok(_) => logging::error(
-                "admin",
-                &format!(
-                    "admin.auth = '{}' is not yet enforced (mTLS lands in #26 Phase 4) — admin API NOT spawned",
-                    admin_cfg.auth
-                ),
-            ),
             Err(e) => logging::error("admin", &format!("admin.listen invalid: {e}")),
         }
     }

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -161,6 +161,52 @@ fn load_certified_key(cert_path: &str, key_path: &str) -> Result<Arc<CertifiedKe
     Ok(Arc::new(CertifiedKey::new(certs, signing_key)))
 }
 
+/// Build a TLS acceptor for the admin listener's `auth = "mtls"` mode (#26): the
+/// daemon's own server cert/key on the server side, and a **required** client-cert
+/// verifier rooted at `ca_path`. Deliberately minimal — TLS 1.3 only, no SNI, no
+/// 0-RTT, no session tickets: the admin listener is single-purpose. A client that
+/// can't present a cert chaining to `ca_path` never completes the handshake, so
+/// the HTTP layer above only ever sees authorized peers.
+pub(crate) fn admin_mtls_acceptor(
+    cert_path: &str,
+    key_path: &str,
+    ca_path: &str,
+) -> Result<TlsAcceptor, String> {
+    // Server identity (reuses the daemon's cert/key).
+    let cert_file =
+        std::fs::File::open(cert_path).map_err(|e| format!("admin TLS cert {cert_path}: {e}"))?;
+    let certs: Vec<_> = rustls_pemfile::certs(&mut BufReader::new(cert_file))
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| format!("admin TLS cert PEM: {e}"))?;
+    let key_file =
+        std::fs::File::open(key_path).map_err(|e| format!("admin TLS key {key_path}: {e}"))?;
+    let key = rustls_pemfile::private_key(&mut BufReader::new(key_file))
+        .map_err(|e| format!("admin TLS key PEM: {e}"))?
+        .ok_or_else(|| "admin TLS key: no private key in PEM".to_string())?;
+
+    // Client CA → REQUIRED verifier (no `allow_unauthenticated`: a client cert
+    // chaining to this CA is mandatory).
+    let ca_file =
+        std::fs::File::open(ca_path).map_err(|e| format!("admin client CA {ca_path}: {e}"))?;
+    let mut root_store = rustls::RootCertStore::empty();
+    for cert in rustls_pemfile::certs(&mut BufReader::new(ca_file)) {
+        let cert = cert.map_err(|e| format!("admin client CA PEM: {e}"))?;
+        root_store
+            .add(cert)
+            .map_err(|e| format!("admin client CA add: {e}"))?;
+    }
+    let verifier = rustls::server::WebPkiClientVerifier::builder(Arc::new(root_store))
+        .build()
+        .map_err(|e| format!("admin client verifier: {e}"))?;
+
+    let config = ServerConfig::builder_with_protocol_versions(&[&rustls::version::TLS13])
+        .with_client_cert_verifier(verifier)
+        .with_single_cert(certs, key)
+        .map_err(|e| format!("admin TLS config: {e}"))?;
+
+    Ok(TlsAcceptor::from(Arc::new(config)))
+}
+
 /// Map the configured `min_version` to the rustls protocol-version list.
 /// **Fail-safe by design (RFC 8446):** only the exact literal `"1.2"` opens the
 /// TLS 1.2 floor; ANY other value — a typo, an empty string, `"1.3"`, `"tls1.2"`
@@ -713,6 +759,16 @@ mod tests {
         let mode = "optional";
         assert_ne!(mode, "none");
         assert_ne!(mode, "required");
+    }
+
+    #[test]
+    fn admin_mtls_acceptor_errors_on_missing_files() {
+        // No real cert fixtures in unit tests (certs are generated, not
+        // committed); the mTLS happy path is covered by the reproducible smoke
+        // in the PR. Here we assert the builder fails cleanly (Err, not panic)
+        // when the cert/key/CA paths don't exist.
+        let r = super::admin_mtls_acceptor("/no/cert.pem", "/no/key.pem", "/no/ca.pem");
+        assert!(r.is_err(), "missing cert/key/ca must yield Err");
     }
 
     // ── TLS version floor (protocol_versions) — RFC 8446 fail-safe ──


### PR DESCRIPTION
**#26 Phase 4b — the final phase. Closes #26.** `auth = "mtls"` runs the admin listener over TLS with a **required** client certificate chaining to `tls.client_ca_path`. A completed handshake **is** the authorization — only CA-signed clients ever reach the HTTP layer, so the listener can safely bind a routable interface, not just loopback.

```console
# no client cert  → TLS handshake rejected (HTTP 000)
# rogue cert (not CA-signed) → rejected (HTTP 000)
# valid cert (CA-signed) → 200 + snapshot
$ curl --cert operator.crt --key operator.key -k https://host:9180/admin/config
{"config_generation":0, ...}   # HTTP 200
```

## What
- **`tls::admin_mtls_acceptor(cert, key, ca)`**: a minimal **TLS 1.3** acceptor — the daemon's server cert/key + a required `WebPkiClientVerifier` rooted at the CA. No SNI / 0-RTT / tickets; the admin listener is single-purpose.
- **`admin.rs`**: `AdminAuth { InternalIp | Mtls(TlsAcceptor) }`. The accept loop runs the TLS handshake before serving on the mtls path (a missing / untrusted cert drops the connection **pre-HTTP**); serve factored into a generic `serve_admin<S>` over any `AsyncRead+AsyncWrite`. `handle` gains `is_mtls`: an mTLS connection is authorized regardless of peer IP (the cert is the auth); `internal-ip` still gates on the peer. The Phase-2 "refuse to spawn on mtls" fail-safe is now the real implementation.
- **config**: `auth = "mtls"` requires `tls.client_ca_path` (validated at load).
- **docs**: `admin-api.md` — mTLS documented as enforced (config + curl), the "until mtls lands" caveat replaced with real guidance.

## Verified
- Unit: `admin_mtls_acceptor` errors cleanly on missing files; config rejects `auth=mtls` without `client_ca_path`.
- **End-to-end mTLS smoke** (reproducible — generate a CA + client cert, start zion with `auth=mtls`):
  - no client cert → handshake rejected (`HTTP 000`)
  - rogue cert, not CA-signed → rejected (`HTTP 000`)
  - valid CA-signed cert → `200` + snapshot JSON
  - log: `admin API on 127.0.0.1:9180 (...; mTLS (required client cert))`

With this, **#26 is complete**: read (`GET`), write (`POST /admin/config` + `/admin/reload`), rate-limit, audit, and both auth modes (`internal-ip` + `mtls`). Badge → 654.

Closes #26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)