### PR TITLE
chore(release): v0.4.7 — admin API + zion suggest

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,7 +21,7 @@ A clear and concise description of what you expected to happen.
 **Environment (please complete the following information):**
  - OS: [e.g. Linux, macOS]
  - Architecture: [e.g. arm64, amd64]
- - Zion Version: [e.g. 0.4.6]
+ - Zion Version: [e.g. 0.4.7]
 
 **Additional context**
 Add any other context about the problem here (e.g. logs with `RUST_LOG=trace`, upstream backend type like Go/Node).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,45 @@ All notable changes to Zion Edge Gateway are documented here.
 
 ## [Unreleased]
 
+## [0.4.7] - 2026-06-27
+
+A usability release: a runtime **admin API** and a config bootstrapper
+(`zion suggest`), plus the wave-2 consolidation fixes and a new WAF regression
+gate. 9 PRs since 0.4.6; every endpoint smoke-verified end-to-end and every
+security-relevant decision covered by a CI-run unit test.
+
+### Added
+- **Admin API** (`[admin]` section, off by default) — a dedicated,
+  loopback-by-default listener for runtime config management, the programmatic
+  counterpart to the file watcher. `GET /admin/config` returns the live snapshot;
+  `POST /admin/config` pushes a full new TOML body and `POST /admin/reload`
+  re-reads from disk — both flow through the **same** validate → atomic-swap →
+  bump-generation → notify path as a file edit, returning the new config
+  generation synchronously. Rate-limited (`admin.rate_limit_rps`, default 10),
+  audited (a `config_reload` event per write), and authorized by either
+  `internal-ip` (loopback) or `mtls` — a required client certificate chaining to
+  `tls.client_ca_path`, so the listener can safely bind a routable interface. New
+  `zion_admin_rejects_total` metric. Full contract in `docs/deploy/admin-api.md`
+  (#254, #255, #256, #257, #258).
+- **`zion suggest`** — deterministic `zion.toml` synthesis: detect a local
+  backend (or take `--upstream`), emit a TLS + WAF-protected config that
+  self-validates against the schema before it is written. Zero dependencies, no
+  ML (#253).
+
+### Fixed
+- Hop-by-hop headers are scrubbed on the WebSocket **non-101** upgrade path too,
+  not only the 101 path (#250).
+- Adversarial re-review (round 2): a `[cors]` example that `deny_unknown_fields`
+  would reject is corrected; the audit-log writer now self-heals after a
+  transient write failure instead of disabling itself; and `zion doctor` bounds
+  its upstream DNS probe (#251).
+
+### CI / Internal
+- The WAF detection / false-positive corpus is now a **nightly + on-WAF-change**
+  regression gate that hard-fails on any benign false positive (#252).
+- `reload_now(ConfigSource)` extracts the shared reload entry point used by both
+  the file watcher and the admin API (#254).
+
 ## [0.4.6] - 2026-06-26
 
 A correctness, conformance & operability release — the summer "diamond"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5540,7 +5540,7 @@ dependencies = [
 
 [[package]]
 name = "zion"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "aho-corasick",
  "aimp_node",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zion"
-version = "0.4.6"
+version = "0.4.7"
 edition = "2021"
 # MSRV is the *core* default-features build (TLS proxy + WAF + cache + metrics).
 # Opt-in features (acme, auth, init, http3) pull crypto/i18n crates that have

--- a/README.md
+++ b/README.md
@@ -272,12 +272,12 @@ Every release is signed and carries SLSA v1.0 build provenance — see
 
 ```bash
 # Binary release (Sigstore-backed provenance via gh CLI)
-gh release download v0.4.6 -R fabriziosalmi/zion -p '*x86_64-unknown-linux-musl*' -p 'SHA256SUMS'
+gh release download v0.4.7 -R fabriziosalmi/zion -p '*x86_64-unknown-linux-musl*' -p 'SHA256SUMS'
 sha256sum --check --ignore-missing SHA256SUMS
-gh attestation verify zion-v0.4.6-x86_64-unknown-linux-musl.tar.gz --owner fabriziosalmi
+gh attestation verify zion-v0.4.7-x86_64-unknown-linux-musl.tar.gz --owner fabriziosalmi
 
 # Container image (cosign keyless)
-cosign verify ghcr.io/fabriziosalmi/zion:v0.4.6 \
+cosign verify ghcr.io/fabriziosalmi/zion:v0.4.7 \
     --certificate-identity-regexp "^https://github.com/fabriziosalmi/zion/\\.github/workflows/release\\.yml@refs/tags/v" \
     --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ from their containing minor — i.e. the latest `0.4.x` is always patched.
 | Version | Supported |
 | ------- | --------- |
 | 0.4.x (latest minor) | Yes |
-| < 0.4.6 | No |
+| < 0.4.7 | No |
 
 ## Reporting a Vulnerability
 

--- a/deploy/helm/zion/Chart.yaml
+++ b/deploy/helm/zion/Chart.yaml
@@ -3,7 +3,7 @@ name: zion
 description: Zion Edge Gateway — high-performance Rust TLS reverse proxy with WAF
 type: application
 version: 0.2.2
-appVersion: "0.4.6"
+appVersion: "0.4.7"
 home: https://fabriziosalmi.github.io/zion
 sources:
   - https://github.com/fabriziosalmi/zion

--- a/docs/deploy/hot-reload.md
+++ b/docs/deploy/hot-reload.md
@@ -130,7 +130,7 @@ Two surfaces report the reload state:
 
   ```json
   {
-    "version": "0.4.6",
+    "version": "0.4.7",
     "timestamp_ms": 1714425600000,
     "uptime_secs": 3712,
     "config_generation": 5,

--- a/docs/security/supply-chain.md
+++ b/docs/security/supply-chain.md
@@ -46,8 +46,8 @@ You need the GitHub CLI (`gh >= 2.49`) and `cosign >= 2.2`.
 
 ```bash
 # 1. Download the artifact + SHA256SUMS from the release page.
-gh release download v0.4.6 -R fabriziosalmi/zion \
-    -p 'zion-v0.4.6-x86_64-unknown-linux-musl.tar.gz' \
+gh release download v0.4.7 -R fabriziosalmi/zion \
+    -p 'zion-v0.4.7-x86_64-unknown-linux-musl.tar.gz' \
     -p 'SHA256SUMS' \
     -p 'zion-sbom.cdx.json'
 
@@ -55,7 +55,7 @@ gh release download v0.4.6 -R fabriziosalmi/zion \
 sha256sum --check --ignore-missing SHA256SUMS
 
 # 3. Verify the SLSA build provenance bound to the artifact's hash.
-gh attestation verify zion-v0.4.6-x86_64-unknown-linux-musl.tar.gz \
+gh attestation verify zion-v0.4.7-x86_64-unknown-linux-musl.tar.gz \
     --owner fabriziosalmi
 
 # Step 3 fails if:
@@ -78,7 +78,7 @@ grype zion-sbom.cdx.json
 ## Verifying a container image
 
 ```bash
-IMAGE=ghcr.io/fabriziosalmi/zion:v0.4.6
+IMAGE=ghcr.io/fabriziosalmi/zion:v0.4.7
 
 # 1. Pin to the digest immediately — tags are mutable, digests are not.
 DIGEST=$(crane digest "$IMAGE")
@@ -120,7 +120,7 @@ deterministically, and pins the Rust toolchain via
 [`rust-toolchain.toml`](../../rust-toolchain.toml). To reproduce locally:
 
 ```bash
-git checkout v0.4.6
+git checkout v0.4.7
 export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)
 # Linux musl example — matches the release artifact byte-for-byte
 # (modulo strip's stable behavior on your distro).


### PR DESCRIPTION
**v0.4.7** — a usability release. 9 PRs since 0.4.6 (#250–258).

## Headlines
- **Admin API** (#254–258) — a runtime config management listener: `GET/POST /admin/config` + `POST /admin/reload`, flowing through the file-watcher's reload engine (atomic-swap, health preservation, generation bump, notify). Rate-limited, audited, with `internal-ip` or **mTLS** auth. `docs/deploy/admin-api.md` is the contract.
- **`zion suggest`** (#253) — deterministic `zion.toml` synthesis from detected signals (no ML).
- **Fixes**: WS non-101 hop-by-hop scrub (#250); adversarial re-review round 2 (#251).
- **CI**: WAF corpus nightly + on-change regression gate (#252).

## Mechanics
- Version bumped 0.4.6 → 0.4.7 across the SSOT (Cargo.toml/lock, Helm `appVersion`, README, SECURITY, hot-reload + supply-chain docs, issue template) via `scripts/bump-version.sh`; `check-version-sync.sh` passes. CHANGELOG by hand.
- On merge: tag `v0.4.7` → `release.yml` builds the 7-target binaries + SBOM + SLSA provenance + signed multi-arch container.

Full notes: [CHANGELOG.md](CHANGELOG.md#047---2026-06-27).

🤖 Generated with [Claude Code](https://claude.com/claude-code)