### PR TITLE
fix(ws): bound the WebSocket upgrade handoff so a vanished client can't leak an upstream socket FD

### DIFF
--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -752,28 +752,39 @@ async fn send_ws_upgrade(
     // The previous implementation only had the 24h cap, allowing idle
     // connections to hold resources indefinitely (Slowloris-style exhaustion).
     tokio::spawn(async move {
-        if let Ok(client_upgraded) = on_client_upgrade.await {
-            let mut c = hyper_util::rt::TokioIo::new(client_upgraded);
-            let mut u = hyper_util::rt::TokioIo::new(upstream_upgraded);
-
-            let max_session = std::time::Duration::from_secs(24 * 60 * 60);
-            let idle_timeout = std::time::Duration::from_secs(5 * 60);
-
-            let session_deadline = tokio::time::Instant::now() + max_session;
-
-            let ws_pipe = async {
-                // copy_bidirectional runs until either side closes or errors.
-                // The idle timeout tears down completely silent sessions.
-                let _ = tokio::time::timeout(
-                    idle_timeout,
-                    tokio::io::copy_bidirectional(&mut c, &mut u),
-                )
-                .await;
+        // Bound the upgrade handoff itself. `on_client_upgrade` normally
+        // resolves near-instantly (right after the 101 is written), but a
+        // client that vanishes in that window can otherwise leave this future
+        // pending forever — pinning `upstream_upgraded`'s socket FD for the
+        // whole process lifetime, since the idle/session timeouts below only
+        // start once the upgrade has resolved. A short cap guarantees the
+        // upstream socket is released when the handoff never completes.
+        const UPGRADE_HANDOFF_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+        let client_upgraded =
+            match tokio::time::timeout(UPGRADE_HANDOFF_TIMEOUT, on_client_upgrade).await {
+                Ok(Ok(c)) => c,
+                // Timed out or the upgrade errored → return, dropping
+                // `upstream_upgraded` and freeing its FD.
+                _ => return,
             };
+        let mut c = hyper_util::rt::TokioIo::new(client_upgraded);
+        let mut u = hyper_util::rt::TokioIo::new(upstream_upgraded);
 
-            // Cap total session at the absolute deadline.
-            let _ = tokio::time::timeout_at(session_deadline, ws_pipe).await;
-        }
+        let max_session = std::time::Duration::from_secs(24 * 60 * 60);
+        let idle_timeout = std::time::Duration::from_secs(5 * 60);
+
+        let session_deadline = tokio::time::Instant::now() + max_session;
+
+        let ws_pipe = async {
+            // copy_bidirectional runs until either side closes or errors.
+            // The idle timeout tears down completely silent sessions.
+            let _ =
+                tokio::time::timeout(idle_timeout, tokio::io::copy_bidirectional(&mut c, &mut u))
+                    .await;
+        };
+
+        // Cap total session at the absolute deadline.
+        let _ = tokio::time::timeout_at(session_deadline, ws_pipe).await;
     });
 
     Ok(resp)


### PR DESCRIPTION
Found by the stability-soak investigation (item #4): the one traffic-reachable FD-leak path. Every other request-reachable structure is bounded (route cache 256/worker LRU, response cache by `max_entries`, rate map fail-closed at 100k + 60s scavenger, per-IP conn map self-cleaning, reload Arc lifecycle freed by ArcSwap refcounting).

## The bug

In `proxy_websocket` (proxy.rs), the 5-minute idle timeout and 24-hour session cap live **inside** the `if let Ok(client_upgraded) = on_client_upgrade.await` block — so they only begin once the upgrade resolves. The `await` on the handoff itself was **unbounded**.

`on_client_upgrade` normally resolves near-instantly, right after the `101 Switching Protocols` is written. But a client that disappears in that window (RST after the 101, or just vanishes) can leave that future pending forever. The spawned task then holds `upstream_upgraded` — the socket to the **already-connected upstream** — pinning its FD for the entire process lifetime. Under adversarial or flaky-client WebSocket churn that's a slow, unbounded FD leak.

## The fix

Wrap `on_client_upgrade` in a 30-second timeout. The handoff either completes near-instantly or the client is gone; on timeout (or an upgrade error) the task returns, dropping `upstream_upgraded` and freeing its FD. The idle/session timeouts on the pipe are unchanged.

## Verification

Builds clean; proxy tests pass; clippy `-D warnings` on pinned 1.88. The stability-soak harness (item #4, next PR) adds a WebSocket-churn generator with an RST-after-101 slice that exercises exactly this path as a standing regression guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)