### PR TITLE
ci: close the two rotting gaps — WAF recall ratchet + Dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,53 @@
+# Auto-merge green Dependabot PRs so the queue stops rotting.
+#
+# Why this exists: the supply-chain gate (cargo-vet exemptions per version)
+# makes every bump a manual chore, so PRs pile up — and a genuinely-bad bump
+# (e.g. one that trips cargo-audit/deny with a fresh advisory) hides in the
+# same pile as trivial patch bumps. This workflow enables GitHub's native
+# auto-merge for the SAFE, low-risk classes; it uses `--auto`, so a PR merges
+# ONLY once all required checks pass. A bump that fails cargo-vet / audit /
+# deny is never merged by this — it waits for a human, now visible in a queue
+# that otherwise stays empty.
+#
+# Scope (deliberately conservative):
+#   * cargo   — patch and minor only. Major bumps wait for a human.
+#   * actions — patch and minor (pinned by SHA elsewhere; low blast radius).
+#   * docker  — patch and minor (base-image digests).
+# A major version bump of anything is left for manual review.
+#
+# Requires: repo setting "Allow auto-merge" enabled, and branch protection
+# with required status checks (ci-success). Without those, the merge step is a
+# no-op that logs and exits 0 — it never blocks.
+name: dependabot-auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7 # v2.3.0
+
+      - name: Enable auto-merge for safe classes
+        # Patch/minor for any ecosystem = safe. Major = human review.
+        if: >-
+          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+          steps.meta.outputs.update-type == 'version-update:semver-minor'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          # --auto merges only after required checks go green; a vet/audit/deny
+          # failure keeps the PR open for a human. If the repo doesn't allow
+          # auto-merge, log and exit 0 rather than failing the run.
+          gh pr merge --auto --squash "$PR_URL" || {
+            echo "::notice::auto-merge not enabled or not permitted — leaving PR for manual merge"
+            exit 0
+          }

--- a/.github/workflows/waf-corpus.yml
+++ b/.github/workflows/waf-corpus.yml
@@ -3,11 +3,14 @@ name: waf-corpus
 # WAF detection / false-positive regression gate.
 #
 # Fires the frozen attack+benign corpora (benchmarks/waf-corpus/) at a live,
-# WAF-protected zion route and asserts the precision invariant: run.py exits
-# non-zero if ANY benign payload is blocked (a false positive is a hard fail).
-# Detection rate per class is printed for visibility (a recall *drop* shows in
-# the log even though it isn't a hard gate — recall is the thing we improve, FP
-# is the thing we must never regress).
+# WAF-protected zion route and asserts TWO invariants (run.py exits non-zero on
+# either):
+#   * precision — ANY benign payload blocked is a false positive, a hard fail.
+#   * recall ratchet — per-class detection may not drop below the committed
+#     baseline-*.json counts. Detection is deterministic for a fixed corpus, so
+#     a drop is a real regression; this closes the gap where the WAF's recall
+#     could rot to zero with CI staying green. Refresh a baseline after a
+#     genuine recall improvement with WAF_EMIT_BASELINE=<file>.
 #
 # Was a manual/local gate; this turns it into an automated nightly + a gate on
 # any change to the WAF or the corpus. Mirrors integration.yml's setup
@@ -94,12 +97,18 @@ jobs:
           echo "--- zion.log ---";    cat zion.log || true
           exit 1
 
-      - name: WAF corpus v1 (balanced) — hard-fails on any false positive
+      # Two regression gates now, not one: 0% false positives (precision) AND
+      # the recall ratchet — per-class detection may not drop below the
+      # committed baseline. A silent WAF recall regression is a red build.
+      - name: WAF corpus v1 (balanced) — 0% FP + recall ratchet
+        env:
+          WAF_BASELINE: benchmarks/waf-corpus/baseline-v1.json
         run: python3 benchmarks/waf-corpus/run.py https://127.0.0.1:4431 "balanced / v1"
 
-      - name: WAF corpus v2 (balanced, sourced) — hard-fails on any false positive
+      - name: WAF corpus v2 (balanced, sourced) — 0% FP + recall ratchet
         env:
           WAF_CORPUS: corpus-v2.json
+          WAF_BASELINE: benchmarks/waf-corpus/baseline-v2.json
         run: python3 benchmarks/waf-corpus/run.py https://127.0.0.1:4431 "balanced / v2"
 
       - name: Dump daemon logs on failure

