### PR TITLE
docs: 1:1 codebase sync + full-coverage Grafana dashboard; release v0.6.1

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,7 +21,7 @@ A clear and concise description of what you expected to happen.
 **Environment (please complete the following information):**
  - OS: [e.g. Linux, macOS]
  - Architecture: [e.g. arm64, amd64]
- - Zion Version: [e.g. 0.6.0]
+ - Zion Version: [e.g. 0.6.1]
 
 **Additional context**
 Add any other context about the problem here (e.g. logs with `RUST_LOG=trace`, upstream backend type like Go/Node).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to Zion Edge Gateway are documented here.
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-07-07
+
+### Documentation
+- **README + docs synced 1:1 with the code** after a five-surface audit
+  (features / metrics / CLI / config / capability claims). Highlights: WAF
+  pattern counts corrected everywhere (aggressive set had doubled to ~240, docs
+  still said ~190); CORS re-documented as the per-route `cors = { … }` table it
+  actually is (the old top-level `[cors]` examples failed to load under
+  `deny_unknown_fields`); `cache_profile.ttl_seconds` default fixed (1 hour, not
+  1 year); the config reference tables completed (`xff_mode`, `trusted_proxies`,
+  `max_connections_per_ip`, upstream `urls`/mTLS, `client_auth`, WAF
+  `mode`/`entropy`/`streaming`); CLI feature-gates and missing `zion init` ACME
+  flags documented; `numa-aware` added to the build-flavor lists.
+- **Grafana dashboard now covers every metric `/metrics` emits.** New rows:
+  Protocols & tarpit detail (WebSocket upgrades, tarpit hold time), Mesh — AIMP
+  fleet gossip (claims / drops-by-reason / gossip bandwidth), and Reliability &
+  internals (panics, dropped audit events, admin rejects). The metrics reference
+  in `docs/deploy/observability.md` was expanded from ~12 to all ~40 series.
+
 ### Added
 - **Stability soak** (`tests/stability-soak/`): drives a real Zion with the
   traffic shapes that stress every leak-prone surface — random Host/path/XFF

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5458,7 +5458,7 @@ dependencies = [
 
 [[package]]
 name = "zion"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "aho-corasick",
  "aimp_node",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zion"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 # MSRV is the *core* default-features build (TLS proxy + WAF + cache + metrics).
 # Opt-in features (acme, auth, init, http3) pull crypto/i18n crates that have

--- a/README.md
+++ b/README.md
@@ -313,12 +313,12 @@ Every release is signed and carries SLSA v1.0 build provenance — see
 
 ```bash
 # Binary release (Sigstore-backed provenance via gh CLI)
-gh release download v0.6.0 -R fabriziosalmi/zion -p '*x86_64-unknown-linux-musl*' -p 'SHA256SUMS'
+gh release download v0.6.1 -R fabriziosalmi/zion -p '*x86_64-unknown-linux-musl*' -p 'SHA256SUMS'
 sha256sum --check --ignore-missing SHA256SUMS
-gh attestation verify zion-v0.6.0-x86_64-unknown-linux-musl.tar.gz --owner fabriziosalmi
+gh attestation verify zion-v0.6.1-x86_64-unknown-linux-musl.tar.gz --owner fabriziosalmi
 
 # Container image (cosign keyless)
-cosign verify ghcr.io/fabriziosalmi/zion:v0.6.0 \
+cosign verify ghcr.io/fabriziosalmi/zion:v0.6.1 \
     --certificate-identity-regexp "^https://github.com/fabriziosalmi/zion/\\.github/workflows/release\\.yml@refs/tags/v" \
     --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 ```

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ cargo build --release --features otel            # + OpenTelemetry tracing + OTL
 cargo build --release --features fips            # + FIPS 140-3 build (aws-lc-rs validated backend)
 cargo build --release --features geo-ita         # + Italian / EU sovereign edge classification
 cargo build --release --features io-uring-accept # Linux 5.19+: single-shot accept
+cargo build --release --features numa-aware      # + per-NUMA-node DashMap sharding (Linux multi-socket)
 
 # "max" build
 cargo build --release --features init,tui,acme,auth,http3,otel
@@ -185,7 +186,7 @@ survives. See [zion.example.toml](zion.example.toml) for the full reference and
 ```
 Client -> TLS 1.3 -> Security Gates -> Radix Router -> WAF Pipeline (5 gates) -> Proxy/Cache -> Upstream
                          |                                |
-                    URI limit                  Aho-Corasick (~100 balanced / ~190 aggressive)
+                    URI limit                  Aho-Corasick (~100 balanced / ~240 aggressive)
                     Method whitelist           Entropy analysis (JSON-string-only)
                     Rate limiter               simd-json validation
                     CORS pre-flight            Depth/size limits
@@ -207,13 +208,13 @@ Client -> TLS 1.3 -> Security Gates -> Radix Router -> WAF Pipeline (5 gates) ->
 
 **Cache** — two-level RAM cache: L1 thread-local (O(1) intrusive-LRU) + L2 sharded DashMap, generation-based coherence (no stale data after update), request coalescing (singleflight: N concurrent misses → 1 upstream fetch). Honors the origin's `Cache-Control`, emits `Age` and an `X-Zion-Cache: HIT|MISS|BYPASS` decision header, and exposes a `POST /_zion/cache/purge` flush for deploys.
 
-**WAF (zero-regex, O(N) single-pass)** — Aho-Corasick scanner, two pattern sets (`balanced` ~100 high-precision / `aggressive` ~190 broad-recall), Shannon-entropy analysis (JSON-string-only), simd-json structural limits, Content-Type enforcement, iterative normalization (URL-decode / SQL-comment / unicode), mTLS `X-Client-Cert-Fingerprint` forwarding, and a shadow mode (log + count, never block).
+**WAF (zero-regex, O(N) single-pass)** — Aho-Corasick scanner, two pattern sets (`balanced` ~100 high-precision / `aggressive` ~240 broad-recall), Shannon-entropy analysis (JSON-string-only), simd-json structural limits, Content-Type enforcement, iterative normalization (URL-decode / SQL-comment / unicode), mTLS `X-Client-Cert-Fingerprint` forwarding, and a shadow mode (log + count, never block).
 
 **Security** — HSTS preload, nosniff, frame-deny, Referrer-Policy, Permissions-Policy, per-route CSP; `Server`/hop-by-hop stripping (RFC 7230); URI-length cap + 7-method whitelist; per-IP rate limit **and** per-IP concurrent-connection cap (enforced at accept); CORS (FNV O(1)); header-bomb limits (64 headers / 16 KB).
 
 **Observability** — `/healthz` · `/readyz` fast-path (~1 µs), `/metrics` Prometheus (lock-free sharded counters), `X-Request-ID` + W3C `traceparent` propagation, structured text/JSON logs, and the `zion top` live TUI.
 
-**Operations** — fail-fast config validation, graceful 30 s drain, [adaptive upstream recovery](#) (decorrelated-jitter backoff: a recovered origin returns in ~1.4 s vs up to 30 s), boot-time platform auto-detection + performance-tier calibration, `zion doctor` diagnostics, TCP tuning (NODELAY / DEFER_ACCEPT / FASTOPEN / QUICKACK), systemd unit + Docker HEALTHCHECK.
+**Operations** — fail-fast config validation, graceful 30 s drain, adaptive upstream recovery (decorrelated-jitter backoff: a recovered origin returns in ~1.4 s vs up to 30 s), boot-time platform auto-detection + performance-tier calibration, `zion doctor` diagnostics, TCP tuning (NODELAY / DEFER_ACCEPT / FASTOPEN / QUICKACK), systemd unit + Docker HEALTHCHECK.
 
 **Opt-in tracks (feature-gated, default-off)**
 - **kTLS offload** (`--features ktls`, Linux 5.10+) — *experimental*: flips the socket into in-kernel TLS after handshake toward `sendfile`-class zero-copy. The offload is wired but not yet exercised end-to-end in CI (issue #52).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ from their containing minor — i.e. the latest `0.4.x` is always patched.
 | Version | Supported |
 | ------- | --------- |
 | 0.4.x (latest minor) | Yes |
-| < 0.6.0 | No |
+| < 0.6.1 | No |
 
 ## Reporting a Vulnerability
 

--- a/deploy/grafana/README.md
+++ b/deploy/grafana/README.md
@@ -40,15 +40,26 @@ import the JSON.
   file descriptors per instance, plus an **RSS leak-slope** panel
   (`deriv(...[30m])`): a persistently positive slope while request rate is flat
   is the silent memory-leak signal a front door must never hide. ACME
-  renewals-vs-failures and sovereign classifications round it out (both no-ops
-  unless the matching feature is built in).
+  renewals-vs-failures and sovereign classifications round it out.
+- **Protocols & tarpit detail** — WebSocket upgrade rate, and tarpit requests
+  held/s plus mean hold time (`rate(zion_tarpit_held_ms_total)/rate(zion_tarpit_total)`).
+- **Mesh — AIMP fleet gossip** — mesh claims emitted/received/score-hits, claims
+  dropped by reason (signature / replay / rate / other), and gossip bandwidth
+  in/out. Flat at 0 unless the node runs `--features sovereign-aimp`.
+- **Reliability & internals** — panics/s (must stay flat 0), audit-log events vs
+  **dropped** (alert on any drop — the HMAC chain has gaps), trace emit/invalid,
+  and admin-API rejects.
+
+Every metric Zion exposes at `/metrics` has a panel here.
 
 ## Note on optional metrics
 
-Some panels reference metrics that only appear with a feature: `zion_acme_*`
-(`--features acme`) and `zion_sovereign_*` (`--features geo-ita`/`geo-eu`).
-Those panels stay empty on a default build — that's expected, not a
-misconfiguration.
+Two panels depend on a feature and read absent on a default build (that's
+expected, not a misconfiguration): `zion_sovereign_classifications_total`
+(`--features geo-ita`/`geo-eu`) is genuinely `#[cfg]`-gated. The `zion_acme_*`
+and `zion_mesh_*` metrics are **always emitted** — they render as a flat `0`
+line until you build with `--features acme` / `sovereign-aimp` respectively, so
+their panels show zero rather than "no data".
 
 The raw PromQL for each panel is also listed in
 [`docs/deploy/observability.md`](../../docs/deploy/observability.md) if you'd

--- a/deploy/grafana/zion-overview.json
+++ b/deploy/grafana/zion-overview.json
@@ -201,6 +201,70 @@
     { "id": 44, "type": "timeseries", "title": "Sovereign classifications rate", "description": "Requires --features geo-ita/geo-eu.", "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "gridPos": { "h": 8, "w": 12, "x": 12, "y": 41 },
       "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "drawStyle": "line", "fillOpacity": 10 } } },
-      "targets": [ { "refId": "A", "expr": "sum by (class) (rate(zion_sovereign_classifications_total{instance=~\"$instance\"}[5m]))", "legendFormat": "{{class}}", "datasource": { "type": "prometheus", "uid": "${datasource}" } } ] }
+      "targets": [ { "refId": "A", "expr": "sum by (class) (rate(zion_sovereign_classifications_total{instance=~\"$instance\"}[5m]))", "legendFormat": "{{class}}", "datasource": { "type": "prometheus", "uid": "${datasource}" } } ] },
+
+    { "type": "row", "title": "Protocols & tarpit detail", "gridPos": { "h": 1, "w": 24, "x": 0, "y": 49 }, "collapsed": false, "id": 105 },
+
+    { "id": 50, "type": "timeseries", "title": "WebSocket upgrades/s", "description": "Rate of completed WebSocket upgrades (bidirectional TLS-to-upstream pipes). zion_websocket_upgrades.", "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 50 },
+      "fieldConfig": { "defaults": { "unit": "ops", "custom": { "drawStyle": "line", "fillOpacity": 10 } } },
+      "targets": [ { "refId": "A", "expr": "sum by (instance) (rate(zion_websocket_upgrades{instance=~\"$instance\"}[5m]))", "legendFormat": "{{instance}}", "datasource": { "type": "prometheus", "uid": "${datasource}" } } ] },
+
+    { "id": 51, "type": "timeseries", "title": "Tarpit — requests held/s + mean hold time", "description": "zion_tarpit_total is requests held by the L7 tarpit before rejection; mean hold = rate(zion_tarpit_held_ms_total) / rate(zion_tarpit_total).", "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 50 },
+      "fieldConfig": { "defaults": { "unit": "ops", "custom": { "drawStyle": "line", "fillOpacity": 10 } },
+        "overrides": [ { "matcher": { "id": "byName", "options": "mean hold (ms)" }, "properties": [ { "id": "unit", "value": "ms" }, { "id": "custom.axisPlacement", "value": "right" } ] } ] },
+      "targets": [
+        { "refId": "A", "expr": "sum(rate(zion_tarpit_total{instance=~\"$instance\"}[5m]))", "legendFormat": "held/s", "datasource": { "type": "prometheus", "uid": "${datasource}" } },
+        { "refId": "B", "expr": "sum(rate(zion_tarpit_held_ms_total{instance=~\"$instance\"}[5m])) / clamp_min(sum(rate(zion_tarpit_total{instance=~\"$instance\"}[5m])), 1)", "legendFormat": "mean hold (ms)", "datasource": { "type": "prometheus", "uid": "${datasource}" } }
+      ] },
+
+    { "type": "row", "title": "Mesh — AIMP fleet gossip", "gridPos": { "h": 1, "w": 24, "x": 0, "y": 58 }, "collapsed": false, "id": 106 },
+
+    { "id": 60, "type": "timeseries", "title": "Mesh claims — emitted / received / score hits", "description": "Requires --features sovereign-aimp (metrics render as 0 otherwise). Claims published from this node, claims received+merged, and dispatcher score-lookups that found a mesh score for the client IP.", "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 59 },
+      "fieldConfig": { "defaults": { "unit": "ops", "custom": { "drawStyle": "line", "fillOpacity": 10 } } },
+      "targets": [
+        { "refId": "A", "expr": "sum(rate(zion_mesh_claims_emitted_total{instance=~\"$instance\"}[5m]))", "legendFormat": "emitted/s", "datasource": { "type": "prometheus", "uid": "${datasource}" } },
+        { "refId": "B", "expr": "sum(rate(zion_mesh_claims_received_total{instance=~\"$instance\"}[5m]))", "legendFormat": "received/s", "datasource": { "type": "prometheus", "uid": "${datasource}" } },
+        { "refId": "C", "expr": "sum(rate(zion_mesh_score_lookups_total{instance=~\"$instance\"}[5m]))", "legendFormat": "score hits/s", "datasource": { "type": "prometheus", "uid": "${datasource}" } }
+      ] },
+
+    { "id": 61, "type": "timeseries", "title": "Mesh claims dropped by reason", "description": "Inbound gossip envelopes rejected: signature (bad Ed25519 sig), replay (seen before), rate (per-source cap), other. A spike in signature/replay is a probing peer.", "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 59 },
+      "fieldConfig": { "defaults": { "unit": "ops", "custom": { "drawStyle": "line", "fillOpacity": 40, "stacking": { "mode": "normal" } } } },
+      "targets": [ { "refId": "A", "expr": "sum by (reason) (rate(zion_mesh_claims_dropped_total{instance=~\"$instance\"}[5m]))", "legendFormat": "{{reason}}", "datasource": { "type": "prometheus", "uid": "${datasource}" } } ] },
+
+    { "id": 62, "type": "timeseries", "title": "Gossip bandwidth (in / out)", "description": "Bytes on the UDP gossip socket. zion_mesh_gossip_bytes_in_total / _out_total.", "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 59 },
+      "fieldConfig": { "defaults": { "unit": "Bps", "custom": { "drawStyle": "line", "fillOpacity": 10 } } },
+      "targets": [
+        { "refId": "A", "expr": "sum(rate(zion_mesh_gossip_bytes_in_total{instance=~\"$instance\"}[5m]))", "legendFormat": "in", "datasource": { "type": "prometheus", "uid": "${datasource}" } },
+        { "refId": "B", "expr": "sum(rate(zion_mesh_gossip_bytes_out_total{instance=~\"$instance\"}[5m]))", "legendFormat": "out", "datasource": { "type": "prometheus", "uid": "${datasource}" } }
+      ] },
+
+    { "type": "row", "title": "Reliability & internals", "gridPos": { "h": 1, "w": 24, "x": 0, "y": 67 }, "collapsed": false, "id": 107 },
+
+    { "id": 70, "type": "timeseries", "title": "Panics/s (must stay flat 0)", "description": "zion_panics_total — the panic hook fired. Any non-zero rate is a bug to page on immediately.", "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 68 },
+      "fieldConfig": { "defaults": { "unit": "ops", "custom": { "drawStyle": "line", "fillOpacity": 10, "thresholdsStyle": { "mode": "line" } }, "thresholds": { "steps": [ { "color": "green", "value": null }, { "color": "red", "value": 0.0001 } ] } } },
+      "targets": [ { "refId": "A", "expr": "sum by (instance) (rate(zion_panics_total{instance=~\"$instance\"}[5m]))", "legendFormat": "{{instance}}", "datasource": { "type": "prometheus", "uid": "${datasource}" } } ] },
+
+    { "id": 71, "type": "timeseries", "title": "Audit log — events/s + dropped/s", "description": "zion_audit_events_total written vs zion_audit_events_dropped_total (bounded channel full). Alert on any sustained dropped rate — the audit chain has gaps.", "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 68 },
+      "fieldConfig": { "defaults": { "unit": "ops", "custom": { "drawStyle": "line", "fillOpacity": 10 } } },
+      "targets": [
+        { "refId": "A", "expr": "sum(rate(zion_audit_events_total{instance=~\"$instance\"}[5m]))", "legendFormat": "events/s", "datasource": { "type": "prometheus", "uid": "${datasource}" } },
+        { "refId": "B", "expr": "sum(rate(zion_audit_events_dropped_total{instance=~\"$instance\"}[5m]))", "legendFormat": "dropped/s", "datasource": { "type": "prometheus", "uid": "${datasource}" } }
+      ] },
+
+    { "id": 72, "type": "timeseries", "title": "Tracing + admin API rejects", "description": "zion_traces_emitted_total / zion_traces_invalid_total (bad inbound traceparent) and zion_admin_rejects_total (admin API auth/rate-limit rejects).", "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 68 },
+      "fieldConfig": { "defaults": { "unit": "ops", "custom": { "drawStyle": "line", "fillOpacity": 10 } } },
+      "targets": [
+        { "refId": "A", "expr": "sum(rate(zion_traces_emitted_total{instance=~\"$instance\"}[5m]))", "legendFormat": "traces/s", "datasource": { "type": "prometheus", "uid": "${datasource}" } },
+        { "refId": "B", "expr": "sum(rate(zion_traces_invalid_total{instance=~\"$instance\"}[5m]))", "legendFormat": "invalid traceparent/s", "datasource": { "type": "prometheus", "uid": "${datasource}" } },
+        { "refId": "C", "expr": "sum(rate(zion_admin_rejects_total{instance=~\"$instance\"}[5m]))", "legendFormat": "admin rejects/s", "datasource": { "type": "prometheus", "uid": "${datasource}" } }
+      ] }
   ]
 }

