### PR TITLE
fix(ci): release verify-step digest collision (arm64 aborts, blocks cosign)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -544,6 +544,12 @@ jobs:
             docker create --platform "linux/${arch}" --name "verify-${arch}" "$REF" >/dev/null
             docker cp "verify-${arch}:/usr/local/bin/zion" "/tmp/zion-${arch}" >/dev/null
             docker rm "verify-${arch}" >/dev/null
+            # Drop the locally-stored image before the next platform. `docker
+            # create --platform X image@<manifest-list-digest>` pulls the X image
+            # but stores it under the *manifest-list* digest; the next platform
+            # would then hit "cannot overwrite digest <same>" and abort. Removing
+            # it frees that digest slot so each arch pulls cleanly.
+            docker image rm "$REF" >/dev/null 2>&1 || true
             got="$(file -b "/tmp/zion-${arch}")"
             echo "linux/${arch}: ${got}"
             case "$got" in

--- a/src/acme.rs
+++ b/src/acme.rs
@@ -668,6 +668,44 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "acme")]
+    fn expiry_check_fires_for_short_lived_cert_not_long() {
+        // Boot-time linchpin of auto-HTTPS: a near-expiry cert (the 1-day ACME
+        // bootstrap cert `zion init` stamps) must read as "renewal needed" so
+        // first-boot issuance fires; a long-lived cert must not. Same threshold
+        // the background renewal task runs.
+        let mk = |days: i64| -> String {
+            let key = rcgen::KeyPair::generate().unwrap();
+            let mut p = rcgen::CertificateParams::new(vec!["t.example.com".to_string()]).unwrap();
+            let now = time::OffsetDateTime::now_utc();
+            p.not_before = now - time::Duration::hours(1);
+            p.not_after = now + time::Duration::days(days);
+            p.self_signed(&key).unwrap().pem()
+        };
+        let dir = std::env::temp_dir();
+        let short = dir.join(format!("zion-acme-short-{}.crt", std::process::id()));
+        let long = dir.join(format!("zion-acme-long-{}.crt", std::process::id()));
+        std::fs::write(&short, mk(1)).unwrap();
+        std::fs::write(&long, mk(365)).unwrap();
+
+        assert!(
+            check_cert_expiry(short.to_str().unwrap(), 30),
+            "1-day bootstrap cert must read as renewal-needed (fires first-boot ACME)"
+        );
+        assert!(
+            !check_cert_expiry(long.to_str().unwrap(), 30),
+            "365-day cert must not trigger renewal"
+        );
+        assert!(
+            check_cert_expiry("/nonexistent/zion-no-such.crt", 30),
+            "an unreadable cert must renew to be safe"
+        );
+
+        let _ = std::fs::remove_file(&short);
+        let _ = std::fs::remove_file(&long);
+    }
+
+    #[test]
     fn challenge_empty_store_returns_none() {
         let store = new_challenge_store();
         assert_eq!(

--- a/src/init.rs
+++ b/src/init.rs
@@ -1012,6 +1012,31 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "init")]
+    fn bootstrap_cert_is_short_lived() {
+        // The linchpin of Caddy-style auto-HTTPS: the ACME bootstrap cert MUST
+        // be short-lived (~1 day) so the boot-time expiry check trips first-boot
+        // issuance. rcgen's default not_after is year 4096 — that would bind
+        // :443 but SILENTLY never provision a real cert. Guard the 1-day window
+        // against a regression, using the SAME parser (`cert_expiry_secs`) the
+        // renewal task consults, so this also proves the cert trips issuance.
+        let (cert_pem, _key) =
+            generate_short_lived_cert(&["app.example.com".to_string()]).unwrap();
+        let path =
+            std::env::temp_dir().join(format!("zion-bootstrap-{}.crt", std::process::id()));
+        std::fs::write(&path, cert_pem).unwrap();
+        let secs = crate::tls::cert_expiry_secs(path.to_str().unwrap())
+            .expect("bootstrap cert must parse");
+        let _ = std::fs::remove_file(&path);
+        assert!(secs > 0, "bootstrap cert already expired: {secs}s");
+        assert!(
+            secs < 2 * 86400,
+            "bootstrap cert not short-lived ({secs}s ~ {} days) — first-boot ACME issuance won't fire",
+            secs / 86400
+        );
+    }
+
+    #[test]
     fn acme_off_for_localhost_and_no_email() {
         // localhost never gets ACME even with an email present.
         let opts = InitOpts {

--- a/src/init.rs
+++ b/src/init.rs
@@ -1020,10 +1020,8 @@ mod tests {
         // :443 but SILENTLY never provision a real cert. Guard the 1-day window
         // against a regression, using the SAME parser (`cert_expiry_secs`) the
         // renewal task consults, so this also proves the cert trips issuance.
-        let (cert_pem, _key) =
-            generate_short_lived_cert(&["app.example.com".to_string()]).unwrap();
-        let path =
-            std::env::temp_dir().join(format!("zion-bootstrap-{}.crt", std::process::id()));
+        let (cert_pem, _key) = generate_short_lived_cert(&["app.example.com".to_string()]).unwrap();
+        let path = std::env::temp_dir().join(format!("zion-bootstrap-{}.crt", std::process::id()));
         std::fs::write(&path, cert_pem).unwrap();
         let secs = crate::tls::cert_expiry_secs(path.to_str().unwrap())
             .expect("bootstrap cert must parse");


### PR DESCRIPTION
v0.6.1's release run failed at **Verify each arch ships its own binary**: amd64 verified, then arm64 aborted with `cannot overwrite digest <sha>`.

**Cause (deterministic):** `docker create --platform X image@<manifest-list-digest>` pulls the X image but stores it locally under the *manifest-list* digest. The next platform then tries to store a different image under the same digest and Docker refuses (`cannot overwrite digest`). This was the first release since the verify step (#279) merged, so the bug had never executed.

**Impact:** the image was built and pushed correctly (per-arch binaries are right) — but the buggy verify step gated **cosign signing + SBOM attestation**, so v0.6.1's container image is published **unsigned**.

**Fix:** `docker image rm "$REF"` between the two platform iterations frees the digest slot so each arch pulls cleanly. Future releases verify both arches and sign.

Follow-up: cut **v0.6.2** after this merges to publish a fully-signed, fully-green release (v0.6.1's binaries/tarballs are fine; only its container signature is missing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)