### PR TITLE
feat(boot): structured exit codes + feature-off config warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Client -> TLS 1.3 -> Security Gates -> Radix Router -> WAF Pipeline (5 gates) ->
 ```
 
 <!-- zion-stats:modules-lines (kept in sync by scripts/update-readme-stats.sh) -->
-47 modules, ~35,800 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
+47 modules, ~35,900 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
 
 ## Features
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -74,7 +74,8 @@ impl ZionError {
     ///   * `4` — bind/listener problem (port already used or no permission)
     ///   * `5` — runtime subsystem (ACME, auth, audit) failed
     ///   * `1` — anything else
-    #[allow(dead_code)] // wired by main when adopting structured exit codes
+    ///
+    /// Wired at the `main()` boundary so supervisors can branch on the code.
     pub fn to_exit_code(&self) -> i32 {
         match self {
             ZionError::Config(_) => 2,
@@ -86,9 +87,9 @@ impl ZionError {
     }
 
     /// Stable, lowercase identifier for structured logs / metrics labels.
-    /// Mirrors the variant name minus the payload. Currently consumed by
-    /// the test suite and reserved for the audit-log integration point.
-    #[allow(dead_code)]
+    /// Mirrors the variant name minus the payload. Emitted as the `kind=`
+    /// field in the `main()` fatal line and reserved for the audit-log
+    /// integration point.
     pub fn kind(&self) -> &'static str {
         match self {
             ZionError::Config(_) => "config",

--- a/src/main.rs
+++ b/src/main.rs
@@ -634,7 +634,20 @@ pub(crate) fn unauthorized(text: &'static str, challenge: &'static str) -> Respo
         .unwrap()
 }
 
-fn main() -> error::ZionResult<()> {
+fn main() {
+    // Map a structured boot failure to its conventional exit code so process
+    // supervisors (systemd Restart=, k8s restartPolicy) can branch: a config
+    // error (2) must NOT trigger a restart loop, a bind error (4) should. The
+    // default `fn main() -> Result` termination collapses every error to exit
+    // 1 — hence this explicit boundary. The `kind=` prefix gives log scrapers
+    // a stable field without parsing the message.
+    if let Err(e) = run() {
+        eprintln!("zion: fatal [{}] {}", e.kind(), e);
+        std::process::exit(e.to_exit_code());
+    }
+}
+
+fn run() -> error::ZionResult<()> {
     // ── Subcommand dispatch ──
     // Default (no args) → run the daemon, preserving every existing
     // systemd / Docker invocation path. Subcommands like `top`, `--version`,
@@ -791,6 +804,45 @@ fn main() -> error::ZionResult<()> {
     runtime.block_on(async_main(platform))
 }
 
+/// Warn loudly when the config uses a section whose behaviour is compiled out.
+/// The silent footgun this closes: an operator sets `auth_profile` on a route
+/// (or `[tls.acme]`) but built the binary without the matching feature, so the
+/// section parses and validates yet does *nothing* — routes believed to be
+/// authenticated serve unauthenticated, certs believed to auto-renew don't.
+/// Sections gated on the struct field itself (`[sovereign_aimp]`, sovereign
+/// geo) already hard-fail at parse via `deny_unknown_fields`, so they need no
+/// warning here — only the parse-clean-but-inert ones do.
+fn warn_feature_config_gaps(config: &config::ZionConfig) {
+    #[cfg(not(feature = "auth"))]
+    {
+        let uses_auth = !config.auth_profile.is_empty()
+            || config.route.iter().any(|r| r.auth_profile.is_some());
+        if uses_auth {
+            logging::warn(
+                "config",
+                "auth_profile is configured but this binary was built WITHOUT \
+                 `--features auth` — authentication is NOT enforced and those \
+                 routes serve UNAUTHENTICATED. Rebuild with `--features auth`.",
+            );
+        }
+    }
+    #[cfg(not(feature = "acme"))]
+    {
+        if config.tls.acme.is_some() {
+            logging::warn(
+                "config",
+                "[tls.acme] is configured but this binary was built WITHOUT \
+                 `--features acme` — certificates will NOT be obtained or \
+                 auto-renewed. Rebuild with `--features acme`, or manage certs \
+                 externally.",
+            );
+        }
+    }
+    // In a build where every referenced feature is present, both blocks above
+    // compile out and `config` is otherwise unused here.
+    let _ = config;
+}
+
 async fn async_main(platform: &'static bootstrap::Platform) -> error::ZionResult<()> {
     eprintln!("ZION EDGE GATEWAY — initializing...");
     bootstrap::print_report(platform);
@@ -808,6 +860,7 @@ async fn async_main(platform: &'static bootstrap::Platform) -> error::ZionResult
         &config.server.log_format,
     ));
     logging::info("config", &format!("loaded from {config_path}"));
+    warn_feature_config_gaps(&config);
 
     // 2. (config-derived state is now built later via ResolvedAppConfig::build —
     //  the standalone `let router = …` step was removed in favour of a single

--- a/tests/exit_codes.rs
+++ b/tests/exit_codes.rs
@@ -56,6 +56,12 @@ fn bad_tls_material_exits_3() {
     fs::write(&cert, b"not a real certificate\n").unwrap();
     fs::write(&key, b"not a real key\n").unwrap();
     let cfg = dir.join("zion.toml");
+    // Forward-slash the paths: a Windows path (`C:\Users\...`) embedded in a
+    // TOML basic string would be an invalid escape and fail config PARSING
+    // (exit 2) before ever reaching TLS load (exit 3). Windows file APIs
+    // accept forward slashes, so this keeps the test cross-platform.
+    let cert_toml = cert.display().to_string().replace('\\', "/");
+    let key_toml = key.display().to_string().replace('\\', "/");
     fs::write(
         &cfg,
         format!(
@@ -65,8 +71,8 @@ listen_http = "127.0.0.1:18091"
 listen_https = "127.0.0.1:18491"
 
 [tls]
-cert_path = "{cert}"
-key_path = "{key}"
+cert_path = "{cert_toml}"
+key_path = "{key_toml}"
 hot_reload = false
 
 [upstreams]
@@ -75,9 +81,7 @@ backend = "http://127.0.0.1:9099"
 [[route]]
 path = "/{{*rest}}"
 upstream = "backend"
-"#,
-            cert = cert.display(),
-            key = key.display(),
+"#
         ),
     )
     .unwrap();

--- a/tests/exit_codes.rs
+++ b/tests/exit_codes.rs
@@ -1,0 +1,137 @@
+//! Operator contract: the daemon's exit code encodes the failure category so
+//! a process supervisor (systemd `Restart=`, k8s `restartPolicy`) can branch —
+//! a config error (2) must NOT trigger a restart loop, a bind error (4) should.
+//!
+//! Before `main()` was wired through `ZionError::to_exit_code`, every boot
+//! failure collapsed to exit 1. These tests run the real binary and assert the
+//! distinct codes, so that regression can't silently return.
+//!
+//! They exercise only the pre-bind boot stages (config load = step 1, TLS load
+//! = step 3), so no ports are bound and the runs are fast and deterministic.
+//! `ZION_BOOT_FAST=1` skips the AES self-calibration.
+
+use std::fs;
+use std::process::Command;
+
+fn zion() -> Command {
+    let mut c = Command::new(env!("CARGO_BIN_EXE_zion"));
+    c.env("ZION_BOOT_FAST", "1")
+        // Keep the panic-hook's last-gasp file off the runner's real path.
+        .env(
+            "ZION_LAST_GASP_PATH",
+            std::env::temp_dir().join("zion-test-lastgasp.jsonl"),
+        );
+    c
+}
+
+fn unique_dir(tag: &str) -> std::path::PathBuf {
+    let d = std::env::temp_dir().join(format!("zion-exit-{}-{}", tag, std::process::id()));
+    fs::create_dir_all(&d).expect("mkdir");
+    d
+}
+
+/// A missing / unreadable config is a Config error → exit 2 (was 1).
+#[test]
+fn missing_config_exits_2() {
+    let status = zion()
+        .env("ZION_CONFIG", "/nonexistent/zion-does-not-exist.toml")
+        .status()
+        .expect("spawn zion");
+    assert_eq!(
+        status.code(),
+        Some(2),
+        "unreadable config must exit 2 (config category), got {:?}",
+        status.code()
+    );
+}
+
+/// A schema-valid config whose cert files exist but are not valid PEM passes
+/// validation (which only checks existence) then fails TLS material loading →
+/// exit 3 (was 1). This proves the categories are DISTINCT, not just non-zero.
+#[test]
+fn bad_tls_material_exits_3() {
+    let dir = unique_dir("tls");
+    let cert = dir.join("cert.pem");
+    let key = dir.join("key.pem");
+    fs::write(&cert, b"not a real certificate\n").unwrap();
+    fs::write(&key, b"not a real key\n").unwrap();
+    let cfg = dir.join("zion.toml");
+    fs::write(
+        &cfg,
+        format!(
+            r#"
+[server]
+listen_http = "127.0.0.1:18091"
+listen_https = "127.0.0.1:18491"
+
+[tls]
+cert_path = "{cert}"
+key_path = "{key}"
+hot_reload = false
+
+[upstreams]
+backend = "http://127.0.0.1:9099"
+
+[[route]]
+path = "/{{*rest}}"
+upstream = "backend"
+"#,
+            cert = cert.display(),
+            key = key.display(),
+        ),
+    )
+    .unwrap();
+
+    let status = zion()
+        .env("ZION_CONFIG", &cfg)
+        .status()
+        .expect("spawn zion");
+    let _ = fs::remove_dir_all(&dir);
+    assert_eq!(
+        status.code(),
+        Some(3),
+        "invalid TLS material must exit 3 (tls category), got {:?}",
+        status.code()
+    );
+}
+
+/// A schema-valid config that references an unknown upstream fails semantic
+/// validation → Config → exit 2 (still the config category, distinct from a
+/// TLS or bind failure).
+#[test]
+fn dangling_upstream_exits_2() {
+    let dir = unique_dir("cfg");
+    let cfg = dir.join("zion.toml");
+    fs::write(
+        &cfg,
+        r#"
+[server]
+listen_http = "127.0.0.1:18092"
+listen_https = "127.0.0.1:18492"
+
+[tls]
+cert_path = "/etc/ssl/zion/zion.crt"
+key_path = "/etc/ssl/zion/zion.key"
+
+[upstreams]
+backend = "http://127.0.0.1:9099"
+
+[[route]]
+path = "/{*rest}"
+upstream = "ghost"
+"#,
+    )
+    .unwrap();
+
+    let status = zion()
+        .env("ZION_CONFIG", &cfg)
+        .status()
+        .expect("spawn zion");
+    let _ = fs::remove_dir_all(&dir);
+    assert_eq!(
+        status.code(),
+        Some(2),
+        "dangling upstream reference must exit 2 (config category), got {:?}",
+        status.code()
+    );
+}


### PR DESCRIPTION
Production-hardening items #2 and #7 from the state-of-the-project roadmap — Zion behaving correctly as a fleet front door under a process supervisor.

## Structured exit codes (#2)

`main()` returned `ZionResult<()>`, so Rust's default termination collapsed **every** boot failure to exit 1 — `ZionError::to_exit_code()` existed but was dead (`#[allow(dead_code)]`). A systemd/k8s supervisor couldn't tell a config error (don't restart-loop) from a bind error (do restart).