--- a/deploy/helm/zion/Chart.yaml
+++ b/deploy/helm/zion/Chart.yaml
@@ -3,7 +3,7 @@ name: zion
 description: Zion Edge Gateway — high-performance Rust TLS reverse proxy with WAF
 type: application
 version: 0.2.2
-appVersion: "0.6.0"
+appVersion: "0.6.1"
 home: https://fabriziosalmi.github.io/zion
 sources:
   - https://github.com/fabriziosalmi/zion

--- a/docs/benchmarks/optimization.md
+++ b/docs/benchmarks/optimization.md
@@ -50,7 +50,7 @@ Changes made to improve throughput and latency, with rationale. Throughput claim
 
 | Change | Rationale |
 |---|---|
-| Two pattern sets selected per profile via `mode` | `balanced` (default, ~120 high-precision patterns) or `aggressive` (~190, broader recall). Categories: SQLi, XSS, CMDi, path traversal, SSRF/cloud-metadata, LDAP, XXE, SSTI, CRLF, Log4Shell, prototype pollution; NoSQL, deserialization, generic XSS handlers, JS API sinks live in aggressive |
+| Two pattern sets selected per profile via `mode` | `balanced` (default, ~100 high-precision patterns) or `aggressive` (~240, broader recall). Categories: SQLi, XSS, CMDi, path traversal, SSRF/cloud-metadata, LDAP, XXE, SSTI, CRLF, Log4Shell, prototype pollution; NoSQL, deserialization, generic XSS handlers, JS API sinks live in aggressive |
 | Aho-Corasick (no regex) | O(N) single-pass, no backtracking, case-insensitive, ReDoS-immune by construction |
 | Normalisation: iterative re-scan | URL-decode (`%XX`, `+`), SQL comment strip (`/* … */`), JSON unicode (`\uXXXX`); decode loop runs up to 3 passes (catches single, double, triple encoding) and re-scans after each pass |
 | Buffer shrink-to-fit (>64KB) | Prevents permanent memory inflation from adversarial large bodies |