--- a/benchmarks/waf-corpus/baseline-v1.json
+++ b/benchmarks/waf-corpus/baseline-v1.json
@@ -1,0 +1,69 @@
+{
+  "by_class": {
+    "cmdi": {
+      "detected": 8,
+      "total": 18
+    },
+    "crlf": {
+      "detected": 7,
+      "total": 8
+    },
+    "deser": {
+      "detected": 0,
+      "total": 6
+    },
+    "graphql": {
+      "detected": 1,
+      "total": 3
+    },
+    "header": {
+      "detected": 1,
+      "total": 3
+    },
+    "jndi": {
+      "detected": 6,
+      "total": 8
+    },
+    "ldap": {
+      "detected": 2,
+      "total": 5
+    },
+    "nosql": {
+      "detected": 0,
+      "total": 8
+    },
+    "path": {
+      "detected": 12,
+      "total": 14
+    },
+    "redirect": {
+      "detected": 3,
+      "total": 5
+    },
+    "sqli": {
+      "detected": 12,
+      "total": 22
+    },
+    "ssrf": {
+      "detected": 6,
+      "total": 12
+    },
+    "ssti": {
+      "detected": 4,
+      "total": 10
+    },
+    "xss": {
+      "detected": 16,
+      "total": 22
+    },
+    "xxe": {
+      "detected": 5,
+      "total": 6
+    }
+  },
+  "corpus": "corpus.json",
+  "overall": {
+    "detected": 83,
+    "total": 150
+  }
+}

--- a/benchmarks/waf-corpus/baseline-v2.json
+++ b/benchmarks/waf-corpus/baseline-v2.json
@@ -1,0 +1,57 @@
+{
+  "by_class": {
+    "cmdi": {
+      "detected": 14,
+      "total": 130
+    },
+    "crlf": {
+      "detected": 21,
+      "total": 55
+    },
+    "generic": {
+      "detected": 14,
+      "total": 130
+    },
+    "java": {
+      "detected": 2,
+      "total": 130
+    },
+    "ldap": {
+      "detected": 1,
+      "total": 32
+    },
+    "nosql": {
+      "detected": 0,
+      "total": 26
+    },
+    "path": {
+      "detected": 23,
+      "total": 130
+    },
+    "php": {
+      "detected": 7,
+      "total": 130
+    },
+    "sqli": {
+      "detected": 8,
+      "total": 130
+    },
+    "ssi": {
+      "detected": 1,
+      "total": 10
+    },
+    "ssrf": {
+      "detected": 2,
+      "total": 25
+    },
+    "xss": {
+      "detected": 85,
+      "total": 130
+    }
+  },
+  "corpus": "corpus-v2.json",
+  "overall": {
+    "detected": 178,
+    "total": 1058
+  }
+}

--- a/benchmarks/waf-corpus/run.py
+++ b/benchmarks/waf-corpus/run.py
@@ -6,9 +6,21 @@ Each payload is sent in BOTH vectors — query string (`?q=`) and JSON body
 block). Detection rate is on the malicious set; false-positive rate is on the
 benign set (legit traffic that must NOT be blocked).
 
+Two regression gates:
+  * false positives — ANY benign payload blocked is a hard fail (precision).
+  * detection ratchet — if a committed baseline exists ($WAF_BASELINE), the
+    per-class detected COUNT must not drop below its baseline (recall). This
+    closes the historical gap where recall could rot to zero with CI green.
+The ratchet is on integer counts, not percentages: detection is deterministic
+for a fixed corpus + engine, so a drop is a real regression, never noise. When
+recall genuinely improves, refresh the baseline with --emit-baseline.
+
 Usage:  python3 run.py [base_url] [label]
         base_url default https://127.0.0.1:4431 ; route /api/v1/data must have waf=true.
