### PR TITLE
fix(deps): bump anyhow 1.0.102 → 1.0.103 (RUSTSEC-2026-0190)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,9 +179,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "anymap2"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -67,7 +67,7 @@ version = "3.0.11"
 criteria = "safe-to-deploy"
 
 [[exemptions.anyhow]]
-version = "1.0.102"
+version = "1.0.103"
 criteria = "safe-to-deploy"
 
 [[exemptions.anymap2]]


### PR DESCRIPTION
## What

Bumps the transitive `anyhow` dependency 1.0.102 → 1.0.103 and moves its cargo-vet exemption to match.

## Why

`RUSTSEC-2026-0190` flags an unsoundness in `anyhow::Error::downcast_mut()` in 1.0.102, failing the `cargo-audit` gate on every CI run (it affects `master` — not introduced by any feature branch). 1.0.103 is the patch fix. `anyhow` reaches the tree transitively (via `tract-*` / `prost-derive`).

## Change

- `cargo update -p anyhow` → 1.0.103 (Cargo.lock only; version + checksum).
- `supply-chain/config.toml`: existing `anyhow` cargo-vet exemption moved 1.0.102 → 1.0.103. The 1.0.102 → 1.0.103 delta is published by dtolnay (anyhow's author); keeping the exemption preserves the repo's current trust posture for this crate. (Alternative, if preferred: `cargo vet trust anyhow` to trust the publisher outright — happy to switch.)

## Verification

- `cargo audit --deny warnings --deny unmaintained --deny unsound --deny yanked` — exit 0 (RUSTSEC-2026-0190 resolved).
- `cargo vet` (0.10.2, matching CI) — Vetting Succeeded.
- `cargo deny check advisories` — ok.
- `cargo check` + `cargo test` — green.

## Note

Unblocks the cargo-audit check on #273 (host-based L7 routing) once merged and that branch is synced to master.