--- a/docs/config/cors.md
+++ b/docs/config/cors.md
@@ -1,21 +1,26 @@
 # CORS
 
-CORS is disabled by default. To enable it, add an `[cors]` section with at least one origin.
+CORS is disabled by default and is configured **per route** — there is no
+top-level `[cors]` table (the config parser rejects unknown top-level keys, so a
+`[cors]` section fails to load). Add a `cors = { … }` inline table to any
+`[[route]]` with at least one origin.
 
 ## Configuration
 
 ```toml
-[cors]
-allowed_origins = ["https://app.example.com", "https://admin.example.com"]
-allowed_headers = ["Content-Type", "Authorization", "X-Requested-With"]
-max_age = 86400
+[[route]]
+path     = "/api/{*rest}"
+upstream = "backend"
+cors     = { allowed_origins = ["https://app.example.com", "https://admin.example.com"], allowed_headers = ["Content-Type", "Authorization", "X-Requested-With"], max_age = 86400 }
 ```
 
 ### Wildcard Origin
 
 ```toml
-[cors]
-allowed_origins = ["*"]
+[[route]]
+path     = "/public/{*rest}"
+upstream = "backend"
+cors     = { allowed_origins = ["*"] }
 ```
 
 When `*` is present, `Access-Control-Allow-Origin: *` is returned for all requests. This is suitable for public APIs but not recommended for authenticated endpoints.

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -12,6 +12,9 @@ All configuration is validated at startup. Invalid config produces actionable er
 | `listen_https` | string | **required** | HTTPS bind address (e.g. `"0.0.0.0:443"`) |
 | `rate_limit_rps` | u32 | `0` (disabled) | Max requests per IP per window |
 | `rate_limit_window_secs` | u64 | `1` | Rate limit window in seconds |