-Exit:   non-zero if any benign payload is blocked (a false positive is a hard fail).
+Env:    WAF_CORPUS    corpus file (default corpus.json; v2 = corpus-v2.json)
+        WAF_BASELINE  path to a per-class baseline json; enables the recall gate
+        WAF_EMIT_BASELINE  path to WRITE the current counts as a new baseline
+Exit:   1 if any benign payload is blocked, OR any class regresses below baseline.
 """
 import json, ssl, sys, urllib.parse, urllib.request, urllib.error, collections
 from pathlib import Path
@@ -19,6 +31,8 @@ URL = BASE + "/api/v1/data"
 # Corpus file: $WAF_CORPUS (default v1). v2 is the larger sourced set.
 import os
 CORPUS_FILE = os.environ.get("WAF_CORPUS", "corpus.json")
+BASELINE_FILE = os.environ.get("WAF_BASELINE")
+EMIT_BASELINE = os.environ.get("WAF_EMIT_BASELINE")
 CORPUS = json.loads((Path(__file__).parent / CORPUS_FILE).read_text())
 CTX = ssl.create_default_context(); CTX.check_hostname = False; CTX.verify_mode = ssl.CERT_NONE
 
@@ -70,4 +84,37 @@ if fp:
     print(f"\n── FALSE POSITIVES ({len(fp)} benign blocked — should be 0) ──")
     for p, sq, sb in fp:
         print(f"  q={sq} b={sb}  {p[:72]}")
-sys.exit(1 if fp else 0)
+
+# Emit mode: write the current per-class counts as a fresh baseline and exit
+# (still honoring the FP hard-fail). Use after a genuine recall improvement.
+current = {cat: {"detected": by_cat[cat][0], "total": by_cat[cat][1]} for cat in by_cat}
+if EMIT_BASELINE:
+    payload = {"corpus": CORPUS_FILE,
+               "overall": {"detected": det, "total": tot},
+               "by_class": current}
+    Path(EMIT_BASELINE).write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    print(f"\nwrote baseline → {EMIT_BASELINE} (overall {det}/{tot})")
+
+# Recall ratchet: no class may detect fewer than its baseline count.
+regressions = []
+if BASELINE_FILE:
+    base = json.loads(Path(BASELINE_FILE).read_text())
+    if base.get("corpus") not in (None, CORPUS_FILE):
+        print(f"\n::warning:: baseline is for corpus '{base.get('corpus')}', running '{CORPUS_FILE}'")
+    for cat, b in base.get("by_class", {}).items():
+        got = current.get(cat, {}).get("detected", 0)
+        if got < b["detected"]:
+            regressions.append((cat, got, b["detected"]))
+    base_overall = base.get("overall", {}).get("detected")
+    if base_overall is not None and det < base_overall:
+        regressions.append(("OVERALL", det, base_overall))
+    if regressions:
+        print(f"\n── RECALL REGRESSION ({len(regressions)} class(es) below baseline) ──")
+        for cat, got, want in regressions:
+            print(f"  {cat:9} detected {got} < baseline {want}")
+        print("  detection dropped — this is a silent-WAF-regression gate. If the")
+        print("  drop is intentional, refresh with WAF_EMIT_BASELINE=<file>.")
+    else:
+        print(f"\nrecall ratchet OK vs {Path(BASELINE_FILE).name}")
+
+sys.exit(1 if (fp or regressions) else 0)


### PR DESCRIPTION
Two reliability gates from the state-of-the-project audit, both aimed at "runs like a Swiss watch."

## (a) WAF recall ratchet — `waf-corpus.yml` + `run.py`

The WAF corpus gate only hard-failed on **false positives**. Per-class **detection was printed but never asserted**, so the 2,879-line WAF — the product's core value — could regress from ~55% (v1) / ~17% (v2) recall to near-zero and every CI check stayed green. A silent security regression in the component whose entire job is to not fail silently.

`run.py` now supports a committed per-class baseline (`WAF_BASELINE`) and ratchets on integer **detected-counts**: detection is deterministic for a fixed corpus + engine, so any class dropping below its baseline is a real regression, never noise. Precision (0% FP) stays a hard fail. Baselines were generated from a **real run against a live WAF-protected zion** (v1 83/150, v2 178/1058, 0% FP) and are committed; refresh after a genuine recall improvement with `WAF_EMIT_BASELINE`. Verified locally: passes on baseline, fails on a simulated regression.

## (c) Dependabot auto-merge — `dependabot-auto-merge.yml`

The per-version cargo-vet gate makes every bump a manual chore, so the queue piled 8 deep — and a genuinely-bad bump (#212, which introduces **RUSTSEC-2026-0009** DoS-via-stack-exhaustion) sat camouflaged in the same red pile as trivial patch bumps. This enables GitHub native auto-merge for **patch/minor bumps only** (cargo + actions + docker), using `--auto` so a PR merges **only when all required checks pass**. Anything that trips vet/audit/deny is never merged here — it waits for a human, now visible in a queue that otherwise stays empty. Requires the repo's "Allow auto-merge" setting; the step no-ops gracefully if absent.

## Not included here

- (b) Closing the zombie issues/PRs (#51/#100/#53/#194/#187/#212) is done directly on GitHub with justifications, not in this branch.
- The dead-feature kill list (io-uring-rw/bpf-demux flags, xdp, memfd) is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)