### PR TITLE
test(reload): reload-under-load harness — 0 dropped connections across live config swaps (item #3)

### DIFF
--- a/.github/workflows/reload-under-load.yml
+++ b/.github/workflows/reload-under-load.yml
@@ -1,0 +1,57 @@
+# Reload-under-load: prove a config hot-swap under concurrent traffic drops no
+# in-flight connections. The ArcSwap swap must be invisible to live requests.
+name: reload-under-load
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "src/reload.rs"
+      - "src/dispatch.rs"
+      - "src/config.rs"
+      - "src/admin.rs"
+      - "src/main.rs"
+      - "tests/reload-under-load/**"
+      - ".github/workflows/reload-under-load.yml"
+  pull_request:
+    paths:
+      - "src/reload.rs"
+      - "src/dispatch.rs"
+      - "src/config.rs"
+      - "src/admin.rs"
+      - "src/main.rs"
+      - "tests/reload-under-load/**"
+      - ".github/workflows/reload-under-load.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: reload-under-load-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  reload-under-load:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          shared-key: integration # share the integration job's compiled deps
+
+      - name: Build zion (release)
+        run: cargo build --release --locked --bin zion
+
+      - name: Build bench backend (release)
+        run: cargo build --release --locked --manifest-path benchmarks/backend/Cargo.toml
+
+      - name: Reload under load (0 dropped connections across live swaps)
+        env:
+          NO_COLOR: "1"
+          DURATION: "15"
+          WORKERS: "24"
+          RELOADS: "30"
+        run: ./tests/reload-under-load/run.sh

--- a/.github/workflows/reload-under-load.yml
+++ b/.github/workflows/reload-under-load.yml
@@ -46,7 +46,9 @@ jobs:
         run: cargo build --release --locked --bin zion
 
       - name: Build bench backend (release)
-        run: cargo build --release --locked --manifest-path benchmarks/backend/Cargo.toml
+        # No --locked: the bench backend's Cargo.lock is not maintained in
+        # lockstep (matches integration.yml).
+        run: cargo build --release --manifest-path benchmarks/backend/Cargo.toml
 
       - name: Reload under load (0 dropped connections across live swaps)
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Zion Edge Gateway are documented here.
 ## [Unreleased]
 
 ### Added
+- **Reload-under-load harness** (`tests/reload-under-load/`): proves a config
+  hot-swap under concurrent traffic drops no in-flight connections. Sustained
+  N-worker load hits a live Zion while `POST /admin/reload` fires many real
+  atomic swaps mid-flight; the run fails on a single dropped/errored request or
+  if the config generation didn't advance during the load. Wired into CI
+  (`reload-under-load.yml`) on any change to the reload/dispatch/config path.
 - **Automatic HTTPS via Let's Encrypt is on by default in the release binary
   and official container.** A new `dist` feature bundle (`acme` + `init`) is
   what the container and release artifacts build with, so the shipped binary

--- a/tests/reload-under-load/README.md
+++ b/tests/reload-under-load/README.md
@@ -1,0 +1,46 @@
+# Reload-under-load harness
+
+On a fleet you reload `zion.toml` often — a new route, a changed upstream, a
+tweaked rate limit. The swap must be **invisible to live traffic**: not one
+in-flight request may be dropped, reset, or mis-routed while the config
+changes underneath it. Zion swaps config with an atomic `ArcSwap` store
+precisely so this holds; this harness proves it under real load.
+
+## What it does
+
+`run.sh` starts a real Zion (+ the bench backend), then:
+
+1. fires **sustained concurrent traffic** — N workers hammering a WAF-gated
+   route for a fixed duration,
+2. triggers **many real config swaps** *while the traffic is flowing* via
+   `POST /admin/reload` (the same `reload_now` atomic swap the file watcher
+   uses — every call stores a freshly-built snapshot, so each is a genuine
+   swap, and it skips the file watcher's 2 s debounce so the test is
+   deterministic),
+3. asserts:
+   - **zero failed requests** across the whole run (no transport error, no
+     non-2xx, no timeout), and
+   - the config **generation actually advanced during the load** — i.e. the
+     swaps really happened concurrently with traffic, not before or after it.
+
+A single dropped connection during any swap makes the run fail.
+
+## Run it
+
+Requirements: `curl`, `openssl`, `bash`, and a release build of Zion + the
+bench backend (the harness builds them if absent). No Docker.
+
+```console
+$ ./tests/reload-under-load/run.sh
+  ...
+  requests: 5334 ok, 0 failed
+  config swaps during load: 20 (generation 0 → 20); admin reloads acked: 20/20
+  PASS — 5334 requests, 0 dropped across 20 live config swaps.
+```
+
+Tunable via env: `DURATION` (seconds, default 15), `WORKERS` (default 24),
+`RELOADS` (default 30). Prebuilt binaries: `ZION_BIN`, `BACKEND_BIN`.
+
+CI (`.github/workflows/reload-under-load.yml`) runs it on every change to the
+reload/dispatch/config path, so a regression that makes a swap drop
+connections is caught before merge.

--- a/tests/reload-under-load/run.sh
+++ b/tests/reload-under-load/run.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# Reload-under-load harness — proves a config hot-swap under concurrent traffic
+# drops NO in-flight connections. (Production-hardening item #3.)
+#
+# On a fleet you reload config often; the ArcSwap swap must be invisible to
+# live traffic. This fires sustained concurrent requests at a real Zion while
+# repeatedly triggering real config swaps, and asserts:
+#   1. ZERO failed requests across the whole run (no reset / non-2xx / timeout).
+#   2. The config generation actually advanced during the load — i.e. many real
+#      atomic swaps happened WHILE traffic was flowing (not before/after it).
+#
+# The reload trigger is `POST /admin/reload`, which re-reads zion.toml and runs
+# the SAME `reload_now` atomic swap the file watcher uses (skipping the file
+# watcher's 2s debounce, so the test is deterministic). `reload_now` stores a
+# freshly-built snapshot unconditionally, so every call is a genuine swap.
+#
+# Requirements: a release zion + the bench backend (built here or via ZION_BIN),
+# curl, openssl, bash. No Docker.
+#
+#   ./tests/reload-under-load/run.sh
+#
+# Env: DURATION (s, default 15) · WORKERS (default 24) · RELOADS (default 30)
+#      ZION_BIN / BACKEND_BIN — prebuilt binaries (CI builds them once).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+DURATION="${DURATION:-15}"
+WORKERS="${WORKERS:-24}"
+RELOADS="${RELOADS:-30}"
+HTTPS_PORT=4433
+ADMIN_PORT=9180
+BACKEND_PORT=9090
+
+if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
+    G=$'\033[32m'; R=$'\033[31m'; B=$'\033[1m'; N=$'\033[0m'
+else G=""; R=""; B=""; N=""; fi
+step() { printf '\n%s── %s%s\n' "$B" "$*" "$N"; }
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/zion-reload.XXXXXX")"
+cleanup() {
+    [ -f "$WORK/zion.pid" ] && kill "$(cat "$WORK/zion.pid")" 2>/dev/null || true
+    [ -f "$WORK/be.pid" ] && kill "$(cat "$WORK/be.pid")" 2>/dev/null || true
+    rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+# ── Binaries ──
+ZION_BIN="${ZION_BIN:-$ROOT/target/release/zion}"
+BACKEND_BIN="${BACKEND_BIN:-$ROOT/benchmarks/backend/target/release/zion-bench-backend}"
+if [ ! -x "$ZION_BIN" ]; then
+    step "building zion (release)"; (cd "$ROOT" && cargo build --release --bin zion)
+fi
+if [ ! -x "$BACKEND_BIN" ]; then
+    step "building bench backend (release)"
+    (cd "$ROOT" && cargo build --release --manifest-path benchmarks/backend/Cargo.toml)
+fi
+
+# ── Cert ──
+step "self-signed cert"
+( cd "$ROOT/benchmarks/certs" && bash generate.sh >/dev/null 2>&1 || true )
+CERT="$ROOT/benchmarks/certs/tls.crt"; KEY="$ROOT/benchmarks/certs/tls.key"
+[ -f "$CERT" ] && [ -f "$KEY" ] || { echo "cert generation failed"; exit 1; }
+
+# ── Config: a WAF /api route + catch-all + the admin API for the reload trigger.
+cat > "$WORK/zion.toml" <<EOF
+[server]
+listen_http  = "0.0.0.0:8080"
+listen_https = "0.0.0.0:$HTTPS_PORT"
+
+[tls]
+cert_path  = "$CERT"
+key_path   = "$KEY"
+hot_reload = false
+
+[upstreams]
+backend = "http://127.0.0.1:$BACKEND_PORT"
+
+[admin]
+listen         = "127.0.0.1:$ADMIN_PORT"
+auth           = "internal-ip"
+rate_limit_rps = 500
+
+[[route]]
+path     = "/api/{*rest}"
+upstream = "backend"
+waf      = true
+
+[[route]]
+path     = "/{*rest}"
+upstream = "backend"
+EOF
+
+step "starting bench backend (:$BACKEND_PORT) + zion (:$HTTPS_PORT, admin :$ADMIN_PORT)"
+"$BACKEND_BIN" > "$WORK/backend.log" 2>&1 & echo $! > "$WORK/be.pid"; disown
+ZION_CONFIG="$WORK/zion.toml" "$ZION_BIN" > "$WORK/zion.log" 2>&1 & echo $! > "$WORK/zion.pid"; disown
+
+# ── Readiness ──
+url="https://127.0.0.1:$HTTPS_PORT/api/v1/data"
+for i in $(seq 1 30); do
+    code="$(curl -sk -o /dev/null -w '%{http_code}' -m 2 "$url" 2>/dev/null || echo 000)"
+    [ "$code" = 200 ] && { echo "ready after ${i}s"; break; }
+    [ "$i" = 30 ] && { echo "::error::zion not ready"; tail -20 "$WORK/zion.log" >&2; exit 1; }
+    sleep 1
+done
+
+gen() { # read zion_config_generation from /metrics
+    curl -sk -m 3 "https://127.0.0.1:$HTTPS_PORT/metrics" 2>/dev/null \
+        | awk '/^zion_config_generation /{print $2; exit}'
+}
+gen0="$(gen)"; gen0="${gen0:-0}"
+
+# ── Load workers: each hammers the WAF route for DURATION, counting ok/fail.
+# fail = curl transport error, HTTP 000, or any non-2xx (a swap must never
+# surface a 5xx/reset/404 to an in-flight request).
+worker() {
+    local id="$1" ok=0 fail=0 code deadline
+    deadline=$(( $(date +%s) + DURATION ))
+    while [ "$(date +%s)" -lt "$deadline" ]; do
+        code="$(curl -sk -o /dev/null -w '%{http_code}' -m 5 "$url" 2>/dev/null || echo 000)"
+        if [ "${code:0:1}" = 2 ]; then ok=$((ok+1)); else fail=$((fail+1)); echo "$code" >> "$WORK/failcodes"; fi
+    done
+    echo "$ok $fail" > "$WORK/w$id"
+}
+
+step "load: $WORKERS workers × ${DURATION}s, with $RELOADS live config swaps"
+worker_pids=()
+for i in $(seq 1 "$WORKERS"); do worker "$i" & worker_pids+=("$!"); done
+
+# ── Reload loop: real atomic swaps spaced across the load window.
+sleep 1  # let traffic ramp
+reload_ok=0
+interval=$(awk "BEGIN{print ($DURATION-2)/$RELOADS}")
+for _ in $(seq 1 "$RELOADS"); do
+    rc="$(curl -s -o /dev/null -w '%{http_code}' -m 3 -X POST "http://127.0.0.1:$ADMIN_PORT/admin/reload" 2>/dev/null || echo 000)"
+    [ "${rc:0:1}" = 2 ] && reload_ok=$((reload_ok+1))
+    sleep "$interval"
+done
+# Wait for the LOAD WORKERS only — a bare `wait` would also block on the
+# backend/zion background daemons, which never exit.
+wait "${worker_pids[@]}"
+
+gen1="$(gen)"; gen1="${gen1:-0}"
+
+# ── Tally ──
+total_ok=0; total_fail=0
+for i in $(seq 1 "$WORKERS"); do
+    read -r o f < "$WORK/w$i" 2>/dev/null || { o=0; f=0; }
+    total_ok=$((total_ok + o)); total_fail=$((total_fail + f))
+done
+swaps=$(( gen1 - gen0 ))
+
+step "result"
+printf '  requests: %s ok, %s%s failed%s\n' "$total_ok" \
+    "$([ "$total_fail" -gt 0 ] && printf '%s' "$R")" "$total_fail" "$N"
+printf '  config swaps during load: %s (generation %s → %s); admin reloads acked: %s/%s\n' \
+    "$swaps" "$gen0" "$gen1" "$reload_ok" "$RELOADS"
+
+fail=0
+if [ "$total_fail" -ne 0 ]; then
+    echo "  ${R}${B}FAIL${N} — $total_fail request(s) dropped/errored during config swaps:"
+    sort "$WORK/failcodes" 2>/dev/null | uniq -c | sed 's/^/    /' >&2
+    fail=1
+fi
+# A swap must have actually happened concurrently with traffic, else the test
+# proves nothing. Require a healthy fraction of the reloads to have landed.
+min_swaps=$(( RELOADS / 2 ))
+if [ "$swaps" -lt "$min_swaps" ]; then
+    echo "  ${R}${B}FAIL${N} — only $swaps swaps observed (< $min_swaps); reloads didn't run under load"
+    fail=1
+fi
+if [ "$fail" -eq 0 ]; then
+    echo "  ${G}${B}PASS${N} — $total_ok requests, 0 dropped across $swaps live config swaps."
+fi
+exit "$fail"


### PR DESCRIPTION
Production-hardening item #3. Proves the config hot-swap is invisible to live traffic — the invariant a dogfooded fleet leans on, since you reload `zion.toml` often (new route, changed upstream, tweaked limit).

## What it proves

`tests/reload-under-load/run.sh` starts a real Zion + the bench backend, then:

1. fires **sustained concurrent traffic** — N workers hammering a WAF-gated route for a fixed duration;
2. triggers **many real atomic config swaps while the traffic flows** via `POST /admin/reload` — the same `reload_now` `ArcSwap` store the file watcher uses. It stores a freshly-built snapshot unconditionally, so each call is a genuine swap, and it skips the file watcher's 2 s debounce so the run is deterministic;
3. asserts **zero failed requests** (no transport error, non-2xx, or timeout) and that the config **generation actually advanced during the load** (so the swaps really overlapped the traffic).

A single dropped connection during any swap fails the run.

## Result

```
requests: 5334 ok, 0 failed
config swaps during load: 20 (generation 0 → 20); admin reloads acked: 20/20
PASS — 5334 requests, 0 dropped across 20 live config swaps.
```

## CI

`.github/workflows/reload-under-load.yml` runs it on any change to the reload / dispatch / config / admin / main path (24 workers × 15 s × 30 swaps), so a regression that makes a swap drop connections is caught before merge. Native — no Docker; builds zion + the bench backend (shares the integration job's rust-cache), or takes prebuilt binaries via `ZION_BIN`/`BACKEND_BIN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)