+| `max_connections_per_ip` | u32? | none | Per-IP concurrent-connection cap, enforced at accept (before the TLS handshake) |
+| `trusted_proxies` | string[] | `[]` | CIDRs whose inbound `X-Forwarded-For` is trusted for client-IP resolution |
+| `xff_mode` | string | `"append"` | Outbound XFF policy: `"append"`, `"rewrite"` (strip inbound, emit one trusted entry), or `"drop"` |
 | `log_format` | string | `"text"` | `"text"` or `"json"` (structured) |
 
 ## `[tls]`
@@ -24,15 +27,20 @@ All configuration is validated at startup. Invalid config produces actionable er
 | `min_version` | string | `"1.3"` | Minimum TLS version (`"1.2"` or `"1.3"`) |
 | `alpn` | string[] | `["h2", "http/1.1"]` | ALPN protocol negotiation list |
 | `sni` | SniCert[] | `[]` | Per-domain certificate mappings |
+| `acme` | table | none | Automatic HTTPS via Let's Encrypt — see [ACME](./acme) |
+| `client_ca_path` | string? | none | CA bundle used to verify client certs (mTLS) |
+| `client_auth` | string | `"none"` | mTLS client-auth mode (`"none"` disables mTLS) |
 
 ## `[upstream.<name>]`
 
 | Key | Type | Default | Description |
 |---|---|---|---|
-| `url` | string | **required** | Upstream URL (e.g. `"http://127.0.0.1:8000"`) |
+| `url` | string | `url` **or** `urls` required | Single upstream URL (e.g. `"http://127.0.0.1:8000"`) |
+| `urls` | string[] | `[]` | Multiple upstream URLs (latency-routed); use instead of `url` |
 | `connect_timeout_ms` | u64 | `3000` | TCP connect timeout in milliseconds |
 | `keepalive` | usize | `64` | Max idle keepalive connections |
 | `tls` | bool | `false` | Use HTTPS to connect to upstream |
+| `client_cert_path` / `client_key_path` | string? | none | Client cert + key for mTLS from Zion to the upstream |
 
 Legacy format `[upstreams]` (flat key-value map of name to URL) is also supported.
 
@@ -40,19 +48,23 @@ Legacy format `[upstreams]` (flat key-value map of name to URL) is also supporte
 
 | Key | Type | Default | Description |
 |---|---|---|---|
+| `mode` | string | `"balanced"` | Pattern set: `"balanced"` (~100, high-precision) or `"aggressive"` (~240, broad-recall) |
 | `max_body_mb` | u64 | `10` | Maximum request body size in MB |
 | `max_depth` | usize | `10` | Maximum JSON nesting depth |
 | `max_string_len` | usize | `1048576` | Maximum JSON string length (bytes) |
 | `deny_unknown_content_types` | bool | `true` | Reject content types not in allowed list |
 | `allowed_content_types` | string[] | `["application/json", "multipart/form-data"]` | Permitted content types |
+| `entropy_check` | bool | `true` | Enable the Shannon-entropy gate on JSON string values |
+| `entropy_threshold` | f64 | `6.5` | Bits/byte above which a JSON string value is flagged |
+| `streaming` | bool | `false` | Scan request bodies chunk-by-chunk as they stream (fail-fast on first hit) |
 
 ## `[cache_profile.<name>]`
 
 | Key | Type | Default | Description |
 |---|---|---|---|
 | `mode` | string | `"memory"` | Cache mode (`"memory"` or `"none"`) |
-| `max_entries` | usize | `10000` | Maximum cached entries (0 = unlimited) |
-| `ttl_seconds` | u64 | `31536000` | Time-to-live in seconds (default: 1 year) |
+| `max_entries` | usize | `10000` | Maximum cached entries; the LRU evicts at this cap. `0` caches nothing (every insert evicts first) — it is not "unlimited". |
+| `ttl_seconds` | u64 | `3600` | Time-to-live in seconds (default: 1 hour — a header-less origin response must not be frozen for a year; RFC 9111 §4.2.2 heuristic freshness). |
 
 ## `[[route]]`
 
@@ -67,7 +79,10 @@ Legacy format `[upstreams]` (flat key-value map of name to URL) is also supporte
 | `waf` | bool | `false` | Legacy: enable WAF with defaults |
 | `max_body_mb` | u64 | `10` | Legacy: override body limit when `waf = true` |
 
-## `[cors]`
+## `[[route]]` → `cors`
+
+CORS is a **per-route** inline table (`cors = { … }` under `[[route]]`), not a
+top-level `[cors]` section — see [CORS](./cors). Keys:
 
 | Key | Type | Default | Description |
 |---|---|---|---|

--- a/docs/config/tls.md
+++ b/docs/config/tls.md
@@ -127,7 +127,7 @@ renew_before_days = 30
 | `email` | *(required)* | Contact email for Let's Encrypt notifications |
 | `domains` | *(required)* | List of domains to request certificates for |
 | `directory_url` | LE production | ACME directory URL |
-| `state_dir` | *(required)* | Directory for account credentials and state |
+| `state_dir` | `/var/lib/zion/acme` | Directory for account credentials and cert/state persistence |
 | `renew_before_days` | `30` | Start renewal this many days before expiry |
 
 ### How It Works

--- a/docs/config/waf.md
+++ b/docs/config/waf.md
@@ -62,8 +62,8 @@ waf_profile = "upload"
 
 | Mode | Patterns | Use case |
 |---|---|---|
