### PR TITLE
test(acme): guard the 1-day bootstrap-cert → first-boot-issuance linchpin

### DIFF
--- a/src/acme.rs
+++ b/src/acme.rs
@@ -668,6 +668,44 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "acme")]
+    fn expiry_check_fires_for_short_lived_cert_not_long() {
+        // Boot-time linchpin of auto-HTTPS: a near-expiry cert (the 1-day ACME
+        // bootstrap cert `zion init` stamps) must read as "renewal needed" so
+        // first-boot issuance fires; a long-lived cert must not. Same threshold
+        // the background renewal task runs.
+        let mk = |days: i64| -> String {
+            let key = rcgen::KeyPair::generate().unwrap();
+            let mut p = rcgen::CertificateParams::new(vec!["t.example.com".to_string()]).unwrap();
+            let now = time::OffsetDateTime::now_utc();
+            p.not_before = now - time::Duration::hours(1);
+            p.not_after = now + time::Duration::days(days);
+            p.self_signed(&key).unwrap().pem()
+        };
+        let dir = std::env::temp_dir();
+        let short = dir.join(format!("zion-acme-short-{}.crt", std::process::id()));
+        let long = dir.join(format!("zion-acme-long-{}.crt", std::process::id()));
+        std::fs::write(&short, mk(1)).unwrap();
+        std::fs::write(&long, mk(365)).unwrap();
+
+        assert!(
+            check_cert_expiry(short.to_str().unwrap(), 30),
+            "1-day bootstrap cert must read as renewal-needed (fires first-boot ACME)"
+        );
+        assert!(
+            !check_cert_expiry(long.to_str().unwrap(), 30),
+            "365-day cert must not trigger renewal"
+        );
+        assert!(
+            check_cert_expiry("/nonexistent/zion-no-such.crt", 30),
+            "an unreadable cert must renew to be safe"
+        );
+
+        let _ = std::fs::remove_file(&short);
+        let _ = std::fs::remove_file(&long);
+    }
+
+    #[test]
     fn challenge_empty_store_returns_none() {
         let store = new_challenge_store();
         assert_eq!(

--- a/src/init.rs
+++ b/src/init.rs
@@ -1012,6 +1012,31 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "init")]
+    fn bootstrap_cert_is_short_lived() {
+        // The linchpin of Caddy-style auto-HTTPS: the ACME bootstrap cert MUST
+        // be short-lived (~1 day) so the boot-time expiry check trips first-boot
+        // issuance. rcgen's default not_after is year 4096 — that would bind
+        // :443 but SILENTLY never provision a real cert. Guard the 1-day window
+        // against a regression, using the SAME parser (`cert_expiry_secs`) the
+        // renewal task consults, so this also proves the cert trips issuance.
+        let (cert_pem, _key) =
+            generate_short_lived_cert(&["app.example.com".to_string()]).unwrap();
+        let path =
+            std::env::temp_dir().join(format!("zion-bootstrap-{}.crt", std::process::id()));
+        std::fs::write(&path, cert_pem).unwrap();
+        let secs = crate::tls::cert_expiry_secs(path.to_str().unwrap())
+            .expect("bootstrap cert must parse");
+        let _ = std::fs::remove_file(&path);
+        assert!(secs > 0, "bootstrap cert already expired: {secs}s");
+        assert!(
+            secs < 2 * 86400,
+            "bootstrap cert not short-lived ({secs}s ~ {} days) — first-boot ACME issuance won't fire",
+            secs / 86400
+        );
+    }
+
+    #[test]
     fn acme_off_for_localhost_and_no_email() {
         // localhost never gets ACME even with an email present.
         let opts = InitOpts {

--- a/src/init.rs
+++ b/src/init.rs
@@ -1020,10 +1020,8 @@ mod tests {
         // :443 but SILENTLY never provision a real cert. Guard the 1-day window
         // against a regression, using the SAME parser (`cert_expiry_secs`) the
         // renewal task consults, so this also proves the cert trips issuance.
-        let (cert_pem, _key) =
-            generate_short_lived_cert(&["app.example.com".to_string()]).unwrap();
-        let path =
-            std::env::temp_dir().join(format!("zion-bootstrap-{}.crt", std::process::id()));
+        let (cert_pem, _key) = generate_short_lived_cert(&["app.example.com".to_string()]).unwrap();
+        let path = std::env::temp_dir().join(format!("zion-bootstrap-{}.crt", std::process::id()));
         std::fs::write(&path, cert_pem).unwrap();
         let secs = crate::tls::cert_expiry_secs(path.to_str().unwrap())
             .expect("bootstrap cert must parse");


### PR DESCRIPTION
Follow-up to the docs 1:1 audit: the README's Caddy-style auto-HTTPS claim ("`zion init` stamps a short-lived bootstrap cert so `:443` binds instantly while ACME provisions the real one on first boot") was **coded and commented but not covered by a test**. The whole story hinges on the bootstrap cert being ~1 day — rcgen's default `not_after` is year 4096, which would bind `:443` but **silently never issue** a real cert, with nothing failing.

Two guards using the real code paths:
- `init::bootstrap_cert_is_short_lived` — parses what `generate_short_lived_cert` produces with the same `tls::cert_expiry_secs` the daemon reads at boot; asserts expiry < 2 days.
- `acme::expiry_check_fires_for_short_lived_cert_not_long` — asserts `check_cert_expiry` reads a 1-day cert as renewal-needed and a 365-day cert as not (and renews on an unreadable cert).

Feature-gated (`init` / `acme`); the lean default build is unaffected. Local: both pass under `--features acme,init`; default `cargo test` + clippy `-D warnings` clean.

What was already tested (for reference): the `[tls.acme]` block emission + schema validity (init unit tests), the HTTP-01 responder on :80 (acme unit tests), and the full issue→renew→revoke cycle against Pebble with fault injection (`acme-soak.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)