### PR TITLE
feat(routing): host-based L7 routing (virtual hosting) — ADR-0010

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,7 +21,7 @@ A clear and concise description of what you expected to happen.
 **Environment (please complete the following information):**
  - OS: [e.g. Linux, macOS]
  - Architecture: [e.g. arm64, amd64]
- - Zion Version: [e.g. 0.4.7]
+ - Zion Version: [e.g. 0.5.0]
 
 **Additional context**
 Add any other context about the problem here (e.g. logs with `RUST_LOG=trace`, upstream backend type like Go/Node).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to Zion Edge Gateway are documented here.
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-07-06
+
+Host-based L7 routing (virtual hosting) — Zion can now serve different backends
+for different domains on the same listener, matching nginx `server_name` /
+Caddy site blocks / Traefik `Host()`. Opt-in and zero-cost when unused; every
+step verified end-to-end and covered by CI-run unit tests. Design: ADR-0010.
+
+### Added
+- **Host-based routing** (`hosts` on `[[route]]`, ADR-0010). A route can bind to
+  one or more hosts (`hosts = ["api.example.com", "*.example.com"]`); a route
+  without `hosts` is *shared* and matches every host. Resolution precedence is
+  exact host > most-specific `*.` wildcard > shared layer, selected from the
+  request `Host` header (HTTP/1) or `:authority` (HTTP/2). The same path can now
+  serve different backends per domain — impossible with the previous path-only
+  router. Host entries are normalized (lowercased, port and trailing-dot
+  stripped) and validated at boot. See `docs/config/routing.md` and
+  `examples/multi-site.toml`.
+
+### Changed
+- The route lookup is now a `HostRouter` (a shared radix tree plus one tree per
+  exact host and per wildcard suffix) instead of a single global tree. When no
+  route declares `hosts` the hot path is byte-for-byte the old behavior at zero
+  added cost.
+
+### Security
+- The thread-local route cache is now keyed on `(host, path)` when host routing
+  is active. A path-only key would let one host's request reuse another host's
+  cached route, bypassing a per-route WAF/auth profile or an `internal_only`
+  gate; the host-scoped key closes that cross-host confusion.
+
 ## [0.4.7] - 2026-06-27
 
 A usability release: a runtime **admin API** and a config bootstrapper

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5540,7 +5540,7 @@ dependencies = [
 
 [[package]]
 name = "zion"
-version = "0.4.7"
+version = "0.5.0"
 dependencies = [
  "aho-corasick",
  "aimp_node",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zion"
-version = "0.4.7"
+version = "0.5.0"
 edition = "2021"
 # MSRV is the *core* default-features build (TLS proxy + WAF + cache + metrics).
 # Opt-in features (acme, auth, init, http3) pull crypto/i18n crates that have

--- a/README.md
+++ b/README.md
@@ -272,12 +272,12 @@ Every release is signed and carries SLSA v1.0 build provenance — see
 
 ```bash
 # Binary release (Sigstore-backed provenance via gh CLI)
-gh release download v0.4.7 -R fabriziosalmi/zion -p '*x86_64-unknown-linux-musl*' -p 'SHA256SUMS'
+gh release download v0.5.0 -R fabriziosalmi/zion -p '*x86_64-unknown-linux-musl*' -p 'SHA256SUMS'
 sha256sum --check --ignore-missing SHA256SUMS
-gh attestation verify zion-v0.4.7-x86_64-unknown-linux-musl.tar.gz --owner fabriziosalmi
+gh attestation verify zion-v0.5.0-x86_64-unknown-linux-musl.tar.gz --owner fabriziosalmi
 
 # Container image (cosign keyless)
-cosign verify ghcr.io/fabriziosalmi/zion:v0.4.7 \
+cosign verify ghcr.io/fabriziosalmi/zion:v0.5.0 \
     --certificate-identity-regexp "^https://github.com/fabriziosalmi/zion/\\.github/workflows/release\\.yml@refs/tags/v" \
     --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 ```

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Client -> TLS 1.3 -> Security Gates -> Radix Router -> WAF Pipeline (5 gates) ->
 ```
 
 <!-- zion-stats:modules-lines (kept in sync by scripts/update-readme-stats.sh) -->
-42 modules, ~30,600 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
+42 modules, ~31,300 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
 
 ## Features
 
@@ -245,7 +245,7 @@ MODE=full bash benchmarks/baseline/run-baseline.sh   # → benchmarks/baseline/z
 ## Testing
 
 ```bash
-# Unit tests (657) <!-- zion-stats:test-count (kept in sync by scripts/update-readme-stats.sh) -->
+# Unit tests (670) <!-- zion-stats:test-count (kept in sync by scripts/update-readme-stats.sh) -->
 cargo test
 
 # Integration tests (23 — requires a running Zion + backend)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ from their containing minor — i.e. the latest `0.4.x` is always patched.
 | Version | Supported |
 | ------- | --------- |
 | 0.4.x (latest minor) | Yes |
-| < 0.4.7 | No |
+| < 0.5.0 | No |
 
 ## Reporting a Vulnerability
 

--- a/deploy/helm/zion/Chart.yaml
+++ b/deploy/helm/zion/Chart.yaml
@@ -3,7 +3,7 @@ name: zion
 description: Zion Edge Gateway — high-performance Rust TLS reverse proxy with WAF
 type: application
 version: 0.2.2
-appVersion: "0.4.7"
+appVersion: "0.5.0"
 home: https://fabriziosalmi.github.io/zion
 sources:
   - https://github.com/fabriziosalmi/zion

--- a/docs/adr/0010-host-based-l7-routing.md
+++ b/docs/adr/0010-host-based-l7-routing.md
@@ -1,0 +1,138 @@
+# ADR-0010: Host-based L7 routing (virtual hosting)
+
+- **Status**: accepted
+- **Date**: 2026-07-06
+- **Deciders**: fabriziosalmi
+- **Tags**: routing, virtual-hosting, config, performance, security
+
+## Context
+
+Zion routes L7 purely by path: a single `matchit::Router<Arc<ResolvedRoute>>`
+keyed on `req.uri().path()` (`config::build_router`, `dispatch.rs:491`). The
+only host-awareness in the stack is at TLS — `[[tls.sni]]` selects a
+*certificate* per SNI (`config::SniCert`) — but the HTTP layer is host-blind.
+The `Host` header is read only to validate the HTTP→HTTPS redirect
+(`main.rs:2059`) and to populate `X-Forwarded-Host` before being stripped
+(`proxy.rs:174`); it never enters route selection. Consequence:
+`examples/multi-site.toml` ("3 domains, 3 backends") only works because the
+domains use disjoint path prefixes — two hosts serving the same path (e.g.
+`/`) to different backends is impossible. This blocks Zion from being a
+drop-in replacement for nginx `server_name` / Caddy site blocks / Traefik
+`Host()` rules. Constraints: (1) zero cost when unused — Zion's design
+invariant ("absent block ⇒ zero overhead"); (2) backward-compatible — a route
+with no host binding must behave exactly as today; (3) the route lookup is
+fronted by a thread-local cache keyed on `FNV(path)` only (`dispatch.rs:476`).
+
+## Decision
+
+We add an optional `hosts: Option<Vec<String>>` to `RouteConfig`. A route with
+`hosts` set is served only for those authorities; a route without `hosts` is a
+**shared route** matching every authority. The single global router is replaced
+by a `HostRouter` holding: a `default` radix tree (the hostless/shared routes —
+byte-for-byte today's router), a `by_host: HashMap<Box<str>, Router<…>>` of
+exact-host trees, a `wildcards: Vec<(suffix, Router<…>)>` for `*.example.com`
+(Phase 2), and an `active` bool. Lookup normalizes the authority (lowercase,
+strip `:port` — IPv6-literal-safe — strip trailing `.`) then resolves in order:
+**exact host → wildcard suffix → `default` (shared) → 404**. This is the
+*hostless-as-shared-layer* fallback: host-specific routes override, common
+routes (health, metrics, catch-all) live hostless and are reachable from every
+host. The authority is taken from `req.uri().authority()` first (HTTP/2
+`:authority`, absolute-form) then the `Host` header (HTTP/1 origin-form),
+gated through the existing `security::is_valid_host`. Per-host trees are built
+by reusing `build_router`'s existing alias logic (`catchall_bare_prefix`,
+`trailing_slash_variant`) verbatim per host-group. When no route declares
+`hosts`, `active` is `false` and the hot path short-circuits to `default.at`,
+identical to today. **When `active`, the thread-local route cache key becomes
+`hash(host ‖ path)`.** Both lookup sites are updated: `dispatch.rs:491` and the
+ACME HTTP-01 upstream fallback at `main.rs:2043`.
+
+## Consequences
+
+- **Positive**: true virtual hosting — same path, different host, different
+  backend. Drop-in parity with nginx/Caddy/Traefik for the common case.
+  Zero measurable cost when no route declares `hosts` (`active=false`
+  short-circuit). The battle-tested alias logic is reused unchanged per
+  host-group, not reimplemented. Per-host isolation is a natural consequence:
+  a host's tree cannot resolve another host's routes.
+- **Negative**: one extra `HashMap` probe + authority normalization on the hot
+  path *when active* (~10–20 ns on top of the ~5 ns cache-hit / ~30 ns radix
+  path). Larger config surface and validation (per-host, not global,
+  `(host, path)` de-duplication). `print_routes_table` and per-route metrics
+  gain a host dimension.
+- **Neutral / risks**:
+  - **[LOAD-BEARING] Route-cache poisoning.** The thread-local cache is keyed
+    on path only today. If left unchanged under host routing,
+    `api.example.com/x` and `app.example.com/x` collide → a cache hit returns
+    the wrong `ResolvedRoute` → **cross-host misrouting that can bypass a
+    per-route `waf_profile` / `auth_profile` or reach an `internal_only`
+    backend** (tenant confusion). The key MUST fold in the normalized host when
+    `active`. This is the one non-obvious change to the hot path and is a
+    security invariant, not an optimization.
+  - **Host vs `:authority` divergence** (request-routing smuggling surface):
+    HTTP/1 clients may send a `Host` differing from an absolute-form target;
+    HTTP/2 carries `:authority`. We fix a single precedence (URI authority
+    first, then `Host`) and validate before use.
+  - Wildcard precedence (exact beats `*.example.com` beats bare `*`) is defined
+    in the contract below; regex host matching is explicitly out of scope.
+  - Hot-reload (ADR-0001, ArcSwap) swaps the whole `HostRouter` atomically —
+    no partially-built host map is ever observable.
+
+## Behaviour contract (normative)
+
+Config: `A` = route `hosts=["api.example.com"]` → upstream `api`; `S` = route
+with no `hosts` (shared) `path="/{*rest}"` → upstream `frontend`; both define
+`path="/x"` where noted. Authority normalization is applied before matching.
+
+| Request authority        | Path      | Resolves to        | Rule            |
+|--------------------------|-----------|--------------------|-----------------|
+| `api.example.com`        | `/x`      | `A` (`api`)        | exact host      |
+| `api.example.com:8443`   | `/x`      | `A` (`api`)        | port stripped   |
+| `API.example.com`        | `/x`      | `A` (`api`)        | case-folded     |
+| `api.example.com.`       | `/x`      | `A` (`api`)        | trailing dot    |
+| `app.example.com`        | `/x`      | `S` (`frontend`)   | shared fallback |
+| `api.example.com`        | `/other`  | `S` (`frontend`)   | host miss → shared |
+| *(no Host, HTTP/1.0)*    | `/x`      | `S` (`frontend`)   | hostless → shared |
+| `[2001:db8::1]:443`      | `/x`      | `S` (`frontend`)   | IP literal → shared |
+
+**Cache invariant**: for any two requests with authorities `h1 ≠ h2`
+(normalized) and equal path `p`, the thread-local route cache MUST NOT let a
+lookup for `(h1, p)` return the route selected for `(h2, p)` when `active`.
+
+**Validation**: a `hosts` entry must be a bare authority — no scheme, no path,
+no port; lowercased at load. `(host, path)` collisions are rejected per
+host-group (the same `path` may legitimately recur across different hosts and
+in the shared layer). An empty-string host is rejected.
+
+## Alternatives considered
+
+- **Combined `/host/path` radix key (single tree).** Encode the host as a path
+  prefix and keep one `matchit` tree. Rejected: it breaks the already-subtle,
+  path-shape-dependent alias logic (`catchall_bare_prefix`,
+  `trailing_slash_variant` reason about `rfind('/')` and the root `/`), cannot
+  cleanly express "hostless matches every host" without inserting a route under
+  every known host, and a root catch-all `/{*rest}` would swallow the host
+  segment.
+- **nginx-strict host isolation** (a matched host block never falls back to
+  shared routes). Rejected per decision: the shared layer is more ergonomic —
+  health/metrics/catch-all are written once, hostless, and host routes still
+  override. Strict isolation remains a one-line change (skip the `default`
+  fallback once a host tree matched the host but not the path) if ever needed.
+- **`[[site]]` block grouping routes under a host** (nginx `server {}` shape).
+  Rejected for now: more invasive config refactor; `hosts` on `RouteConfig` is
+  minimal and Traefik-rule-like. May return as ergonomic sugar that desugars to
+  per-route `hosts`.
+- **Do nothing — rely on SNI + path prefixes.** Rejected: impossible when two
+  hosts share a path; the `examples/multi-site.toml` limitation is exactly this.
+
+## References
+
+- `src/config.rs` — `RouteConfig`, `build_router`, `catchall_bare_prefix`,
+  `trailing_slash_variant`
+- `src/dispatch.rs:461-502` — route lookup + thread-local `ROUTE_CACHE`
+- `src/main.rs:2043` — ACME HTTP-01 upstream fallback (second lookup site)
+- `src/security.rs:305` — `is_valid_host`
+- `examples/multi-site.toml` — the host-blind "multi-site" example this fixes
+- ADR-0001 (ArcSwap config + TLS hot-reload) — atomic `HostRouter` swap
+- ADR-0003 (two-level cache with generation counter) — cache-key rationale
+- RFC 9110 §7.2 (Host / `:authority`), nginx `server_name`, Caddy site blocks,
+  Traefik `Host()` matcher, `matchit` radix router

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -20,6 +20,7 @@ defined in [0000-template.md](0000-template.md).
 | 0006  | [`tracing` always-on, OTLP gated by `--features otel`](0006-tracing-with-optional-otlp.md) | accepted |
 | 0007  | [Two-tier MSRV — 1.82 core, 1.88 with optional features](0007-bicapa-msrv.md) | accepted |
 | 0008  | [Embed AIMP as the mesh control-plane bus](0008-mesh-aimp-integration.md) | accepted |
+| 0010  | [Host-based L7 routing (virtual hosting)](0010-host-based-l7-routing.md) | accepted |
 
 ## When to write a new ADR
 

--- a/docs/config/routing.md
+++ b/docs/config/routing.md
@@ -37,6 +37,54 @@ upstream = "frontend"
 
 More specific routes take priority over wildcards. `/api/v1/events/stream` matches before `/api/{*rest}`.
 
+## Host-Based Routing (Virtual Hosting)
+
+Bind a route to one or more `hosts` to serve different backends for different domains on the same listener — the `Host` header (HTTP/1) or `:authority` (HTTP/2) selects the route. A route **without** `hosts` is *shared*: it matches every host and acts as a fallback.
+
+```toml
+# api.example.com → API backend
+[[route]]
+hosts = ["api.example.com"]
+path = "/{*rest}"
+upstream = "api"
+
+# app.example.com and any *.example.com subdomain → frontend
+[[route]]
+hosts = ["app.example.com", "*.example.com"]
+path = "/{*rest}"
+upstream = "frontend"
+
+# Shared: no `hosts`, reachable on every domain
+[[route]]
+path = "/healthz"
+upstream = "api"
+internal_only = true
+```
+
+The same path now serves different backends per host — `api.example.com/` and `app.example.com/` route independently, which a path-only router cannot express.
+
+### Matching Precedence
+
+For a request authority, Zion resolves in this order:
+
+1. **Exact host** — matches a route bound to exactly that host.
+2. **Wildcard** — `*.example.com` matches any subdomain (`foo.example.com`, `a.b.example.com`) but **not** the apex `example.com`. The most specific wildcard wins (`*.api.example.com` before `*.example.com`).
+3. **Shared** — routes with no `hosts`; also the fallback when the selected host tree has no matching path.
+
+An exact host beats a wildcard, and a matched host never falls through to *another* host's routes — only to the shared layer.
+
+### Host Normalization
+
+Authorities are normalized before matching: lowercased, port stripped (`api.example.com:8443` → `api.example.com`), and a trailing FQDN dot removed. Config `hosts` entries must be canonical bare hostnames — no scheme, path, port, or trailing dot (uppercase is folded). Only leading-label wildcards (`*.example.com`) are supported.
+
+### Relationship to TLS SNI
+
+`hosts` (L7 routing) is independent of [`[[tls.sni]]`](./tls) (which certificate to present). SNI picks the cert during the TLS handshake; `hosts` picks the backend from the decrypted request. A direct-IP or unknown-SNI client still routes via `hosts` (or the shared layer) using the `Host` header.
+
+### Performance
+
+Host routing is **opt-in and zero-cost when unused**: with no `hosts` anywhere, lookups skip authority extraction and behave exactly as the path-only router. When active, a lookup adds one hash-map probe plus authority normalization, and the thread-local route cache is keyed on `(host, path)` so different domains never share a cache slot.
+
 ## Route Modes
 
 | Mode | Behavior |
@@ -120,5 +168,6 @@ Zion validates all routes at boot:
 - Every `cache_profile` reference must point to an existing `[cache_profile.<name>]`
 - All upstream URLs must be valid URIs
 - Path patterns must be valid radix tree patterns
+- Every `hosts` entry must be a canonical bare hostname or a `*.<domain>` wildcard
 
 If validation fails, Zion prints all errors and exits with code 1.

--- a/docs/deploy/hot-reload.md
+++ b/docs/deploy/hot-reload.md
@@ -130,7 +130,7 @@ Two surfaces report the reload state:
 
   ```json
   {
-    "version": "0.4.7",
+    "version": "0.5.0",
     "timestamp_ms": 1714425600000,
     "uptime_secs": 3712,
     "config_generation": 5,

--- a/docs/security/supply-chain.md
+++ b/docs/security/supply-chain.md
@@ -46,8 +46,8 @@ You need the GitHub CLI (`gh >= 2.49`) and `cosign >= 2.2`.
 
 ```bash
 # 1. Download the artifact + SHA256SUMS from the release page.
-gh release download v0.4.7 -R fabriziosalmi/zion \
-    -p 'zion-v0.4.7-x86_64-unknown-linux-musl.tar.gz' \
+gh release download v0.5.0 -R fabriziosalmi/zion \
+    -p 'zion-v0.5.0-x86_64-unknown-linux-musl.tar.gz' \
     -p 'SHA256SUMS' \
     -p 'zion-sbom.cdx.json'
 
@@ -55,7 +55,7 @@ gh release download v0.4.7 -R fabriziosalmi/zion \
 sha256sum --check --ignore-missing SHA256SUMS
 
 # 3. Verify the SLSA build provenance bound to the artifact's hash.
-gh attestation verify zion-v0.4.7-x86_64-unknown-linux-musl.tar.gz \
+gh attestation verify zion-v0.5.0-x86_64-unknown-linux-musl.tar.gz \
     --owner fabriziosalmi
 
 # Step 3 fails if:
@@ -78,7 +78,7 @@ grype zion-sbom.cdx.json
 ## Verifying a container image
 
 ```bash
-IMAGE=ghcr.io/fabriziosalmi/zion:v0.4.7
+IMAGE=ghcr.io/fabriziosalmi/zion:v0.5.0
 
 # 1. Pin to the digest immediately — tags are mutable, digests are not.
 DIGEST=$(crane digest "$IMAGE")
@@ -120,7 +120,7 @@ deterministically, and pins the Rust toolchain via
 [`rust-toolchain.toml`](../../rust-toolchain.toml). To reproduce locally:
 
 ```bash
-git checkout v0.4.7
+git checkout v0.5.0
 export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)
 # Linux musl example — matches the release artifact byte-for-byte
 # (modulo strip's stable behavior on your distro).

--- a/examples/multi-site.toml
+++ b/examples/multi-site.toml
@@ -1,13 +1,17 @@
 # ============================================================================
-# MULTI-SITE EXAMPLE — 3 domains, 3 backends, auto-renew certs
+# MULTI-SITE EXAMPLE — 3 domains, host routing, auto-renew certs
 # ============================================================================
 #
-# This config serves:
-#   - api.example.com    → Go backend on :8000 (with WAF)
-#   - app.example.com    → Next.js on :3000 (with cache)
+# True virtual hosting (ADR-0010): each domain routes to its own backend by the
+# request Host / :authority, so the SAME path serves different backends per
+# domain. This config serves:
+#   - api.example.com    → Go backend on :8000 (WAF on every path)
+#   - app.example.com    → Next.js on :3000 (static assets cached)
+#   - *.example.com      → Next.js too (preview subdomains); exact hosts win
 #   - admin.example.com  → Admin panel on :4000 (internal only)
 #
-# Each domain has its own TLS certificate.
+# Each domain has its own TLS certificate (via [[tls.sni]]) AND its own routing
+# (via per-route `hosts`) — two separate layers.
 # Certificates are auto-renewed via ACME (Let's Encrypt).
 
 [server]
@@ -75,45 +79,56 @@ max_entries = 10000
 ttl_seconds = 31536000
 
 # ── Routes ───────────────────────────────────────────────────────
-# API backend (with WAF + CORS)
+# Routing is HOST-AWARE (ADR-0010): each [[route]] may bind to one or more
+# `hosts`. A route WITHOUT `hosts` is *shared* — it matches every host and
+# acts as a fallback. Precedence: exact host > `*.wildcard` > shared. This is
+# a separate layer from `[[tls.sni]]` above, which only picks the certificate.
+
+# ── api.example.com → API backend (WAF + CORS on every path) ─────
 [[route]]
-path = "/api/{*rest}"
+hosts = ["api.example.com"]
+path = "/{*rest}"
 upstream = "api"
 waf_profile = "strict"
 # CORS is configured PER ROUTE (there is no top-level [cors] table).
 cors = { allowed_origins = ["https://app.example.com"], allowed_headers = ["Content-Type", "Authorization"], max_age = 86400 }
 
-# Next.js static assets (cached in RAM)
 [[route]]
-path = "/_next/static/{*rest}"
-upstream = "frontend"
-cache_profile = "immutable"
-
-# WebSocket endpoint
-[[route]]
+hosts = ["api.example.com"]
 path = "/ws"
 upstream = "api"
 mode = "websocket"
 
-# SSE streaming
 [[route]]
+hosts = ["api.example.com"]
 path = "/events/stream"
 upstream = "api"
 mode = "sse_stream"
 
-# Admin panel (internal network only)
+# ── app.example.com (and any other *.example.com) → Next.js ──────
+# The wildcard also serves preview subdomains (pr-123.example.com, …). The
+# exact hosts above win over it, so api/admin are never caught here.
 [[route]]
-path = "/admin/{*rest}"
+hosts = ["app.example.com", "*.example.com"]
+path = "/_next/static/{*rest}"
+upstream = "frontend"
+cache_profile = "immutable"
+
+[[route]]
+hosts = ["app.example.com", "*.example.com"]
+path = "/{*rest}"
+upstream = "frontend"
+
+# ── admin.example.com → admin panel (internal network only) ──────
+[[route]]
+hosts = ["admin.example.com"]
+path = "/{*rest}"
 upstream = "admin"
 internal_only = true
 
-# Health + metrics (built-in, no upstream needed)
+# ── Shared route (no `hosts`) — reachable on every domain ────────
+# Written once, served for api/app/admin alike. Internal-only.
 [[route]]
 path = "/metrics"
 upstream = "api"
 internal_only = true
-
-# Catch-all → frontend
-[[route]]
-path = "/{*rest}"
-upstream = "frontend"

--- a/src/config.rs
+++ b/src/config.rs
@@ -655,6 +655,16 @@ fn validate_upstream_url(label: &str, url: &str) -> Option<String> {
 /// accepted and folded; anything else non-canonical is rejected. Returns
 /// `Some(error)` on rejection, `None` when valid.
 fn validate_host_entry(label: &str, host: &str) -> Option<String> {
+    // Wildcards (`*.example.com`) are planned (ADR-0010, follow-up) but not yet
+    // routed. Reject them at load rather than silently inserting an exact key
+    // that no normalized request authority can ever match — a config that
+    // "loads but never matches" is worse than a clear error.
+    if host.contains('*') {
+        return Some(format!(
+            "{label} host '{host}': wildcard hosts are not yet supported — \
+             list exact hostnames (see ADR-0010)"
+        ));
+    }
     let lower = host.to_ascii_lowercase();
     if crate::security::normalize_host(host).as_deref() == Some(lower.as_str()) {
         None
@@ -1645,6 +1655,13 @@ mtls_fingerprint = false
                 "should reject host: {bad:?}"
             );
         }
+    }
+
+    #[test]
+    fn validate_host_entry_rejects_wildcards_until_supported() {
+        // Wildcards must fail loudly at load, not load-and-never-match (ADR-0010).
+        assert!(validate_host_entry("r", "*.example.com").is_some());
+        assert!(validate_host_entry("r", "api.*.example.com").is_some());
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -655,22 +655,38 @@ fn validate_upstream_url(label: &str, url: &str) -> Option<String> {
 /// accepted and folded; anything else non-canonical is rejected. Returns
 /// `Some(error)` on rejection, `None` when valid.
 fn validate_host_entry(label: &str, host: &str) -> Option<String> {
-    // Wildcards (`*.example.com`) are planned (ADR-0010, follow-up) but not yet
-    // routed. Reject them at load rather than silently inserting an exact key
-    // that no normalized request authority can ever match — a config that
-    // "loads but never matches" is worse than a clear error.
+    // A leading-label wildcard `*.example.com` is valid: validate the domain
+    // after `*.` as a canonical bare host (ADR-0010).
+    if let Some(domain) = host.strip_prefix("*.") {
+        if domain.is_empty() || domain.contains('*') {
+            return Some(format!(
+                "{label} host '{host}': a wildcard must be `*.<domain>` with a \
+                 concrete domain (e.g. `*.example.com`)"
+            ));
+        }
+        return bare_host_error(label, host, domain);
+    }
+    // Any other use of `*` (embedded or trailing) is not supported.
     if host.contains('*') {
         return Some(format!(
-            "{label} host '{host}': wildcard hosts are not yet supported — \
-             list exact hostnames (see ADR-0010)"
+            "{label} host '{host}': only leading-label wildcards `*.<domain>` are \
+             supported (not embedded or trailing `*`)"
         ));
     }
-    let lower = host.to_ascii_lowercase();
-    if crate::security::normalize_host(host).as_deref() == Some(lower.as_str()) {
+    bare_host_error(label, host, host)
+}
+
+/// Shared fixed-point check for a bare host: `candidate` must be canonical under
+/// [`crate::security::normalize_host`] (modulo case folding). `original` is the
+/// raw entry, used only in the error message. Returns `Some(error)` on
+/// rejection, `None` when valid.
+fn bare_host_error(label: &str, original: &str, candidate: &str) -> Option<String> {
+    let lower = candidate.to_ascii_lowercase();
+    if crate::security::normalize_host(candidate).as_deref() == Some(lower.as_str()) {
         None
     } else {
         Some(format!(
-            "{label} host '{host}' must be a bare hostname \
+            "{label} host '{original}' must be a bare hostname \
              (no scheme, path, port, or trailing dot)"
         ))
     }
@@ -881,19 +897,25 @@ fn resolve_upstream(config: &ZionConfig, name: &str) -> Result<Vec<String>, Stri
     ))
 }
 
-/// Host-aware L7 router (ADR-0010). Holds the hostless/shared radix tree plus
-/// one tree per bound host; a route with no `hosts` lands in `default` and is
-/// reachable from every authority (the shared fallback layer). When no route
-/// declares `hosts`, `active` is false and lookups go straight to `default` —
-/// identical, and identically cheap, to the pre-host-routing single router.
+/// Host-aware L7 router (ADR-0010). Holds the hostless/shared radix tree, one
+/// tree per exact bound host, and one tree per `*.suffix` wildcard. A route with
+/// no `hosts` lands in `default` and is reachable from every authority (the
+/// shared fallback layer). When no route declares `hosts`, `active` is false and
+/// lookups go straight to `default` — identical, and identically cheap, to the
+/// pre-host-routing single router. Precedence: exact host > most-specific
+/// wildcard > shared.
 #[derive(Debug)]
 pub struct HostRouter {
     /// Hostless / shared routes — matched for every authority.
     default: Router<Arc<ResolvedRoute>>,
     /// Exact-host radix trees, keyed by normalized authority.
     by_host: HashMap<Box<str>, Router<Arc<ResolvedRoute>>>,
-    /// True iff at least one route is host-bound. Lets the hot path skip
-    /// authority extraction entirely in the common (hostless) deployment.
+    /// Wildcard trees keyed by their dotted suffix (`*.example.com` →
+    /// `.example.com`), sorted longest-suffix-first so the most specific wins.
+    /// A request host matches when it `ends_with` the suffix.
+    wildcards: Vec<(String, Router<Arc<ResolvedRoute>>)>,
+    /// True iff at least one route is host-bound (exact or wildcard). Lets the
+    /// hot path skip authority extraction entirely in the hostless deployment.
     active: bool,
 }
 
@@ -902,6 +924,7 @@ impl Default for HostRouter {
         Self {
             default: Router::new(),
             by_host: HashMap::new(),
+            wildcards: Vec::new(),
             active: false,
         }
     }
@@ -916,17 +939,32 @@ impl HostRouter {
     }
 
     /// Resolve `(host, path)` to a route, per ADR-0010's hostless-as-shared-layer
-    /// rule: consult the exact-host tree first, then fall back to the shared
-    /// `default` tree. `host` is the normalized request authority
-    /// ([`crate::security::normalize_host`]), or `None` when the authority is
-    /// absent/invalid — in which case only the shared layer is consulted.
+    /// rule with precedence exact > wildcard > shared: an exact-host tree wins;
+    /// otherwise the most-specific matching `*.suffix` wildcard; then the shared
+    /// `default` tree. On a path-miss within the selected host tree we still fall
+    /// through to shared (shared routes are reachable from every host). `host` is
+    /// the normalized request authority ([`crate::security::normalize_host`]), or
+    /// `None` when absent/invalid — then only the shared layer is consulted.
     #[inline]
     pub fn at(&self, host: Option<&str>, path: &str) -> Option<&Arc<ResolvedRoute>> {
         if self.active {
             if let Some(h) = host {
                 if let Some(tree) = self.by_host.get(h) {
+                    // Exact host wins outright (nginx-style); path-miss → shared.
                     if let Ok(m) = tree.at(path) {
                         return Some(m.value);
+                    }
+                } else {
+                    // No exact host: the most-specific matching wildcard, if any.
+                    // `wildcards` is sorted longest-suffix-first, so the first
+                    // `ends_with` hit is the most specific one.
+                    for (suffix, tree) in &self.wildcards {
+                        if h.ends_with(suffix.as_str()) {
+                            if let Ok(m) = tree.at(path) {
+                                return Some(m.value);
+                            }
+                            break; // most-specific wildcard chosen; fall to shared
+                        }
                     }
                 }
             }
@@ -1016,43 +1054,70 @@ pub fn build_router(config: &ZionConfig) -> Result<HostRouter, String> {
     let mut default = RouterBuilder::default();
     let mut by_host: HashMap<Box<str>, RouterBuilder> = HashMap::new();
 
+    let mut wild: HashMap<String, RouterBuilder> = HashMap::new();
+
     for route in &config.route {
         let resolved = resolve_route(config, route)?;
         match &route.hosts {
             // Shared route: reachable from every authority.
             None => default.insert(&route.path, resolved)?,
-            // Host-bound: insert into each host's tree. Validation guarantees
-            // every entry is a canonical host, so normalize_host returns Some.
+            // Host-bound. Validation guarantees each entry is either a canonical
+            // exact host or a `*.<canonical-domain>` wildcard.
             Some(hosts) => {
-                let mut seen = std::collections::HashSet::new();
+                let mut seen_exact = std::collections::HashSet::new();
+                let mut seen_wild = std::collections::HashSet::new();
                 for h in hosts {
-                    let key = crate::security::normalize_host(h)
-                        .ok_or_else(|| format!("route '{}': invalid host '{}'", route.path, h))?
-                        .into_owned();
-                    // A host repeated in one route's list must insert once, not
-                    // twice into the same tree (which matchit rejects as a dup).
-                    if !seen.insert(key.clone()) {
-                        continue;
+                    if let Some(rest) = h.strip_prefix("*.") {
+                        // Wildcard: the match key is the dotted, normalized
+                        // suffix (`*.example.com` → `.example.com`).
+                        let domain = crate::security::normalize_host(rest).ok_or_else(|| {
+                            format!("route '{}': invalid wildcard host '{}'", route.path, h)
+                        })?;
+                        let suffix = format!(".{domain}");
+                        // A suffix repeated in one route's list inserts once.
+                        if !seen_wild.insert(suffix.clone()) {
+                            continue;
+                        }
+                        wild.entry(suffix)
+                            .or_default()
+                            .insert(&route.path, resolved.clone())?;
+                    } else {
+                        let key = crate::security::normalize_host(h)
+                            .ok_or_else(|| format!("route '{}': invalid host '{}'", route.path, h))?
+                            .into_owned();
+                        // A host repeated in one route's list must insert once,
+                        // not twice into the same tree (matchit rejects a dup).
+                        if !seen_exact.insert(key.clone()) {
+                            continue;
+                        }
+                        by_host
+                            .entry(key.into_boxed_str())
+                            .or_default()
+                            .insert(&route.path, resolved.clone())?;
                     }
-                    by_host
-                        .entry(key.into_boxed_str())
-                        .or_default()
-                        .insert(&route.path, resolved.clone())?;
                 }
             }
         }
     }
 
-    let active = !by_host.is_empty();
+    let active = !by_host.is_empty() || !wild.is_empty();
     let by_host = by_host
         .into_iter()
         .map(|(host, builder)| (host, builder.finish()))
         .collect();
+    // Longest suffix first so the most specific wildcard wins at lookup; the
+    // content tiebreak keeps the order deterministic across rebuilds.
+    let mut wildcards: Vec<(String, Router<Arc<ResolvedRoute>>)> = wild
+        .into_iter()
+        .map(|(suffix, builder)| (suffix, builder.finish()))
+        .collect();
+    wildcards.sort_by(|a, b| b.0.len().cmp(&a.0.len()).then_with(|| a.0.cmp(&b.0)));
 
     print_routes_table(&config.route);
     Ok(HostRouter {
         default: default.finish(),
         by_host,
+        wildcards,
         active,
     })
 }
@@ -1658,10 +1723,24 @@ mtls_fingerprint = false
     }
 
     #[test]
-    fn validate_host_entry_rejects_wildcards_until_supported() {
-        // Wildcards must fail loudly at load, not load-and-never-match (ADR-0010).
-        assert!(validate_host_entry("r", "*.example.com").is_some());
-        assert!(validate_host_entry("r", "api.*.example.com").is_some());
+    fn validate_host_entry_wildcards() {
+        // Leading-label wildcards are accepted (domain case-folded)...
+        assert!(validate_host_entry("r", "*.example.com").is_none());
+        assert!(validate_host_entry("r", "*.API.example.com").is_none());
+        // ...but the domain must be canonical, and embedded / trailing / bare
+        // `*` (or an empty domain / a port) is rejected.
+        for bad in [
+            "*.",
+            "*.example.com:8443",
+            "api.*.example.com",
+            "www.example.*",
+            "*",
+        ] {
+            assert!(
+                validate_host_entry("r", bad).is_some(),
+                "should reject wildcard host: {bad:?}"
+            );
+        }
     }
 
     #[test]
@@ -2292,5 +2371,69 @@ upstream = "shared"
         // A host is simply ignored — everything resolves via the shared tree.
         assert!(router.at(Some("whatever.example.com"), "/api/x").is_some());
         assert!(router.at(None, "/api/x").is_some());
+    }
+
+    #[test]
+    fn host_router_wildcard_and_precedence() {
+        fn url<'a>(r: &'a HostRouter, host: &str, path: &str) -> &'a str {
+            r.at(Some(host), path)
+                .expect("route should resolve")
+                .upstream_url[0]
+                .as_str()
+        }
+        let toml_str = r#"
+[server]
+listen_http = "0.0.0.0:80"
+listen_https = "0.0.0.0:443"
+[tls]
+cert_path = "/tmp/c.pem"
+key_path = "/tmp/k.pem"
+[upstream.exact]
+url = "http://127.0.0.1:8000"
+[upstream.wild]
+url = "http://127.0.0.1:8001"
+[upstream.deep]
+url = "http://127.0.0.1:8002"
+[upstream.shared]
+url = "http://127.0.0.1:9000"
+[[route]]
+path = "/{*rest}"
+hosts = ["api.example.com"]
+upstream = "exact"
+[[route]]
+path = "/{*rest}"
+hosts = ["*.example.com"]
+upstream = "wild"
+[[route]]
+path = "/{*rest}"
+hosts = ["*.api.example.com"]
+upstream = "deep"
+[[route]]
+path = "/{*rest}"
+upstream = "shared"
+"#;
+        let config: ZionConfig = toml::from_str(toml_str).unwrap();
+        let router = build_router(&config).unwrap();
+        assert!(router.active);
+
+        // Exact host beats any wildcard.
+        assert_eq!(
+            url(&router, "api.example.com", "/x"),
+            "http://127.0.0.1:8000"
+        );
+        // A subdomain with no exact entry matches the wildcard.
+        assert_eq!(
+            url(&router, "foo.example.com", "/x"),
+            "http://127.0.0.1:8001"
+        );
+        // The most-specific wildcard wins (`*.api.example.com` > `*.example.com`).
+        assert_eq!(
+            url(&router, "v1.api.example.com", "/x"),
+            "http://127.0.0.1:8002"
+        );
+        // The apex (no leading label) does NOT match `*.example.com` → shared.
+        assert_eq!(url(&router, "example.com", "/x"), "http://127.0.0.1:9000");
+        // An unrelated host → shared.
+        assert_eq!(url(&router, "other.org", "/x"), "http://127.0.0.1:9000");
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -510,6 +510,18 @@ fn default_ttl() -> u64 {
 #[serde(deny_unknown_fields)]
 pub struct RouteConfig {
     pub path: String,
+
+    /// Optional Host/authority bindings (ADR-0010). When set, this route is
+    /// served only for these hosts; when unset, the route is a *shared* route
+    /// matching every host (the hostless fallback layer). Entries are bare
+    /// hostnames — validated as fixed points of
+    /// [`crate::security::normalize_host`] (lowercase modulo case-folding, no
+    /// scheme/path/port/trailing dot) so a config key and a normalized request
+    /// authority compare in the same form. Parsed and validated here; wired
+    /// into the router in a follow-up.
+    #[serde(default)]
+    pub hosts: Option<Vec<String>>,
+
     pub upstream: String,
     #[serde(default)]
     pub mode: RouteMode,
@@ -634,6 +646,26 @@ fn validate_upstream_url(label: &str, url: &str) -> Option<String> {
     }
 }
 
+/// A route `hosts` entry must be a canonical bare host — a fixed point of
+/// [`crate::security::normalize_host`] (ADR-0010): lowercase modulo case
+/// folding, with no scheme, path, port, or trailing FQDN dot. That guarantees
+/// the host-routing key equals the normalized request authority the dispatcher
+/// will look up, so a subtly-different config entry (a stray `:443`, an
+/// uppercased or dotted FQDN) can never silently fail to match. Uppercase is
+/// accepted and folded; anything else non-canonical is rejected. Returns
+/// `Some(error)` on rejection, `None` when valid.
+fn validate_host_entry(label: &str, host: &str) -> Option<String> {
+    let lower = host.to_ascii_lowercase();
+    if crate::security::normalize_host(host).as_deref() == Some(lower.as_str()) {
+        None
+    } else {
+        Some(format!(
+            "{label} host '{host}' must be a bare hostname \
+             (no scheme, path, port, or trailing dot)"
+        ))
+    }
+}
+
 /// Validate config at startup — fail fast with actionable error messages.
 fn validate_config(config: &ZionConfig, path: &str) -> Result<(), String> {
     let mut errors: Vec<String> = Vec::new();
@@ -738,6 +770,24 @@ fn validate_config(config: &ZionConfig, path: &str) -> Result<(), String> {
                     "route '{}' references unknown auth_profile '{}'",
                     route.path, profile
                 ));
+            }
+        }
+
+        // Host bindings (ADR-0010): each entry must be a canonical bare host so
+        // the routing key matches the normalized request authority. An explicit
+        // empty list is meaningless — omit `hosts` for a shared route.
+        if let Some(hosts) = &route.hosts {
+            if hosts.is_empty() {
+                errors.push(format!(
+                    "route '{}' has `hosts = []` — omit `hosts` for a shared route, \
+                     or list at least one host",
+                    route.path
+                ));
+            }
+            for h in hosts {
+                if let Some(e) = validate_host_entry(&format!("route '{}'", route.path), h) {
+                    errors.push(e);
+                }
             }
         }
     }
@@ -1158,6 +1208,7 @@ mod tests {
     fn route(path: &str) -> RouteConfig {
         RouteConfig {
             path: path.into(),
+            hosts: None,
             upstream: "backend".into(),
             mode: RouteMode::Standard,
             internal_only: false,
@@ -1447,6 +1498,66 @@ mtls_fingerprint = false
                 "should reject upstream URL: {bad}"
             );
         }
+    }
+
+    #[test]
+    fn validate_host_entry_accepts_bare_and_folds_case() {
+        // A bare host is accepted; uppercase is folded (friendly); an IPv6
+        // literal is a valid host key.
+        assert!(validate_host_entry("r", "api.example.com").is_none());
+        assert!(validate_host_entry("r", "API.Example.COM").is_none());
+        assert!(validate_host_entry("r", "[::1]").is_none());
+    }
+
+    #[test]
+    fn validate_host_entry_rejects_non_canonical() {
+        // Anything that isn't a fixed point of normalize_host (modulo case) is
+        // rejected with an actionable error — a stray port, trailing dot,
+        // scheme, path, userinfo, or empty entry can never silently mis-match.
+        for bad in [
+            "api.example.com:8443",
+            "api.example.com.",
+            "https://api.example.com",
+            "api.example.com/x",
+            "user@api.example.com",
+            "",
+        ] {
+            assert!(
+                validate_host_entry("r", bad).is_some(),
+                "should reject host: {bad:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_route_hosts_field() {
+        // A route may bind one or more hosts; a route without `hosts` is shared.
+        let toml_str = r#"
+[server]
+listen_http = "0.0.0.0:80"
+listen_https = "0.0.0.0:443"
+[tls]
+cert_path = "/tmp/cert.pem"
+key_path = "/tmp/key.pem"
+[upstreams]
+backend = "http://127.0.0.1:8000"
+[[route]]
+path = "/api/{*rest}"
+upstream = "backend"
+hosts = ["api.example.com", "api2.example.com"]
+[[route]]
+path = "/{*rest}"
+upstream = "backend"
+"#;
+        let config: ZionConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            config.route[0].hosts,
+            Some(vec![
+                "api.example.com".to_string(),
+                "api2.example.com".to_string()
+            ])
+        );
+        assert!(config.route[1].hosts.is_none(), "shared route ⇒ hosts None");
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -871,157 +871,85 @@ fn resolve_upstream(config: &ZionConfig, name: &str) -> Result<Vec<String>, Stri
     ))
 }
 