-| `balanced` (default) | ~120 high-precision: anchored SQLi/XSS tags, specific SSRF endpoints, exact-string CVEs (Log4Shell, XXE), specific PHP wrappers. | User-content APIs (comments, code paste, MDN-style docs, base64-bearing payloads). |
-| `aggressive` | balanced + ~70 broad-substring patterns: `alert(`, `eval(`, `confirm(`, `document.cookie`, `innerhtml`, `$gt`/`$ne`/`$regex`, `os.system(`, `pickle.loads`, `Runtime.getRuntime`, generic event handlers (`onclick=`, `onmouseover=`, …). | Admin panels, internal tooling, API surfaces where the FP cost is acceptable. |
+| `balanced` (default) | ~100 high-precision: anchored SQLi/XSS tags, specific SSRF endpoints, exact-string CVEs (Log4Shell, XXE), specific PHP wrappers. | User-content APIs (comments, code paste, MDN-style docs, base64-bearing payloads). |
+| `aggressive` | balanced + ~140 broad-substring patterns: `alert(`, `eval(`, `confirm(`, `document.cookie`, `innerhtml`, `$gt`/`$ne`/`$regex`, `os.system(`, `pickle.loads`, `Runtime.getRuntime`, generic event handlers (`onclick=`, `onmouseover=`, …). | Admin panels, internal tooling, API surfaces where the FP cost is acceptable. |
 
 The two automata are built lazily (on first hit per process) and cached; switching profiles costs nothing at request time. A request denied by an aggressive-only pattern returns the same `400` body and `waf_denied` metric as a balanced denial — there is no separate counter.
 

--- a/docs/deploy/hot-reload.md
+++ b/docs/deploy/hot-reload.md
@@ -130,7 +130,7 @@ Two surfaces report the reload state:
 
   ```json
   {
-    "version": "0.6.0",
+    "version": "0.6.1",
     "timestamp_ms": 1714425600000,
     "uptime_secs": 3712,
     "config_generation": 5,

--- a/docs/deploy/observability.md
+++ b/docs/deploy/observability.md
@@ -23,21 +23,95 @@ always respond even under load. `/metrics`, `/_zion/snapshot.json`, and
 
 ### Counter Reference
 
+This table is the authoritative list — every counter `/metrics` emits appears
+here. All are lock-free atomic `u64` (a `fetch_add` with `Relaxed` ordering,
+~2 ns). Counters marked *(always emitted)* render even when their feature is off
+(as a flat `0`), so one dashboard works across builds; the single genuinely
+feature-gated series (absent, not zero, without the feature) is called out.
+
+**Traffic & responses**
+
 | Metric | Type | Description |
 |---|---|---|
 | `zion_requests_total` | counter | Total HTTP requests processed |
-| `zion_requests_by_status{class="2xx"}` | counter | Successful responses |
-| `zion_requests_by_status{class="4xx"}` | counter | Client errors |
-| `zion_requests_by_status{class="5xx"}` | counter | Server errors |
-| `zion_waf_denied` | counter | Requests denied by WAF |
-| `zion_rate_limited` | counter | Requests denied by rate limiter |
+| `zion_requests_by_status{class="2xx"/"4xx"/"5xx"}` | counter | Responses by status class |
+| `zion_config_generation` | counter | Config hot-reload generation (increments on every atomic swap) |
+| `zion_websocket_upgrades` | counter | WebSocket upgrades completed |
+
+**Cache**
+
+| Metric | Type | Description |
+|---|---|---|
 | `zion_cache_hits` | counter | Responses served from RAM cache |
 | `zion_cache_misses` | counter | Cache misses (fetched from upstream) |
-| `zion_websocket_upgrades` | counter | WebSocket upgrades completed |
+
+**Security — WAF, rate limit, enforcement, tarpit**
+
+| Metric | Type | Description |
+|---|---|---|
+| `zion_waf_denied` | counter | Requests blocked by the WAF |
+| `zion_waf_shadow_would_block` | counter | Requests a shadow-mode WAF *would* have blocked (logged, not blocked) |
+| `zion_rate_limited` | counter | Requests denied by the per-IP rate limiter |
+| `zion_connections_rejected_per_ip` | counter | Connections rejected by the per-IP concurrent-connection cap (at accept) |
+| `zion_enforcement_denied_total{reason="class"/"mesh_score"}` | counter | Sovereign-enforcement `403`s, by trigger |
+| `zion_tarpit_active` | gauge | Connections currently held in the L7 tarpit |
+| `zion_tarpit_total` | counter | Total requests held by the tarpit before rejection |
+| `zion_tarpit_shed_total` | counter | Tarpit holds shed to a plain `403` when the global ceiling was hit |
+| `zion_tarpit_held_ms_total` | counter | Cumulative ms connections were held by the tarpit (mean hold = `rate(held_ms)/rate(total)`) |
+
+**Connections & TLS** — histograms below.
+
+| Metric | Type | Description |
+|---|---|---|
 | `zion_connections_total` | counter | Total TLS connections accepted |
 | `zion_tls_handshake_errors` | counter | Failed TLS handshakes |
 
-All counters are lock-free atomic `u64` values. Incrementing a counter costs ~2ns (single `fetch_add` with `Relaxed` ordering).
+**ACME** *(always emitted; `0` without `--features acme`)*
+
+| Metric | Type | Description |
+|---|---|---|
+| `zion_acme_renewals_total` | counter | Certificates renewed |
+| `zion_acme_renewal_failures_total` | counter | Renewal attempts that failed (sustained non-zero = certs will expire) |
+
+**Mesh — AIMP** *(always emitted; `0` without `--features sovereign-aimp`)*
+
+| Metric | Type | Description |
+|---|---|---|
+| `zion_mesh_claims_emitted_total` | counter | Mesh claims published from this node |
+| `zion_mesh_claims_received_total` | counter | Claims received and merged into local state |
+| `zion_mesh_claims_dropped_total{reason="signature"/"replay"/"rate"/"other"}` | counter | Inbound envelopes rejected, by reason |
+| `zion_mesh_score_lookups_total` | counter | Dispatcher hits that found a mesh score for the client IP |
+| `zion_mesh_gossip_bytes_in_total` | counter | Bytes received on the gossip socket |
+| `zion_mesh_gossip_bytes_out_total` | counter | Bytes sent on the gossip socket |
+
+**Reliability & internals**
+
+| Metric | Type | Description |
+|---|---|---|
+| `zion_panics_total` | counter | Worker panics caught by the panic hook (must stay `0`) |
+| `zion_audit_events_total` | counter | Audit-log events emitted (signed + HMAC-chained) |
+| `zion_audit_events_dropped_total` | counter | Audit events dropped because the writer queue was full (alert on any drop) |
+| `zion_traces_emitted_total` | counter | Request spans observed (one per request) |
+| `zion_traces_invalid_total` | counter | Inbound `traceparent` headers rejected as malformed |
+| `zion_admin_rejects_total` | counter | Admin-API requests rejected (auth or rate-limit) |
+
+**Sovereign classification** *(feature-gated — absent without `--features geo-ita`/`geo-eu`)*
+
+| Metric | Type | Description |
+|---|---|---|
+| `zion_sovereign_classifications_total{class="…"}` | counter | Requests classified by origin (IT/EU/unknown), by class |
+
+### Histograms
+
+Latency is exposed as Prometheus histograms — each emits `_bucket{le="…"}`,
+`_sum`, and `_count` series; query with `histogram_quantile()`. In OpenMetrics
+output they also carry trace-ID exemplars.
+
+| Metric | Description |
+|---|---|
+| `zion_request_duration_seconds` | End-to-end request latency (client-facing) |
+| `zion_upstream_duration_seconds` | Time spent waiting on the upstream |
+| `zion_tls_handshake_duration_seconds` | TLS handshake duration |
 
 ### Runtime Resource Gauges
 
@@ -66,8 +140,11 @@ scrape_configs:
 ### Grafana Dashboard
 
 An importable dashboard covering the whole fleet — golden signals, security,
-TLS/upstream, and a **leak-watch** row (RSS slope + open FDs per instance) — is
-committed at [`deploy/grafana/zion-overview.json`](https://github.com/fabriziosalmi/zion/blob/master/deploy/grafana/zion-overview.json).
+TLS/upstream, a **leak-watch** row (RSS slope + open FDs per instance), protocols
+& tarpit detail, the **AIMP mesh**, and a **reliability & internals** row
+(panics / dropped audit events / admin rejects). Every metric `/metrics` exposes
+has a panel. It is committed at
+[`deploy/grafana/zion-overview.json`](https://github.com/fabriziosalmi/zion/blob/master/deploy/grafana/zion-overview.json).
 Grafana → Dashboards → Import → upload the JSON → pick your Prometheus source.
 See [`deploy/grafana/README.md`](https://github.com/fabriziosalmi/zion/blob/master/deploy/grafana/README.md).
 
@@ -96,6 +173,19 @@ deriv(zion_process_resident_memory_bytes[30m])
 # File-descriptor leak: open fds climbing without bound (alert if it
 # approaches the `zion doctor` fd soft limit).
 zion_process_open_fds
+
+# Panics — must stay flat 0; page immediately on any non-zero rate.
+rate(zion_panics_total[5m])
+
+# Audit-log gaps — alert on any dropped event (the HMAC chain has holes).
+rate(zion_audit_events_dropped_total[5m])
+
+# Tarpit mean hold time (ms) — how long a flooding source is stalled.
+rate(zion_tarpit_held_ms_total[5m]) / clamp_min(rate(zion_tarpit_total[5m]), 1)
+
+# Mesh: inbound envelopes dropped by reason (spike in signature/replay = a
+# probing peer). Requires --features sovereign-aimp; flat 0 otherwise.
+sum by (reason) (rate(zion_mesh_claims_dropped_total[5m]))
 ```
 
 ## X-Request-ID

