### PR TITLE
fix(docker): arm64 container image ships an arm64 binary (was x86-64 in both manifests)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -527,6 +527,30 @@ jobs:
           build-args: |
             SOURCE_DATE_EPOCH=${{ env.SOURCE_DATE_EPOCH }}
 
+      # Guard against the "arm64 manifest carries an amd64 binary" class of
+      # bug (a Dockerfile that builds on $BUILDPLATFORM instead of
+      # $TARGETPLATFORM stamps one host-arch binary into every manifest). This
+      # is invisible to `imagetools inspect` — you have to look at the ELF.
+      - name: Verify each arch ships its own binary
+        env:
+          DIGEST: ${{ steps.push.outputs.digest }}
+        run: |
+          REF="${REGISTRY}/${IMAGE_NAME}@${DIGEST}"
+          fail=0
+          for entry in amd64:x86-64 arm64:aarch64; do
+            arch="${entry%%:*}"; want="${entry##*:}"
+            docker create --platform "linux/${arch}" --name "verify-${arch}" "$REF" >/dev/null
+            docker cp "verify-${arch}:/usr/local/bin/zion" "/tmp/zion-${arch}" >/dev/null
+            docker rm "verify-${arch}" >/dev/null
+            got="$(file -b "/tmp/zion-${arch}")"
+            echo "linux/${arch}: ${got}"
+            case "$got" in
+              *"$want"*) ;;
+              *) echo "::error::linux/${arch} image binary is not ${want}"; fail=1 ;;
+            esac
+          done
+          [ "$fail" -eq 0 ] || { echo "multi-arch image is mislabeled — refusing to sign"; exit 1; }
+
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ All notable changes to Zion Edge Gateway are documented here.
   README demo is an animated SVG recorded from a real run (`record-demo.sh`),
   so it cannot drift from what the code actually does.
 
+### Fixed
+- **arm64 container image now ships an arm64 binary.** The multi-arch image
+  (v0.4.7–v0.6.0) built its binary on `$BUILDPLATFORM` and stamped that single
+  host-arch (x86-64) binary into *both* the amd64 and arm64 manifests, so the
+  `linux/arm64` image could not exec on ARM hosts (Graviton, Apple Silicon).
+  The Dockerfile builder now runs on `$TARGETPLATFORM` so `cargo build`
+  produces a binary for the target arch, and `release.yml` gained a step that
+  extracts the binary from each published arch variant and fails the release
+  (before signing) unless the ELF matches — this class of bug is invisible to
+  a manifest inspection.
+
 ## [0.6.0] - 2026-07-06
 
 The migration release: `zion import nginx` converts an existing nginx config

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,10 +19,16 @@
 # Pinned to match rust-toolchain.toml. MSRV (Cargo.toml rust-version=1.82)
 # only applies to the no-default-features build; this image bakes a full
 # default-features binary so we need the same compiler we ship with.
-FROM --platform=$BUILDPLATFORM rust:1.96-bookworm@sha256:19817ead3289c8c631c73df281e18b59b172f6a31f4f563290f69cddd06c30e9 AS builder
+#
+# `--platform=$TARGETPLATFORM` (NOT $BUILDPLATFORM): the builder runs on the
+# *target* architecture, so `cargo build` below produces a binary for that
+# arch. Under `docker buildx --platform linux/amd64,linux/arm64` the arm64 leg
+# runs under QEMU emulation on an amd64 runner — slower, but correct. Building
+# on $BUILDPLATFORM instead would compile a host-arch (amd64) binary and stamp
+# it into BOTH manifests, leaving the arm64 image unable to exec on real ARM.
+FROM --platform=$TARGETPLATFORM rust:1.96-bookworm@sha256:19817ead3289c8c631c73df281e18b59b172f6a31f4f563290f69cddd06c30e9 AS builder
 
-# Build arg flowed through by `docker buildx build --platform=...`.
-# Lets us cross-compile on the native runner architecture.
+# Populated by buildx from the active `--platform` entry.
 ARG TARGETPLATFORM
 ARG TARGETARCH
 ARG TARGETVARIANT
@@ -33,10 +39,11 @@ ENV SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH}
 
 WORKDIR /build
 
-# Native build deps for aws-lc-rs / mimalloc (CMake + clang).
-# musl-tools/cross-toolchains are intentionally NOT installed here — the
-# CI release pipeline cross-compiles via cargo-zigbuild on the host runner;
-# this Dockerfile compiles natively on the target arch under buildx.
+# Native build deps for aws-lc-rs / mimalloc (CMake + clang). No cross
+# toolchains needed: the builder is the target arch (FROM $TARGETPLATFORM), so
+# `cargo build` compiles natively — under QEMU for the non-host arch. (The
+# standalone release-artifact binaries take a different, cross-compiled path
+# via cargo-zigbuild in release.yml; this Dockerfile is self-contained.)
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         cmake pkg-config build-essential clang ca-certificates && \


### PR DESCRIPTION
## The bug

The published multi-arch image built its binary on `$BUILDPLATFORM` (the amd64 CI runner) and then `docker buildx` stamped that **single x86-64 binary into both the amd64 and arm64 manifests**. So `ghcr.io/fabriziosalmi/zion`'s `linux/arm64` image cannot exec on ARM hosts (AWS Graviton, Apple Silicon, Raspberry Pi):

```
rosetta error: failed to open elf at /lib64/ld-linux-x86-64.so.2
```

Affected **v0.4.7 through v0.6.0**. Confirmed by extracting `/usr/local/bin/zion` from both arch variants of `:0.6.0` — identical x86-64 ELF, identical BuildID. `TARGETPLATFORM`/`TARGETARCH` were declared in the Dockerfile but never used to select a build target.

Surfaced while building the equivalence harness (#278) on Apple Silicon.

## The fix

- **Dockerfile**: the builder stage now runs on `--platform=$TARGETPLATFORM` (not `$BUILDPLATFORM`), so `cargo build` produces a binary for the target arch. Under `buildx --platform linux/amd64,linux/arm64` the arm64 leg compiles under QEMU emulation — slower, but correct, and it matches the Dockerfile's own documented intent ("compiles natively on the target arch under buildx").
- **release.yml**: a verification step extracts the binary from each published arch variant (`docker create --platform … && docker cp`) and `file`-checks the ELF, failing the release **before signing** if any arch is mislabeled. This class of bug is invisible to `docker buildx imagetools inspect` — you have to look at the binary.

## Validation

Built the arm64 image leg natively on Apple Silicon and confirmed:

```
$ file zion       # was: ELF … x86-64
ELF 64-bit LSB pie executable, ARM aarch64, … interpreter /lib/ld-linux-aarch64.so.1
$ zion --version
zion 0.6.0
```

## Note

The next tagged release carries the corrected images. The already-published `:0.4.7…:0.6.0` arm64 tags remain broken; re-tagging/rebuilding them is optional and separate. `amd64` images are and were fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)