-/// Build a radix tree from config routes, pre-resolving all references.
-/// Routes are wrapped in Arc for zero-allocation cloning on the hot path.
-///
-/// Returns `Err` if any route references an unknown upstream, profile, or
-/// contains an invalid pattern. The caller (boot path or hot-reload) decides
-/// whether to abort or log-and-keep the previous snapshot.
-pub fn build_router(config: &ZionConfig) -> Result<Router<Arc<ResolvedRoute>>, String> {
-    let mut router = Router::new();
-    // Extra route aliases applied after every explicit route is inserted (so an
-    // explicit route always wins): a catch-all's bare prefix, and the
-    // trailing-slash-toggled variant of each explicit route.
-    let mut route_aliases: Vec<(String, Arc<ResolvedRoute>)> = Vec::new();
+/// Host-aware L7 router (ADR-0010). Holds the hostless/shared radix tree plus
+/// one tree per bound host; a route with no `hosts` lands in `default` and is
+/// reachable from every authority (the shared fallback layer). When no route
+/// declares `hosts`, `active` is false and lookups go straight to `default` —
+/// identical, and identically cheap, to the pre-host-routing single router.
+#[derive(Debug)]
+pub struct HostRouter {
+    /// Hostless / shared routes — matched for every authority.
+    default: Router<Arc<ResolvedRoute>>,
+    /// Exact-host radix trees, keyed by normalized authority.
+    by_host: HashMap<Box<str>, Router<Arc<ResolvedRoute>>>,
+    /// True iff at least one route is host-bound. Lets the hot path skip
+    /// authority extraction entirely in the common (hostless) deployment.
+    active: bool,
+}
 
-    for route in &config.route {
-        let upstream_url = resolve_upstream(config, &route.upstream)?;
+impl Default for HostRouter {
+    fn default() -> Self {
+        Self {
+            default: Router::new(),
+            by_host: HashMap::new(),
+            active: false,
+        }
+    }
+}
 
-        // Resolve WAF: named profile > legacy bool flag
-        let waf = if let Some(ref profile_name) = route.waf_profile {
-            Some(
-                config
-                    .waf_profile
-                    .get(profile_name)
-                    .ok_or_else(|| {
-                        format!(
-                            "Unknown waf_profile '{}' in route {}",
-                            profile_name, route.path
-                        )
-                    })?
-                    .clone(),
-            )
-        } else if route.waf {
-            // Legacy: create inline profile from max_body_mb
-            Some(WafProfile {
-                max_body_mb: route.max_body_mb.unwrap_or(10),
-                ..WafProfile::default()
-            })
-        } else {
-            // Footgun guard: `max_body_mb` is enforced by the WAF body gate, so
-            // on a WAF-off route it has no effect. Surface it at boot rather
-            // than silently dropping the operator's intended size cap (a no-WAF
-            // route otherwise streams the body to the upstream, hyper-framed).
-            if route.max_body_mb.is_some() {
-                eprintln!(
-                    "  ⚠ route '{}': max_body_mb is set but WAF is off (no waf=true / waf_profile) \
-                     — the body-size cap is NOT enforced; enable WAF or remove max_body_mb",
-                    route.path
-                );
+impl HostRouter {
+    /// Resolve `(host, path)` to a route, per ADR-0010's hostless-as-shared-layer
+    /// rule: consult the exact-host tree first, then fall back to the shared
+    /// `default` tree. `host` is the normalized request authority
+    /// ([`crate::security::normalize_host`]), or `None` when the authority is
+    /// absent/invalid — in which case only the shared layer is consulted.
+    #[inline]
+    pub fn at(&self, host: Option<&str>, path: &str) -> Option<&Arc<ResolvedRoute>> {
+        if self.active {
+            if let Some(h) = host {
+                if let Some(tree) = self.by_host.get(h) {
+                    if let Ok(m) = tree.at(path) {
+                        return Some(m.value);
+                    }
+                }
             }
-            None
-        };
+        }
+        self.default.at(path).ok().map(|m| m.value)
+    }
+}
 
-        // Resolve cache: named profile > legacy mode=static_cache
-        let cache = if let Some(ref profile_name) = route.cache_profile {
-            Some(
-                config
-                    .cache_profile
-                    .get(profile_name)
-                    .ok_or_else(|| {
-                        format!(
-                            "Unknown cache_profile '{}' in route {}",
-                            profile_name, route.path
-                        )
-                    })?
-                    .clone(),
-            )
-        } else if route.mode == RouteMode::StaticCache {
-            // Default in-RAM profile for a profile-less static_cache route:
-            // conservative 1h TTL (default_ttl), NOT immutable. Name an explicit
-            // [cache_profile] with a longer ttl_seconds for content-hashed assets.
-            Some(CacheProfile {
-                mode: CacheMode::Memory,
-                max_entries: default_max_entries(),
-                ttl_seconds: default_ttl(),
-            })
-        } else {
-            None
-        };
+/// Accumulates the routes of a single host-group into one radix tree, deferring
+/// the catch-all bare-prefix and trailing-slash aliases until every explicit
+/// route of the group is inserted (so an explicit route always wins a conflict).
+struct RouterBuilder {
+    router: Router<Arc<ResolvedRoute>>,
+    aliases: Vec<(String, Arc<ResolvedRoute>)>,
+}
 
-        // Pre-parse the FIRST upstream URI at startup for legacy fallback.
-        // In a true clustered setup with latency routing, we use the first to get the scheme.
-        let upstream_uri: hyper::Uri = upstream_url[0]
-            .parse()
-            .map_err(|e| format!("Invalid upstream URL '{}': {}", upstream_url[0], e))?;
-        let upstream_scheme = upstream_uri
-            .scheme()
-            .cloned()
-            .unwrap_or_else(|| "http".parse().unwrap());
-        let upstream_authority = upstream_uri
-            .authority()
-            .cloned()
-            .ok_or_else(|| format!("Upstream '{}' has no authority", upstream_url[0]))?;
+impl Default for RouterBuilder {
+    fn default() -> Self {
+        Self {
+            router: Router::new(),
+            aliases: Vec::new(),
+        }
+    }
+}
 
-        // Pre-parse CSP at startup for zero-cost injection at runtime
-        let csp = match route.csp.as_ref() {
-            Some(s) => Some(
-                hyper::header::HeaderValue::from_str(s)
-                    .map_err(|e| format!("Invalid CSP in route '{}': {}", route.path, e))?,
-            ),
-            None => None,
-        };
-
-        // Resolve auth profile at startup (feature-gated)
-        #[cfg(feature = "auth")]
-        let auth = match route.auth_profile.as_ref() {
-            Some(name) => {
-                let profile_config = config.auth_profile.get(name).ok_or_else(|| {
-                    format!("Auth profile '{}' not found (route '{}')", name, route.path)
-                })?;
-                let resolved = crate::auth::resolve_auth_profile(profile_config).map_err(|e| {
-                    format!("Auth profile '{}' (route '{}'): {}", name, route.path, e)
-                })?;
-                eprintln!(
-                    "  auth: route {} → profile '{}' (alg={})",
-                    route.path, name, profile_config.algorithm
-                );
-                Some(resolved)
-            }
-            None => None,
-        };
-
-        let cors = route
-            .cors
-            .as_ref()
-            .map(|c| Arc::new(crate::security::CorsHeaders::from_config(c)));
-
-        let resolved = Arc::new(ResolvedRoute {
-            upstream_url,
-            upstream_scheme,
-            upstream_authority,
-            mode: route.mode.clone(),
-            waf,
-            waf_shadow: route.waf_shadow,
-            cache,
-            internal_only: route.internal_only,
-            csp,
-            #[cfg(feature = "auth")]
-            auth,
-            cors,
-        });
-
+impl RouterBuilder {
+    /// Insert one explicit route and record its bare-prefix / trailing-slash
+    /// alias for the deferred second pass.
+    fn insert(&mut self, path: &str, resolved: Arc<ResolvedRoute>) -> Result<(), String> {
         // A matchit catch-all "<prefix>/{*name}" does NOT match the bare
         // "<prefix>" (nor the root "/" when the prefix is empty), so a
         // "/{*rest}" route silently 404s on "/" even though it is meant to be
         // the fallback for everything. Record the bare prefix so we can also
         // map it to this route in a second pass (after all explicit routes).
-        match catchall_bare_prefix(&route.path) {
+        match catchall_bare_prefix(path) {
             Some(bare) => {
-                router
-                    .insert(route.path.clone(), resolved.clone())
-                    .map_err(|e| format!("Bad route pattern '{}': {}", route.path, e))?;
-                route_aliases.push((bare, resolved));
+                self.router
+                    .insert(path.to_string(), resolved.clone())
+                    .map_err(|e| format!("Bad route pattern '{}': {}", path, e))?;
+                self.aliases.push((bare, resolved));
             }
             None => {
                 // Non-catch-all: also alias the trailing-slash-toggled variant
@@ -1029,35 +957,218 @@ pub fn build_router(config: &ZionConfig) -> Result<Router<Arc<ResolvedRoute>>, S
                 // them as distinct, so "/x/" would otherwise fall through to a
                 // different (often more permissive) route — e.g. a stricter
                 // per-route WAF profile silently downgraded.
-                match trailing_slash_variant(&route.path) {
+                match trailing_slash_variant(path) {
                     Some(variant) => {
-                        router
-                            .insert(route.path.clone(), resolved.clone())
-                            .map_err(|e| format!("Bad route pattern '{}': {}", route.path, e))?;
-                        route_aliases.push((variant, resolved));
+                        self.router
+                            .insert(path.to_string(), resolved.clone())
+                            .map_err(|e| format!("Bad route pattern '{}': {}", path, e))?;
+                        self.aliases.push((variant, resolved));
                     }
                     None => {
-                        router
-                            .insert(route.path.clone(), resolved)
-                            .map_err(|e| format!("Bad route pattern '{}': {}", route.path, e))?;
+                        self.router
+                            .insert(path.to_string(), resolved)
+                            .map_err(|e| format!("Bad route pattern '{}': {}", path, e))?;
                     }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Apply the deferred aliases and return the finished tree. Alias inserts
+    /// are best-effort: a conflict means an explicit route already owns the
+    /// slot — exactly the precedence we want (matchit specificity then makes an
+    /// exact prefix win over a less-specific parent catch-all, e.g. "/api" →
+    /// "/api/{*rest}", not the root "/{*rest}").
+    fn finish(mut self) -> Router<Arc<ResolvedRoute>> {
+        for (alias, resolved) in self.aliases {
+            let _ = self.router.insert(alias, resolved);
+        }
+        self.router
+    }
+}
+
+/// Build the host-aware router from config routes, pre-resolving all references.
+/// A route with `hosts` is inserted into each of its host trees; a route without
+/// `hosts` goes into the shared/default tree (ADR-0010, hostless-as-shared).
+///
+/// Returns `Err` if any route references an unknown upstream, profile, or
+/// contains an invalid pattern. The caller (boot path or hot-reload) decides
+/// whether to abort or log-and-keep the previous snapshot.
+pub fn build_router(config: &ZionConfig) -> Result<HostRouter, String> {
+    let mut default = RouterBuilder::default();
+    let mut by_host: HashMap<Box<str>, RouterBuilder> = HashMap::new();
+
+    for route in &config.route {
+        let resolved = resolve_route(config, route)?;
+        match &route.hosts {
+            // Shared route: reachable from every authority.
+            None => default.insert(&route.path, resolved)?,
+            // Host-bound: insert into each host's tree. Validation guarantees
+            // every entry is a canonical host, so normalize_host returns Some.
+            Some(hosts) => {
+                let mut seen = std::collections::HashSet::new();
+                for h in hosts {
+                    let key = crate::security::normalize_host(h)
+                        .ok_or_else(|| format!("route '{}': invalid host '{}'", route.path, h))?
+                        .into_owned();
+                    // A host repeated in one route's list must insert once, not
+                    // twice into the same tree (which matchit rejects as a dup).
+                    if !seen.insert(key.clone()) {
+                        continue;
+                    }
+                    by_host
+                        .entry(key.into_boxed_str())
+                        .or_default()
+                        .insert(&route.path, resolved.clone())?;
                 }
             }
         }
     }
 
-    // Apply the aliases (catch-all bare prefixes + trailing-slash variants).
-    // Insert unconditionally and ignore the result: if an explicit route
-    // already occupies the alias, matchit returns a conflict (so the explicit
-    // route keeps priority); otherwise the alias resolves to its route, and
-    // matchit's specificity rules make an exact prefix win over a less-specific
-    // parent catch-all (e.g. "/api" → "/api/{*rest}", not the root "/{*rest}").
-    for (alias, resolved) in route_aliases {
-        let _ = router.insert(alias, resolved);
-    }
+    let active = !by_host.is_empty();
+    let by_host = by_host
+        .into_iter()
+        .map(|(host, builder)| (host, builder.finish()))
+        .collect();
 
     print_routes_table(&config.route);
-    Ok(router)
+    Ok(HostRouter {
+        default: default.finish(),
+        by_host,
+        active,
+    })
+}
+
+/// Resolve one `[[route]]` into its fully pre-computed [`ResolvedRoute`]
+/// (upstream URLs, WAF/cache profiles, CSP, auth, CORS) — everything the hot
+/// path needs, computed once at build. Pure: no router insertion, so
+/// `build_router` can place the result into one or more host-scoped trees.
+fn resolve_route(config: &ZionConfig, route: &RouteConfig) -> Result<Arc<ResolvedRoute>, String> {
+    let upstream_url = resolve_upstream(config, &route.upstream)?;
+
+    // Resolve WAF: named profile > legacy bool flag
+    let waf = if let Some(ref profile_name) = route.waf_profile {
+        Some(
+            config
+                .waf_profile
+                .get(profile_name)
+                .ok_or_else(|| {
+                    format!(
+                        "Unknown waf_profile '{}' in route {}",
+                        profile_name, route.path
+                    )
+                })?
+                .clone(),
+        )
+    } else if route.waf {
+        // Legacy: create inline profile from max_body_mb
+        Some(WafProfile {
+            max_body_mb: route.max_body_mb.unwrap_or(10),
+            ..WafProfile::default()
+        })
+    } else {
+        // Footgun guard: `max_body_mb` is enforced by the WAF body gate, so
+        // on a WAF-off route it has no effect. Surface it at boot rather
+        // than silently dropping the operator's intended size cap (a no-WAF
+        // route otherwise streams the body to the upstream, hyper-framed).
+        if route.max_body_mb.is_some() {
+            eprintln!(
+                "  ⚠ route '{}': max_body_mb is set but WAF is off (no waf=true / waf_profile) \
+                     — the body-size cap is NOT enforced; enable WAF or remove max_body_mb",
+                route.path
+            );
+        }
+        None
+    };
+
+    // Resolve cache: named profile > legacy mode=static_cache
+    let cache = if let Some(ref profile_name) = route.cache_profile {
+        Some(
+            config
+                .cache_profile
+                .get(profile_name)
+                .ok_or_else(|| {
+                    format!(
+                        "Unknown cache_profile '{}' in route {}",
+                        profile_name, route.path
+                    )
+                })?
+                .clone(),
+        )
+    } else if route.mode == RouteMode::StaticCache {
+        // Default in-RAM profile for a profile-less static_cache route:
+        // conservative 1h TTL (default_ttl), NOT immutable. Name an explicit
+        // [cache_profile] with a longer ttl_seconds for content-hashed assets.
+        Some(CacheProfile {
+            mode: CacheMode::Memory,
+            max_entries: default_max_entries(),
+            ttl_seconds: default_ttl(),
+        })
+    } else {
+        None
+    };
+
+    // Pre-parse the FIRST upstream URI at startup for legacy fallback.
+    // In a true clustered setup with latency routing, we use the first to get the scheme.
+    let upstream_uri: hyper::Uri = upstream_url[0]
+        .parse()
+        .map_err(|e| format!("Invalid upstream URL '{}': {}", upstream_url[0], e))?;
+    let upstream_scheme = upstream_uri
+        .scheme()
+        .cloned()
+        .unwrap_or_else(|| "http".parse().unwrap());
+    let upstream_authority = upstream_uri
+        .authority()
+        .cloned()
+        .ok_or_else(|| format!("Upstream '{}' has no authority", upstream_url[0]))?;
+
+    // Pre-parse CSP at startup for zero-cost injection at runtime
+    let csp = match route.csp.as_ref() {
+        Some(s) => Some(
+            hyper::header::HeaderValue::from_str(s)
+                .map_err(|e| format!("Invalid CSP in route '{}': {}", route.path, e))?,
+        ),
+        None => None,
+    };
+
+    // Resolve auth profile at startup (feature-gated)
+    #[cfg(feature = "auth")]
+    let auth = match route.auth_profile.as_ref() {
+        Some(name) => {
+            let profile_config = config.auth_profile.get(name).ok_or_else(|| {
+                format!("Auth profile '{}' not found (route '{}')", name, route.path)
+            })?;
+            let resolved = crate::auth::resolve_auth_profile(profile_config)
+                .map_err(|e| format!("Auth profile '{}' (route '{}'): {}", name, route.path, e))?;
+            eprintln!(
+                "  auth: route {} → profile '{}' (alg={})",
+                route.path, name, profile_config.algorithm
+            );
+            Some(resolved)
+        }
+        None => None,
+    };
+
+    let cors = route
+        .cors
+        .as_ref()
+        .map(|c| Arc::new(crate::security::CorsHeaders::from_config(c)));
+
+    Ok(Arc::new(ResolvedRoute {
+        upstream_url,
+        upstream_scheme,
+        upstream_authority,
+        mode: route.mode.clone(),
+        waf,
+        waf_shadow: route.waf_shadow,
+        cache,
+        internal_only: route.internal_only,
+        csp,
+        #[cfg(feature = "auth")]
+        auth,
+        cors,
+    }))
 }
 
 /// If `path` is a matchit catch-all (`<prefix>/{*name}`), return the bare
@@ -1741,10 +1852,10 @@ enabledd = true
     fn build_router_with_legacy_upstreams() {
         let config: ZionConfig = toml::from_str(minimal_toml()).unwrap();
         let router = build_router(&config).unwrap();
-        let matched = router.at("/api/v1/users").unwrap();
-        assert_eq!(matched.value.upstream_url[0], "http://127.0.0.1:8000");
-        assert!(matched.value.waf.is_some()); // legacy waf=true
-        assert_eq!(matched.value.waf.as_ref().unwrap().max_body_mb, 10); // default
+        let matched = router.at(None, "/api/v1/users").unwrap();
+        assert_eq!(matched.upstream_url[0], "http://127.0.0.1:8000");
+        assert!(matched.waf.is_some()); // legacy waf=true
+        assert_eq!(matched.waf.as_ref().unwrap().max_body_mb, 10); // default
     }
 
     #[test]
@@ -1753,23 +1864,22 @@ enabledd = true
         let router = build_router(&config).unwrap();
 
         // API route with strict WAF
-        let api = router.at("/api/v1/test").unwrap();
-        assert_eq!(api.value.upstream_url[0], "http://127.0.0.1:8000");
-        let waf = api.value.waf.as_ref().unwrap();
+        let api = router.at(None, "/api/v1/test").unwrap();
+        assert_eq!(api.upstream_url[0], "http://127.0.0.1:8000");
+        let waf = api.waf.as_ref().unwrap();
         assert_eq!(waf.max_body_mb, 5);
         assert_eq!(waf.max_depth, 8);
 
         // Upload route with upload WAF
-        let upload = router.at("/upload").unwrap();
-        let waf = upload.value.waf.as_ref().unwrap();
+        let upload = router.at(None, "/upload").unwrap();
+        let waf = upload.waf.as_ref().unwrap();
         assert_eq!(waf.max_body_mb, 200);
         // Trailing-slash variant resolves to the SAME route (rank 18: without
         // the alias, "/upload/" falls through and loses the upload WAF profile).
         assert_eq!(
             router
-                .at("/upload/")
+                .at(None, "/upload/")
                 .expect("/upload/ should alias /upload")
-                .value
                 .waf
                 .as_ref()
                 .unwrap()
@@ -1778,36 +1888,36 @@ enabledd = true
         );
 
         // Static cache route
-        let statics = router.at("/_next/static/chunk.js").unwrap();
-        assert_eq!(statics.value.upstream_url[0], "http://127.0.0.1:3000");
-        let cache = statics.value.cache.as_ref().unwrap();
+        let statics = router.at(None, "/_next/static/chunk.js").unwrap();
+        assert_eq!(statics.upstream_url[0], "http://127.0.0.1:3000");
+        let cache = statics.cache.as_ref().unwrap();
         assert_eq!(cache.ttl_seconds, 86400);
         assert_eq!(cache.max_entries, 5000);
 
         // Catch-all has no WAF or cache
-        let catchall = router.at("/about").unwrap();
-        assert!(catchall.value.waf.is_none());
-        assert!(catchall.value.cache.is_none());
+        let catchall = router.at(None, "/about").unwrap();
+        assert!(catchall.waf.is_none());
+        assert!(catchall.cache.is_none());
 
         // Bare-prefix fallback: a catch-all "<prefix>/{*rest}" must also serve
         // its bare prefix. matchit alone would 404 these (regression guard for
         // the root-route bug found in the e2e harness).
         // Root "/{*rest}" → "/" resolves to the catch-all (no WAF/cache).
-        let root = router.at("/").expect("root '/' should match the catch-all");
-        assert!(root.value.waf.is_none());
-        assert!(root.value.cache.is_none());
+        let root = router
+            .at(None, "/")
+            .expect("root '/' should match the catch-all");
+        assert!(root.waf.is_none());
+        assert!(root.cache.is_none());
         // "/api/{*rest}" → bare "/api" resolves to the API route (strict WAF).
         assert!(router
-            .at("/api")
+            .at(None, "/api")
             .expect("/api should match its catch-all")
-            .value
             .waf
             .is_some());
         // "/_next/static/{*rest}" → bare "/_next/static" resolves to the cache route.
         assert!(router
-            .at("/_next/static")
+            .at(None, "/_next/static")
             .expect("/_next/static should match its catch-all")
-            .value
             .cache
             .is_some());
     }
@@ -1831,8 +1941,8 @@ max_body_mb = 500
 "#;
         let config: ZionConfig = toml::from_str(toml_str).unwrap();
         let router = build_router(&config).unwrap();
-        let route = router.at("/upload").unwrap();
-        assert_eq!(route.value.waf.as_ref().unwrap().max_body_mb, 500);
+        let route = router.at(None, "/upload").unwrap();
+        assert_eq!(route.waf.as_ref().unwrap().max_body_mb, 500);
     }
 
     #[test]
@@ -1853,11 +1963,11 @@ mode = "static_cache"
 "#;
         let config: ZionConfig = toml::from_str(toml_str).unwrap();
         let router = build_router(&config).unwrap();
-        let route = router.at("/_next/static/chunk.js").unwrap();
-        assert!(route.value.cache.is_some());
+        let route = router.at(None, "/_next/static/chunk.js").unwrap();
+        assert!(route.cache.is_some());
         // Profile-less static_cache route → conservative 1h default (was 1 year;
         // the audiolibri staleness fix). Operators set ttl_seconds for longer.
-        assert_eq!(route.value.cache.as_ref().unwrap().ttl_seconds, 3600);
+        assert_eq!(route.cache.as_ref().unwrap().ttl_seconds, 3600);
     }
 
     #[test]
@@ -1878,8 +1988,8 @@ internal_only = true
 "#;
         let config: ZionConfig = toml::from_str(toml_str).unwrap();
         let router = build_router(&config).unwrap();
-        let route = router.at("/metrics").unwrap();
-        assert!(route.value.internal_only);
+        let route = router.at(None, "/metrics").unwrap();
+        assert!(route.internal_only);
     }
 
     #[test]
@@ -1900,8 +2010,8 @@ mode = "sse_stream"
 "#;
         let config: ZionConfig = toml::from_str(toml_str).unwrap();
         let router = build_router(&config).unwrap();
-        let route = router.at("/events").unwrap();
-        assert_eq!(route.value.mode, RouteMode::SseStream);
+        let route = router.at(None, "/events").unwrap();
+        assert_eq!(route.mode, RouteMode::SseStream);
     }
 
     #[test]
@@ -2032,8 +2142,131 @@ upstream = "api"
 "#;
         let config: ZionConfig = toml::from_str(toml_str).unwrap();
         let router = build_router(&config).unwrap();
-        let route = router.at("/test").unwrap();
+        let route = router.at(None, "/test").unwrap();
         // New [upstream.X] takes precedence over [upstreams] legacy
-        assert_eq!(route.value.upstream_url[0], "http://new:9000");
+        assert_eq!(route.upstream_url[0], "http://new:9000");
+    }
+
+    // ── Host-based L7 routing (ADR-0010) ──────────────────────────────────
+
+    #[test]
+    fn host_router_exact_and_shared_fallback() {
+        // Two host-bound routes on the SAME path + a shared catch-all — exactly
+        // what path-only routing could not express (ADR-0010).
+        let toml_str = r#"
+[server]
+listen_http = "0.0.0.0:80"
+listen_https = "0.0.0.0:443"
+[tls]
+cert_path = "/tmp/c.pem"
+key_path = "/tmp/k.pem"
+[upstream.api]
+url = "http://127.0.0.1:8000"
+[upstream.app]
+url = "http://127.0.0.1:3000"
+[upstream.fallback]
+url = "http://127.0.0.1:9000"
+[[route]]
+path = "/{*rest}"
+hosts = ["api.example.com"]
+upstream = "api"
+[[route]]
+path = "/{*rest}"
+hosts = ["app.example.com"]
+upstream = "app"
+[[route]]
+path = "/{*rest}"
+upstream = "fallback"
+"#;
+        let config: ZionConfig = toml::from_str(toml_str).unwrap();
+        let router = build_router(&config).unwrap();
+        assert!(router.active);
+
+        // Same path, different host → different backend (the whole point).
+        assert_eq!(
+            router
+                .at(Some("api.example.com"), "/x")
+                .unwrap()
+                .upstream_url[0],
+            "http://127.0.0.1:8000"
+        );
+        assert_eq!(
+            router
+                .at(Some("app.example.com"), "/x")
+                .unwrap()
+                .upstream_url[0],
+            "http://127.0.0.1:3000"
+        );
+        // Unknown host → shared/default layer.
+        assert_eq!(
+            router
+                .at(Some("other.example.com"), "/x")
+                .unwrap()
+                .upstream_url[0],
+            "http://127.0.0.1:9000"
+        );
+        // No host (e.g. HTTP/1.0) → shared layer.
+        assert_eq!(
+            router.at(None, "/x").unwrap().upstream_url[0],
+            "http://127.0.0.1:9000"
+        );
+    }
+
+    #[test]
+    fn host_router_falls_back_to_shared_on_path_miss() {
+        // A host with its own tree still falls through to the shared layer for a
+        // path it doesn't define (hostless-as-shared-layer, decision #1).
+        let toml_str = r#"
+[server]
+listen_http = "0.0.0.0:80"
+listen_https = "0.0.0.0:443"
+[tls]
+cert_path = "/tmp/c.pem"
+key_path = "/tmp/k.pem"
+[upstream.api]
+url = "http://127.0.0.1:8000"
+[upstream.shared]
+url = "http://127.0.0.1:9000"
+[[route]]
+path = "/api/{*rest}"
+hosts = ["api.example.com"]
+upstream = "api"
+[[route]]
+path = "/health"
+upstream = "shared"
+"#;
+        let config: ZionConfig = toml::from_str(toml_str).unwrap();
+        let router = build_router(&config).unwrap();
+
+        // api.example.com/api/* → its own route.
+        assert_eq!(
+            router
+                .at(Some("api.example.com"), "/api/v1")
+                .unwrap()
+                .upstream_url[0],
+            "http://127.0.0.1:8000"
+        );
+        // api.example.com/health → NOT in api's tree → shared /health.
+        assert_eq!(
+            router
+                .at(Some("api.example.com"), "/health")
+                .unwrap()
+                .upstream_url[0],
+            "http://127.0.0.1:9000"
+        );
+        // A path in NO tree → 404 (None).
+        assert!(router.at(Some("api.example.com"), "/nope").is_none());
+    }
+
+    #[test]
+    fn hostless_config_is_not_active() {
+        // No route declares `hosts` ⇒ host routing inactive ⇒ the shared tree
+        // behaves exactly as the pre-ADR-0010 single router.
+        let config: ZionConfig = toml::from_str(minimal_toml()).unwrap();
+        let router = build_router(&config).unwrap();
+        assert!(!router.active);
+        // A host is simply ignored — everything resolves via the shared tree.
+        assert!(router.at(Some("whatever.example.com"), "/api/x").is_some());
+        assert!(router.at(None, "/api/x").is_some());
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -898,6 +898,13 @@ impl Default for HostRouter {
 }
 
 impl HostRouter {
+    /// Whether any host-bound route exists. Callers gate authority extraction
+    /// and cache-key hashing on this, so a hostless deployment pays nothing.
+    #[inline]
+    pub fn host_routing_active(&self) -> bool {
+        self.active
+    }
+
     /// Resolve `(host, path)` to a route, per ADR-0010's hostless-as-shared-layer
     /// rule: consult the exact-host tree first, then fall back to the shared
     /// `default` tree. `host` is the normalized request authority

--- a/src/config.rs
+++ b/src/config.rs
@@ -1003,7 +1003,7 @@ impl RouterBuilder {
             Some(bare) => {
                 self.router
                     .insert(path.to_string(), resolved.clone())
-                    .map_err(|e| format!("Bad route pattern '{}': {}", path, e))?;
+                    .map_err(|e| format!("Bad route pattern '{path}': {e}"))?;
                 self.aliases.push((bare, resolved));
             }
             None => {
@@ -1016,13 +1016,13 @@ impl RouterBuilder {
                     Some(variant) => {
                         self.router
                             .insert(path.to_string(), resolved.clone())
-                            .map_err(|e| format!("Bad route pattern '{}': {}", path, e))?;
+                            .map_err(|e| format!("Bad route pattern '{path}': {e}"))?;
                         self.aliases.push((variant, resolved));
                     }
                     None => {
                         self.router
                             .insert(path.to_string(), resolved)
-                            .map_err(|e| format!("Bad route pattern '{}': {}", path, e))?;
+                            .map_err(|e| format!("Bad route pattern '{path}': {e}"))?;
                     }
                 }
             }

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -488,15 +488,15 @@ async fn process_request_inner(
             route
         } else {
             // Radix tree fallback (~30ns)
-            match cfg.router.at(path) {
-                Ok(m) => {
-                    let route = m.value.clone();
+            match cfg.router.at(None, path) {
+                Some(matched) => {
+                    let route = matched.clone();
                     ROUTE_CACHE.with(|cache| {
                         cache.borrow_mut().insert(path_hash, route.clone());
                     });
                     route
                 }
-                Err(_) => return Ok(empty_response(StatusCode::NOT_FOUND)),
+                None => return Ok(empty_response(StatusCode::NOT_FOUND)),
             }
         }
     };

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -192,6 +192,25 @@ fn early_data_rejected(is_early_data: bool, method: &hyper::Method) -> bool {
     is_early_data && !matches!(*method, hyper::Method::GET | hyper::Method::HEAD)
 }
 
+/// Thread-local route-cache key. Folds the normalized host into the key when a
+/// host is present (host routing active) so two authorities that share a path
+/// never collide — the ADR-0010 cache invariant. A collision would let one
+/// host's request reuse another host's cached `ResolvedRoute`, bypassing a
+/// per-route WAF/auth profile or an `internal_only` gate. With `host = None`
+/// the key is the bare path hash, byte-identical to the pre-host-routing key,
+/// so hostless deployments are unchanged. `str`'s `Hash` writes a terminator,
+/// so `(host, path)` can never alias a different host/path split.
+#[inline]
+fn route_cache_key(host: Option<&str>, path: &str) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut h = fnv::FnvHasher::default();
+    if let Some(host) = host {
+        host.hash(&mut h);
+    }
+    path.hash(&mut h);
+    h.finish()
+}
+
 async fn process_request_inner(
     mut req: Request<ZionBody>,
     state: Arc<AppState>,
@@ -473,26 +492,35 @@ async fn process_request_inner(
 
     let rule = {
         let path = req.uri().path();
-        // FNV hash of path for O(1) thread-local lookup
-        let path_hash = {
-            use std::hash::{Hash, Hasher};
-            let mut h = fnv::FnvHasher::default();
-            path.hash(&mut h);
-            h.finish()
+
+        // Host-based routing (ADR-0010): extract the normalized authority only
+        // when a route is host-bound — hostless deployments skip this entirely.
+        // The URI :authority (HTTP/2 / absolute-form) wins over the Host header
+        // (HTTP/1 origin-form).
+        let host_cow = if cfg.router.host_routing_active() {
+            crate::security::request_host(&req)
+        } else {
+            None
         };
+        let host = host_cow.as_deref();
+
+        // Cache key folds the host in when present, so two authorities sharing a
+        // path never collide (ADR-0010 cache invariant); with no host it is the
+        // bare path hash — byte-identical to the pre-host-routing key.
+        let cache_key = route_cache_key(host, path);
 
         // Thread-local cache hit (~5ns) — touch promotes to MRU
-        let cached = ROUTE_CACHE.with(|cache| cache.borrow_mut().get(path_hash));
+        let cached = ROUTE_CACHE.with(|cache| cache.borrow_mut().get(cache_key));
 
         if let Some(route) = cached {
             route
         } else {
             // Radix tree fallback (~30ns)
-            match cfg.router.at(None, path) {
+            match cfg.router.at(host, path) {
                 Some(matched) => {
                     let route = matched.clone();
                     ROUTE_CACHE.with(|cache| {
-                        cache.borrow_mut().insert(path_hash, route.clone());
+                        cache.borrow_mut().insert(cache_key, route.clone());
                     });
                     route
                 }
@@ -2015,6 +2043,37 @@ mod route_cache {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn route_cache_key_is_host_scoped() {
+        // The load-bearing ADR-0010 cache invariant: two authorities that share
+        // a path MUST get distinct keys, or a thread-local cache hit would
+        // cross-wire their routes (bypassing a per-host WAF/auth/internal gate).
+        let a = route_cache_key(Some("api.example.com"), "/x");
+        let b = route_cache_key(Some("app.example.com"), "/x");
+        assert_ne!(a, b, "same path, different host must not collide");
+
+        // A hostless key equals the bare path hash — byte-identical to the
+        // pre-host-routing behavior, so hostless deployments are unchanged.
+        let none = route_cache_key(None, "/x");
+        let bare = {
+            use std::hash::{Hash, Hasher};
+            let mut h = fnv::FnvHasher::default();
+            "/x".hash(&mut h);
+            h.finish()
+        };
+        assert_eq!(
+            none, bare,
+            "hostless key must match the legacy path-only key"
+        );
+        assert_ne!(
+            none, a,
+            "a host-scoped key must differ from the hostless key"
+        );
+
+        // The key is stable for the same (host, path).
+        assert_eq!(a, route_cache_key(Some("api.example.com"), "/x"));
+    }
 
     fn hdr(name: hyper::header::HeaderName, val: &str) -> hyper::HeaderMap {
         let mut h = hyper::HeaderMap::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -2037,9 +2037,19 @@ async fn handle_http(
                 )
                 .unwrap());
         }
-        // Fallback: proxy to upstream (for external ACME clients like certbot)
+        // Fallback: proxy to upstream (for external ACME clients like certbot).
+        // Honor host routing here too so a host-bound route is reachable on :80.
+        // Resolve inside a block so the borrow of `req` ends before it is moved.
         let cfg = state.cfg();
-        if let Some(rule) = cfg.router.at(None, path) {
+        let rule = {
+            let host = if cfg.router.host_routing_active() {
+                security::request_host(&req)
+            } else {
+                None
+            };
+            cfg.router.at(host.as_deref(), path).cloned()
+        };
+        if let Some(rule) = rule {
             return proxy::proxy_pass(
                 &state.http_client,
                 req,

--- a/src/main.rs
+++ b/src/main.rs
@@ -119,14 +119,12 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 use arc_swap::ArcSwap;
 use bytes::Bytes;
-use config::ResolvedRoute;
 use http_body_util::{BodyExt, Full};
 use hyper::body::Incoming;
 use hyper::service::service_fn;
 use hyper::{Request, Response, StatusCode};
 use hyper_util::rt::{TokioExecutor, TokioIo};
 use hyper_util::server::conn::auto::Builder as AutoBuilder;
-use matchit::Router;
 use proxy::{HttpClient, ZionBody};
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -189,8 +187,9 @@ use security::RateEntry;
 /// once at boot from `zion.toml`. The follow-up commit will wrap the
 /// `Arc` in `ArcSwap` and wire the watcher.
 pub(crate) struct ResolvedAppConfig {
-    /// Radix tree (matchit) of pre-resolved routes.
-    pub(crate) router: Router<Arc<ResolvedRoute>>,
+    /// Host-aware L7 router (ADR-0010): a shared radix tree plus one tree per
+    /// bound host. Hostless when no route declares `hosts` (zero extra cost).
+    pub(crate) router: config::HostRouter,
     /// Upstream URL → shared health/latency state. The `Arc<UpstreamHealth>`
     /// values are intentionally re-used across reloads when the URL is
     /// unchanged so the prober's accumulated state is preserved.
@@ -242,7 +241,7 @@ impl ResolvedAppConfig {
     #[cfg(test)]
     pub(crate) fn test_with_health(health_map: health::HealthMap) -> Self {
         Self {
-            router: matchit::Router::new(),
+            router: config::HostRouter::default(),
             health_map,
             trusted_proxies: security::TrustedProxies::from_config(&[]),
             xff_mode: proxy::XffMode::Append,
@@ -2040,8 +2039,7 @@ async fn handle_http(
         }
         // Fallback: proxy to upstream (for external ACME clients like certbot)
         let cfg = state.cfg();
-        if let Ok(m) = cfg.router.at(path) {
-            let rule = m.value;
+        if let Some(rule) = cfg.router.at(None, path) {
             return proxy::proxy_pass(
                 &state.http_client,
                 req,

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -617,17 +617,17 @@ mod tests {
 
         // Reader A sees the old routing table (route /api works,
         // /billing must not exist).
-        assert!(reader_a.router.at("/api/users").is_ok());
+        assert!(reader_a.router.at(None, "/api/users").is_some());
         assert!(
-            reader_a.router.at("/billing/invoice").is_err(),
+            reader_a.router.at(None, "/billing/invoice").is_none(),
             "in-flight reader must NOT see post-swap routes"
         );
 
         // A new reader (B) grabs the post-swap snapshot and sees both.
         let reader_b = store.load_full();
-        assert!(reader_b.router.at("/api/users").is_ok());
+        assert!(reader_b.router.at(None, "/api/users").is_some());
         assert!(
-            reader_b.router.at("/billing/invoice").is_ok(),
+            reader_b.router.at(None, "/billing/invoice").is_some(),
             "new reader must see the post-swap routing table"
         );
 
@@ -640,7 +640,7 @@ mod tests {
         // Reader A is still alive after B has loaded its snapshot —
         // ArcSwap's epoch GC does not yank a snapshot from under an
         // active reader.
-        assert!(reader_a.router.at("/api/users").is_ok());
+        assert!(reader_a.router.at(None, "/api/users").is_some());
     }
 
     #[test]
@@ -661,8 +661,8 @@ mod tests {
         store.store(Arc::new(snap_v1));
 
         let after = store.load_full();
-        assert!(after.router.at("/api/users").is_ok());
-        assert!(prev.router.at("/api/users").is_err()); // old snapshot still empty
+        assert!(after.router.at(None, "/api/users").is_some());
+        assert!(prev.router.at(None, "/api/users").is_none()); // old snapshot still empty
     }
 
     #[test]

--- a/src/security.rs
+++ b/src/security.rs
@@ -6,6 +6,7 @@
 
 use hyper::header::HeaderValue;
 use hyper::Response;
+use std::borrow::Cow;
 
 use crate::proxy::ZionBody;
 
@@ -309,6 +310,57 @@ pub fn is_valid_host(host: &str) -> bool {
             .as_bytes()
             .iter()
             .any(|&b| matches!(b, b'/' | b'\\' | b'@' | b'\n' | b'\r' | b'\0' | b' '))
+}
+
+/// Normalize a request authority — the URI `:authority` (HTTP/2, absolute-form)
+/// or `Host` header (HTTP/1, origin-form) — into a canonical host-routing key
+/// per ADR-0010: lowercased, `:port` stripped (IPv6-literal-safe), and any
+/// trailing FQDN dot removed. Returns `None` when the authority is empty or
+/// fails [`is_valid_host`]; the caller then routes via the hostless/shared
+/// layer rather than a bogus key.
+///
+/// Borrows when the input is already canonical (the common case — lowercase,
+/// no port) so the hot path allocates only when it must actually fold case.
+/// This is the single primitive both sides of the match go through: config
+/// `hosts` entries are validated to be fixed points of this function, and
+/// request authorities pass through it at lookup, so a config key and a request
+/// key are compared in the same normal form (no silent host mismatch).
+pub fn normalize_host(raw: &str) -> Option<Cow<'_, str>> {
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return None;
+    }
+
+    // Split off an optional `:port`, keeping an IPv6 literal's own colons intact.
+    let host = if raw.starts_with('[') {
+        // `[2001:db8::1]` or `[2001:db8::1]:443` → keep through the closing ']'.
+        let end = raw.find(']')?; // malformed literal (no ']') ⇒ no key ⇒ shared
+        &raw[..=end]
+    } else {
+        match raw.rsplit_once(':') {
+            // Exactly one colon and a numeric suffix ⇒ `host:port`. A bare
+            // (unbracketed) IPv6 literal has multiple colons and is left intact
+            // — it can't be a legal authority, so it just misses the map.
+            Some((h, p))
+                if !h.contains(':') && !p.is_empty() && p.bytes().all(|b| b.is_ascii_digit()) =>
+            {
+                h
+            }
+            _ => raw,
+        }
+    };
+
+    let host = host.trim_end_matches('.'); // drop the root FQDN dot(s)
+    if host.is_empty() || !is_valid_host(host) {
+        return None;
+    }
+
+    // Borrow when already lowercase; allocate only to fold case.
+    if host.bytes().any(|b| b.is_ascii_uppercase()) {
+        Some(Cow::Owned(host.to_ascii_lowercase()))
+    } else {
+        Some(Cow::Borrowed(host))
+    }
 }
 
 /// Check if an IP is internal (loopback, private RFC1918, link-local).
@@ -635,5 +687,72 @@ mod proptests {
             prop_assert!(allowed_a <= 2 * rps as usize);
             prop_assert!(allowed_b <= 2 * rps as usize);
         }
+    }
+}
+
+#[cfg(test)]
+mod normalize_host_tests {
+    //! The normative host-normalization contract from ADR-0010. These lock the
+    //! primitive that both config `hosts` validation and the dispatch hot path
+    //! route through, so a config key and a request authority are always
+    //! compared in the same form.
+    use super::normalize_host;
+
+    /// Each row: raw authority → expected canonical key (`None` = route via the
+    /// hostless/shared layer). Mirrors the ADR-0010 contract table.
+    #[test]
+    fn contract_table() {
+        let cases: &[(&str, Option<&str>)] = &[
+            ("api.example.com", Some("api.example.com")), // plain
+            ("api.example.com:8443", Some("api.example.com")), // port stripped
+            ("API.Example.COM", Some("api.example.com")), // case-folded
+            ("api.example.com.", Some("api.example.com")), // trailing FQDN dot
+            ("api.example.com.:443", Some("api.example.com")), // dot + port
+            ("  api.example.com  ", Some("api.example.com")), // trimmed
+            ("[2001:db8::1]", Some("[2001:db8::1]")),     // v6 literal kept
+            ("[2001:db8::1]:443", Some("[2001:db8::1]")), // v6 literal, port off
+            ("", None),                                   // empty ⇒ shared
+            (":8443", None),                              // port only ⇒ shared
+            ("host/with/slash", None),                    // path char ⇒ invalid
+            ("user@host", None),                          // userinfo ⇒ invalid
+        ];
+        for (raw, want) in cases {
+            assert_eq!(
+                normalize_host(raw).as_deref(),
+                *want,
+                "normalize_host({raw:?})"
+            );
+        }
+    }
+
+    #[test]
+    fn borrows_when_already_canonical() {
+        // No allocation when the input is already lowercase + portless.
+        assert!(matches!(
+            normalize_host("api.example.com"),
+            Some(std::borrow::Cow::Borrowed(_))
+        ));
+        // Allocates only to fold case.
+        assert!(matches!(
+            normalize_host("API.example.com"),
+            Some(std::borrow::Cow::Owned(_))
+        ));
+    }
+
+    #[test]
+    fn canonical_hosts_are_fixed_points() {
+        // The invariant config validation relies on: a canonical host normalizes
+        // to itself, so `hosts` entries accepted at load are exactly the keys the
+        // dispatcher will look up.
+        for h in ["api.example.com", "a.b.c.example.org", "[::1]"] {
+            assert_eq!(normalize_host(h).as_deref(), Some(h), "fixed point: {h}");
+        }
+    }
+
+    #[test]
+    fn unbracketed_v6_is_not_port_split() {
+        // A bare (illegal) IPv6 literal must not be mangled by the port splitter
+        // into a truncated key — it stays intact and simply misses the host map.
+        assert_eq!(normalize_host("::1").as_deref(), Some("::1"));
     }
 }

--- a/src/security.rs
+++ b/src/security.rs
@@ -363,6 +363,24 @@ pub fn normalize_host(raw: &str) -> Option<Cow<'_, str>> {
     }
 }
 
+/// Extract and normalize the request authority for host routing (ADR-0010):
+/// the URI `:authority` (HTTP/2 / absolute-form) when present, otherwise the
+/// `Host` header (HTTP/1 origin-form). Returns the canonical routing key via
+/// [`normalize_host`], or `None` when the authority is absent or invalid.
+/// Callers gate this behind `HostRouter::host_routing_active` so a hostless
+/// deployment never pays for the extraction.
+pub fn request_host<B>(req: &hyper::Request<B>) -> Option<Cow<'_, str>> {
+    req.uri()
+        .authority()
+        .map(|a| a.as_str())
+        .or_else(|| {
+            req.headers()
+                .get(hyper::header::HOST)
+                .and_then(|h| h.to_str().ok())
+        })
+        .and_then(normalize_host)
+}
+
 /// Check if an IP is internal (loopback, private RFC1918, link-local).
 #[inline]
 pub fn is_internal_ip(ip: &std::net::IpAddr) -> bool {


### PR DESCRIPTION
## Summary

Adds Host/authority-based L7 routing (virtual hosting) so a route can bind to specific hosts. Before this, routing was path-only (a single `matchit` tree keyed on `req.uri().path()`); host-awareness existed only at TLS (`[[tls.sni]]` cert selection). Two domains serving the same path to different backends was not expressible — `examples/multi-site.toml` only worked because its domains used disjoint path prefixes.

Design and rationale: [ADR-0010](docs/adr/0010-host-based-l7-routing.md).

## Behavior

- `hosts` on `[[route]]` binds a route to one or more hosts. A route without `hosts` is shared and matches every host.
- Resolution precedence: exact host, then most-specific `*.` wildcard, then the shared layer. On a path-miss within the selected host tree, resolution falls through to the shared layer.
- The authority is read from the URI `:authority` (HTTP/2) first, then the `Host` header (HTTP/1), and normalized before matching (lowercased, port stripped, trailing dot stripped).
- Opt-in: when no route declares `hosts`, `active` is false, the dispatcher skips authority extraction, and the route-lookup path (including the cache key) is unchanged from before.

## Commits (one per phase)

- `d156731` ADR-0010 + index
- `c40d86d` P1: `security::normalize_host` + `RouteConfig.hosts` + validation
- `2ee3629` P2: `HostRouter` (shared tree + per-host + wildcard trees); `build_router` groups by host
- `e397404` P3: dispatch/ACME authority extraction + host-scoped route cache
- `00012ef` P4: leading-label wildcard `*.example.com`
- `02d41a2` P5: routing docs + `multi-site.toml` rewritten to use `hosts`
- `726f075` version bump 0.4.7 to 0.5.0 + CHANGELOG

## Route-cache change (correctness)

The thread-local route cache was keyed on the path alone. Under host routing that lets `api.example.com/x` reuse `app.example.com/x`'s cached route, which can select the wrong backend and bypass a per-route WAF/auth profile or an `internal_only` gate. The cache key now includes the normalized host when host routing is active; with no host it is the bare path hash, unchanged. Covered by `route_cache_key_is_host_scoped`.

## Verification

- Unit tests: `normalize_host` cases, `hosts` validation, `HostRouter` exact/shared/wildcard/precedence, cache-key invariant.
- `cargo fmt --check`; `clippy -D warnings` on default, `--features auth`, and `auth acme http3 tui init otel geo-eu`; `rustdoc -D warnings`; `cargo test` 473 (default) / 476 (`--features auth`); `--release` build; `Cargo.lock` in sync (`--locked`).
- End-to-end (release binary, self-signed TLS, four backends): same path `/`, different Host to different backend over HTTP/1.1 (Host header) and HTTP/2 (`:authority`); exact host takes precedence over a matching wildcard; a multi-label subdomain matches the wildcard; the apex and unrelated hosts fall to the shared layer; `API.LOCAL:8443` normalizes to `api.local`; interleaved `api/app/api/app` on the same path returns `A/B/A/B`.

## Scope / follow-ups

- Wildcards are leading-label only (`*.example.com`); embedded or trailing `*` is rejected at load with an error message.
- Not included: tagging `v0.5.0` (fires `release.yml`) and updating the `v0.4.7` download/verify snippets in README/SECURITY/docs.