`main()` now maps the error to its category and exits accordingly:

| code | category | operator meaning |
|---|---|---|
| 2 | config | fix `zion.toml` — a restart won't help |
| 3 | tls | rotate/repair cert material |
| 4 | listener | port in use / no `CAP_NET_BIND_SERVICE` — restart may help |
| 5 | acme/auth/audit | runtime subsystem failed |
| 1 | other | — |

The fatal line carries a stable `kind=` field (`zion: fatal [config] …`) for log scrapers. `tests/exit_codes.rs` runs the **real binary** and asserts the distinct codes (config→2, tls→3, dangling-upstream→2), so the collapse-to-1 regression can't silently return. Both dead_code allows removed — now wired.

## Feature-off config warnings (#7)

`warn_feature_config_gaps()` closes the silent footgun where a config section parses and validates but does nothing because the binary was built without its feature. The severe case is **auth**: `auth_profile` parses and its reference is validated even without `--features auth`, but enforcement is `#[cfg(feature = "auth")]` — so a route the operator believes is authenticated serves **unauthenticated**. That's now a loud boot warning. Same for `[tls.acme]` without `--features acme` (certs won't auto-renew). Sections gated on the struct field itself (`[sovereign_aimp]`, sovereign geo) already hard-fail via `deny_unknown_fields`, so they need no warning.

## Verification

Full suite green (incl. the 3 new exit-code integration tests); clippy `-D warnings` on pinned 1.88 (default + all-features); MSRV 1.82 `--no-default-features`. No new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)