--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -85,8 +85,8 @@ Client
   │  Gate 1: Body size enforcement (O(1))               │
   │  Gate 2: Content-Type validation (delimiter-aware)  │
   │  Gate 3: Aho-Corasick scan — pattern set selected   │
-  │           per profile mode (balanced ~120 /         │
-  │           aggressive ~190); raw + iterative         │
+  │           per profile mode (balanced ~100 /         │
+  │           aggressive ~240); raw + iterative         │
   │           normalisation (URL-decode, SQL comment    │
   │           strip, JSON unicode), up to 3 passes      │
   │  Gate 4: Entropy analysis (Shannon ≥256 bytes;      │
@@ -163,6 +163,18 @@ Zion uses Tokio's multi-threaded runtime. Worker count is set to available CPU c
 | JWT/OIDC auth | `--features auth` | Per-route JWT validation (HMAC, RSA, ECDSA, JWKS) |
 | HTTP/3 QUIC | `--features http3` | UDP listener on same port, Alt-Svc advertisement |
 | io_uring accept | `--features io-uring-accept` | Linux 5.19+, single-shot accept on a dedicated thread |
+| NUMA-aware sharding | `--features numa-aware` | Per-NUMA-node DashMap shards (Linux multi-socket; single-shard fallback elsewhere) |
+| Init wizard / dev mode | `--features init` | `zion init` / `zion auto` scaffolding + self-signed cert |
+| Live TUI | `--features tui` | `zion top` dashboard |
+| OpenTelemetry export | `--features otel` | OTLP trace exporter |
+| FIPS 140-3 | `--features fips` | aws-lc-rs FIPS-validated backend |
+| Sovereign geo | `--features geo-ita` / `geo-eu` | Baked-in IT/EU ASN+CIDR classification |
+| AIMP mesh *(experimental)* | `--features sovereign-aimp` | Ed25519-signed fleet gossip of WAF/reputation |
+| kTLS offload *(experimental)* | `--features ktls` | In-kernel TLS after handshake; wired, not yet exercised e2e in CI |
+| ML-augmented WAF *(experimental)* | `--features ml-waf` | ONNX scorer on the WAF hot path; ships no bundled model |
+
+The release bundle is `--features dist` (= `acme` + `init`). The full flag list
+and lean/`cargo install` defaults live in the README "Build flavors" section.
 
 Build with multiple features:
 ```bash

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -33,13 +33,16 @@ The config file (and the cert files it references) are **hot-reloaded** — see
 Put TLS + HTTP/2 in front of a local backend with no config files at all — a
 self-signed cert is generated in memory. Ideal for local development.
 
+**Requires a build with `--features init`** (or `dist`). A lean build prints
+"zion auto requires the `init` feature" and exits `2`.
+
 ```console
 $ zion auto --upstream :3000          # 127.0.0.1:3000 behind https://localhost:8443
 ```
 
 | Flag | Default | Meaning |
 |---|---|---|
-| `-u, --upstream HOST:PORT` | — | backend to proxy (`:3000` → `127.0.0.1:3000`) |
+| `-u, --upstream HOST:PORT` | `127.0.0.1:3000` | backend to proxy (`:3000` → `127.0.0.1:3000`) |
 | `--http-port <N>` | 8080 | HTTP listen port |
 | `--https-port <N>` | 8443 | HTTPS listen port |
 | `--hostname <H>` | localhost | SAN for the self-signed cert |
@@ -47,6 +50,9 @@ $ zion auto --upstream :3000          # 127.0.0.1:3000 behind https://localhost:
 ## `zion init` — scaffold a config
 
 Generate a `zion.toml` interactively (prompts) or non-interactively from flags.
+The subcommand runs on a lean build, but **self-signed cert generation needs
+`--features init`** (or `dist`); without it the wizard writes the config and
+points you at `openssl` for the cert.
 
 | Flag | Default | Meaning |
 |---|---|---|
@@ -58,6 +64,9 @@ Generate a `zion.toml` interactively (prompts) or non-interactively from flags.
 | `--http-port <N>` / `--https-port <N>` | 80 / 443 | listener ports |
 | `--no-tls` | — | skip self-signed cert generation |
 | `--no-waf` | — | skip WAF on `/api/*` routes |
+| `--acme` / `--no-acme` | heuristic | force automatic HTTPS on/off (default: on for a public hostname, off for localhost/IP) |
+| `--email <ADDR>` | — | Let's Encrypt contact email (required when ACME is on) |
+| `--domain <NAME>` | the hostname | domain to obtain a cert for (repeatable) |
 
 ## `zion suggest` — synthesize from a detected backend
 
@@ -71,9 +80,9 @@ set real `[tls]` cert paths.
 
 | Flag | Meaning |
 |---|---|
-| `--upstream <host:port>` | upstream hint (`:3000`, `3000`, `127.0.0.1:3000`, `api.internal:8080`); a bare port binds `127.0.0.1` |
-| `--domain <name>` | domain for the synthesized cert paths (default `localhost`) |
-| `--write <path>` | write to a file instead of stdout |
+| `-u, --upstream <host:port>` | upstream hint (`:3000`, `3000`, `127.0.0.1:3000`, `api.internal:8080`); a bare port binds `127.0.0.1` |
+| `-d, --domain <name>` | domain for the synthesized cert paths (default `localhost`) |
+| `-w, --write <path>` | write to a file instead of stdout |
 
 ```console
 $ zion suggest --upstream :3000 --domain app.example.com --write zion.toml
@@ -128,6 +137,9 @@ Exit codes: `0` converted, `1` fatal (unparseable input / nothing convertible),
 ## `zion top` — live dashboard
 
 A terminal dashboard that polls a running Zion's snapshot endpoint.
+
+**Requires a build with `--features tui`.** A lean build prints a rebuild hint
+and exits `2` (`dist` does not include `tui` — build with `--features tui`).
 
 | Flag | Default | Meaning |
 |---|---|---|

--- a/docs/guide/observability.md
+++ b/docs/guide/observability.md
@@ -50,7 +50,7 @@ zion_request_duration_seconds_bucket{le="0.512"} 17 # {trace_id="0af7651916cd43d
 
 The exemplar update cost is 4 relaxed atomic stores on a cache line we just touched — measurable in benchmarks at sub-percent overhead, hidden by the existing histogram observation cost.
 
-Five new counters are exposed alongside the existing ones:
+Six reliability counters are exposed alongside the existing ones:
 
 | Counter | Meaning |
 |---|---|
@@ -59,6 +59,7 @@ Five new counters are exposed alongside the existing ones:
 | `zion_audit_events_dropped_total` | Audit events dropped because the writer queue was full. Non-zero values mean either the disk is slow or `audit.queue_depth` is too small. |
 | `zion_traces_emitted_total` | Request spans observed (one per request). |
 | `zion_traces_invalid_total` | Inbound `traceparent` headers rejected as malformed. |
+| `zion_admin_rejects_total` | Admin-API requests rejected (auth or rate-limit) at `[admin]`. |
 
 ## Sovereign IP classification (`--features geo-ita` / `geo-eu`)
 
@@ -286,6 +287,7 @@ Counters wired today (issue #69):
 | `zion_mesh_claims_received_total` | counter | Inbound envelopes that passed *all* policy gates and merged into local state. |
 | `zion_mesh_claims_dropped_total{reason="signature"}` | counter | Inbound envelopes rejected on Ed25519 signature verification. |
 | `zion_mesh_claims_dropped_total{reason="replay"}` | counter | Inbound envelopes rejected as duplicates (seen-signature filter). |
+| `zion_mesh_claims_dropped_total{reason="rate"}` | counter | Inbound envelopes rejected by the per-source claim rate-cap (flood protection). |
 | `zion_mesh_claims_dropped_total{reason="other"}` | counter | Other rejections — timestamp skew (past/future), magic-prefix mismatch, payload decode error, revocation by non-original source. |
 | `zion_mesh_score_lookups_total` | counter | Dispatcher hits that found a mesh score for the client IP — the `X-Zion-Mesh-Score` header rate. |
 | `zion_mesh_gossip_bytes_in_total` | counter | Total bytes received on the gossip socket (covers malformed packets too). |

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ features:
   - title: 233K req/s
     details: Peak throughput on Apple M4 with TLS 1.3 end-to-end. 107K req/s API proxy, 103K with full WAF pipeline active (CV 0.5%). Zero errors.
   - title: Zero-Regex WAF
-    details: Aho-Corasick automaton in a single O(N) pass over the body. Two pattern sets — balanced (default, ~120 high-precision patterns) and aggressive (opt-in, +~70 broad-substring patterns). Per-profile entropy gate (default 6.5 bits/byte, JSON-string-aware).
+    details: Aho-Corasick automaton in a single O(N) pass over the body. Two pattern sets — balanced (default, ~100 high-precision patterns) and aggressive (opt-in, +~140 broad-substring patterns). Per-profile entropy gate (default 6.5 bits/byte, JSON-string-aware).
   - title: Two-Level Cache
     details: "L1 thread-local with O(1) LRU (intrusive doubly-linked list) + L2 shared DashMap. Generation-based coherence. Watch-channel singleflight (race-free even when the fetcher completes between subscribe and await)."
   - title: TLS 1.3 + Hot-Reload

--- a/docs/mesh/integration.md
+++ b/docs/mesh/integration.md
@@ -56,8 +56,10 @@ anti_entropy_secs = 60                     # 0 to disable
 inbound_claims_per_sec = 0                 # 0 = no cap
 inbound_claim_burst    = 256               # headroom, used when cap > 0
 
-# Reconciler threshold for XDP→kernel drop install (0.0–1.0).
-# Default 0.95: only the highest-confidence consensus drops to LPM-trie.
+# RESERVED / inert: the AIMP→XDP reconciler is not shipped — the in-kernel
+# pre-filter track is frozen (issue #53). The key is kept so the TOML schema
+# stays stable if that work is ever picked up; setting it has no effect today.
+# (It would be the score above which a consensus block installs an LPM-trie drop.)
 xdp_block_threshold = 0.95
 ```
 

--- a/docs/perf/roadmap.md
+++ b/docs/perf/roadmap.md
@@ -101,22 +101,19 @@ remaining headroom is *cross-socket cache traffic on shared
 `DashMap`s* — `state.rate_map`, `state.inflight`, and the L2 cache
 shards.
 
-Why deferred:
+**Shipped (scaffold):** the `numa-aware` feature ([`src/numa.rs`](../../src/numa.rs),
+`NumaAwareMap`) splits those maps into per-NUMA-node shards routed by the
+calling thread's node. It reads `/sys/devices/system/node/` directly (no
+`libnuma` dep) and degrades transparently to a single shard on single-socket
+boxes, macOS, and Windows — so the code path is always compiled and correct;
+`bootstrap` surfaces the detected node count on `/metrics`.
 
-- Real NUMA topology is Linux-only (`libnuma`, `hwloc`); we'd need a
-  cross-platform fallback (single-shard on macOS/Windows) and a
-  feature flag to opt in.
-- `dashmap::DashMap` doesn't expose per-shard placement controls; we'd
-  need to fork or replace with a custom sharded lock-free hash.
-- The win is multi-socket-only. Single-socket boxes (which most users
-  have) gain nothing; the test harness would need a CI-runnable
-  multi-socket simulation.
-
-Path forward: write a microbenchmark that mimics
-`state.rate_map`/`state.inflight` access patterns under cross-thread
-contention, then reach for `papaya` or a custom sharded map only if
-the bench shows the expected delta on bare-metal Linux dual-socket
-hardware.
+**Still WIP:** the *measured* dual-socket win. `dashmap::DashMap` doesn't expose
+per-shard memory placement, so the current wrapper shards by node but doesn't
+yet pin each shard's allocation to that node's memory. Path forward: run
+[`benches/numa.rs`](../../benches/numa.rs) on bare-metal Linux dual-socket
+hardware to confirm the +5–10%, then, if the shard-routing alone doesn't land
+it, reach for `papaya` or a custom node-pinned sharded map.
 
 ### io_uring read/write vectored, splice/sendfile (estimate: 1–2% on large payloads)
 

--- a/docs/security/asvs.md
+++ b/docs/security/asvs.md
@@ -27,7 +27,7 @@ external scan whose green status is the operational evidence.
 | 1.1.4 | Threat model documented | [threat-model.md](threat-model.md) | Doc reviewed; STRIDE table covers all surfaces, including [§10 Mesh (AIMP)](threat-model.md#10-mesh-aimp-integration) for `--features sovereign-aimp` |
 | 1.1.7 | Architecture documented | [adr/](../adr/) (8 ADRs) | ADR index in [adr/README.md](../adr/README.md); mesh integration captured in [ADR-0008](../adr/0008-mesh-aimp-integration.md) |
 | 1.4.5 | Data classification documented | [redact](../../src/audit.rs) policy + [`zion.toml`] `[redact]` block | proptest `redact_drops_secret_values` |
-| 1.5.2 | Serialization rejected for untrusted input | `simd-json` validation gate in [waf.rs](../../src/waf.rs) | `denies_long_string_value`, fuzz target `redact_query_string` |
+| 1.5.2 | Serialization rejected for untrusted input | `simd-json` validation gate in [waf.rs](../../src/waf.rs) | unit tests `denies_long_string_value`, `denies_deep_nesting` |
 
 ## V2 — Authentication
 
@@ -59,7 +59,7 @@ to the binary path. Enabling `--features auth` brings:
 
 | ID | Requirement | Implementation | Test / Evidence |
 |---|---|---|---|
-| 5.1.1 | Server validates all input | WAF 5-gate pipeline ([waf.rs](../../src/waf.rs)) | 60+ unit tests, 4 proptest properties, 3 fuzz targets |
+| 5.1.1 | Server validates all input | WAF 5-gate pipeline ([waf.rs](../../src/waf.rs)) | 117 unit tests in `waf.rs` |
 | 5.1.2 | HTTP parameter pollution defence | `matchit` exact-path routing; query rebuilt by [proxy.rs](../../src/proxy.rs) | unit test `denies_double_encoded_traversal` |
 | 5.1.3 | URI length limited | `MAX_URI_LEN = 8192` ([dispatch.rs](../../src/dispatch.rs)) | unit test `uri_too_long_returns_414` |
 | 5.1.4 | Header count limited | `max_headers = 64` on hyper builder ([main.rs](../../src/main.rs)) | hyper-level enforcement |

--- a/docs/security/index.md
+++ b/docs/security/index.md
@@ -27,8 +27,8 @@ Request Body
     ▼
 ┌─ Gate 3: Aho-Corasick Injection Scanner ─────────┐
 │  Pattern set selected by profile mode:           │
-│    balanced   → ~120 high-precision patterns     │
-│    aggressive → ~190 (balanced + ~70 broad-      │
+│    balanced   → ~100 high-precision patterns     │
+│    aggressive → ~240 (balanced + ~140 broad-     │
 │                  substring patterns)              │
 │  Two passes: raw body, then iteratively-         │
 │    normalised body (URL-decode, SQL comment      │

--- a/docs/security/supply-chain.md
+++ b/docs/security/supply-chain.md
@@ -46,8 +46,8 @@ You need the GitHub CLI (`gh >= 2.49`) and `cosign >= 2.2`.
 
 ```bash
 # 1. Download the artifact + SHA256SUMS from the release page.
-gh release download v0.6.0 -R fabriziosalmi/zion \
-    -p 'zion-v0.6.0-x86_64-unknown-linux-musl.tar.gz' \
+gh release download v0.6.1 -R fabriziosalmi/zion \
+    -p 'zion-v0.6.1-x86_64-unknown-linux-musl.tar.gz' \
     -p 'SHA256SUMS' \
     -p 'zion-sbom.cdx.json'
 
@@ -55,7 +55,7 @@ gh release download v0.6.0 -R fabriziosalmi/zion \
 sha256sum --check --ignore-missing SHA256SUMS
 
 # 3. Verify the SLSA build provenance bound to the artifact's hash.
-gh attestation verify zion-v0.6.0-x86_64-unknown-linux-musl.tar.gz \
+gh attestation verify zion-v0.6.1-x86_64-unknown-linux-musl.tar.gz \
     --owner fabriziosalmi
 
 # Step 3 fails if:
@@ -78,7 +78,7 @@ grype zion-sbom.cdx.json
 ## Verifying a container image
 
 ```bash
-IMAGE=ghcr.io/fabriziosalmi/zion:v0.6.0
+IMAGE=ghcr.io/fabriziosalmi/zion:v0.6.1
 
 # 1. Pin to the digest immediately — tags are mutable, digests are not.
 DIGEST=$(crane digest "$IMAGE")
@@ -120,7 +120,7 @@ deterministically, and pins the Rust toolchain via
 [`rust-toolchain.toml`](../../rust-toolchain.toml). To reproduce locally:
 
 ```bash
-git checkout v0.6.0
+git checkout v0.6.1
 export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)
 # Linux musl example — matches the release artifact byte-for-byte
 # (modulo strip's stable behavior on your distro).


### PR DESCRIPTION
## What

A rigorous **README + docs 1:1 sync with the code** (five-surface audit: features / metrics / CLI / config / capability claims), a **Grafana dashboard extended to 100% metric coverage**, and the **v0.6.1** version bump so all of the production-hardening work (freeze, soak, ACME-default, …) ships.

## Docs 1:1 fixes

- **WAF pattern counts** — the aggressive set had doubled (balanced **103**, aggressive-extra **141**, total **244**) but docs still said ~120 / ~190 / +~70 everywhere. Corrected across README + 6 docs to ~100 / ~240 / +~140.
- **CORS** — re-documented as the **per-route** `cors = { … }` table it actually is. The old top-level `[cors]` examples would fail to load (`deny_unknown_fields`). (`docs/config/cors.md`, `index.md`)
- **Config defaults** — `cache_profile.ttl_seconds` 1 year → **3600 (1 hour)**; `max_entries` "0 = unlimited" → 0 caches nothing; acme `state_dir` "required" → default `/var/lib/zion/acme`.
- **Config reference completed** — `xff_mode`, `trusted_proxies`, `max_connections_per_ip`, `[tls] client_auth`, upstream `urls` + mTLS, WAF `mode`/`entropy`/`streaming`, `url` OR `urls`.
- **Metrics** — `docs/deploy/observability.md` Counter Reference expanded from ~12 to **all ~40** emitted series (+ Histograms section); guide observability "Five"→"Six" reliability counters + the missing mesh `reason="rate"`.
- **CLI** — feature-gates noted (`zion top`→`tui`, `zion auto`/`init` cert-gen→`init`), missing `zion init` ACME flags + `zion suggest` short aliases added.
- **Features** — `numa-aware` added to build-flavor lists; perf-roadmap NUMA reframed "deferred"→"scaffold shipped, tuning WIP"; reserved-but-inert `xdp_block_threshold` flagged not-shipped; dead `(#)` README link + asvs.md WAF test attribution fixed.

## Dashboard — every metric now has a panel

New rows: **Protocols & tarpit detail**, **Mesh — AIMP fleet gossip**, **Reliability & internals**. Verified 100% coverage of the 38 emitted metric families.

## Release

Version bumped 0.6.0 → **0.6.1** via `scripts/bump-version.sh` (Cargo.toml SSOT + lock, Helm appVersion, README/SECURITY/supply-chain/hot-reload/bug_report). CHANGELOG `[0.6.1]` added. Tag `v0.6.1` after merge triggers `release.yml`.

No source changes — docs, dashboard JSON, and version strings only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)