### PR TITLE
chore(release): v0.6.2 (signed container; re-cut after the verify-step fix)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,7 +21,7 @@ A clear and concise description of what you expected to happen.
 **Environment (please complete the following information):**
  - OS: [e.g. Linux, macOS]
  - Architecture: [e.g. arm64, amd64]
- - Zion Version: [e.g. 0.6.1]
+ - Zion Version: [e.g. 0.6.2]
 
 **Additional context**
 Add any other context about the problem here (e.g. logs with `RUST_LOG=trace`, upstream backend type like Go/Node).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to Zion Edge Gateway are documented here.
 
 ## [Unreleased]
 
+## [0.6.2] - 2026-07-07
+
+### Fixed
+- **Release container image is signed again.** The `release.yml` "verify each
+  arch ships its own binary" step (added in v0.6.0's arm64 fix, first exercised
+  by v0.6.1) aborted on the second architecture with `cannot overwrite digest`
+  — `docker create --platform` stores the pulled image under the manifest-list
+  digest, so the next platform collides. That failure gated cosign signing +
+  SBOM attestation, so v0.6.1's container shipped unsigned. Fixed by removing the
+  local image between platform iterations; the multi-arch image now verifies both
+  arches and is cosign-signed + SBOM-attested. (v0.6.1's binaries/tarballs were
+  unaffected.)
+
+### Added
+- **Tests for the ACME bootstrap-cert linchpin.** `zion init`'s Caddy-style
+  auto-HTTPS relies on a ~1-day bootstrap cert so first-boot issuance fires
+  (rcgen's default not_after is year 4096, which would bind `:443` but silently
+  never issue). Added `init::bootstrap_cert_is_short_lived` (parses the cert via
+  the same `tls::cert_expiry_secs` the daemon reads at boot) and
+  `acme::expiry_check_fires_for_short_lived_cert_not_long`.
+
 ## [0.6.1] - 2026-07-07
 
 ### Documentation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5458,7 +5458,7 @@ dependencies = [
 
 [[package]]
 name = "zion"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "aho-corasick",
  "aimp_node",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zion"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 # MSRV is the *core* default-features build (TLS proxy + WAF + cache + metrics).
 # Opt-in features (acme, auth, init, http3) pull crypto/i18n crates that have

--- a/README.md
+++ b/README.md
@@ -313,12 +313,12 @@ Every release is signed and carries SLSA v1.0 build provenance — see
 
 ```bash
 # Binary release (Sigstore-backed provenance via gh CLI)
-gh release download v0.6.1 -R fabriziosalmi/zion -p '*x86_64-unknown-linux-musl*' -p 'SHA256SUMS'
+gh release download v0.6.2 -R fabriziosalmi/zion -p '*x86_64-unknown-linux-musl*' -p 'SHA256SUMS'
 sha256sum --check --ignore-missing SHA256SUMS
-gh attestation verify zion-v0.6.1-x86_64-unknown-linux-musl.tar.gz --owner fabriziosalmi
+gh attestation verify zion-v0.6.2-x86_64-unknown-linux-musl.tar.gz --owner fabriziosalmi
 
 # Container image (cosign keyless)
-cosign verify ghcr.io/fabriziosalmi/zion:v0.6.1 \
+cosign verify ghcr.io/fabriziosalmi/zion:v0.6.2 \
     --certificate-identity-regexp "^https://github.com/fabriziosalmi/zion/\\.github/workflows/release\\.yml@refs/tags/v" \
     --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ from their containing minor — i.e. the latest `0.4.x` is always patched.
 | Version | Supported |
 | ------- | --------- |
 | 0.4.x (latest minor) | Yes |
-| < 0.6.1 | No |
+| < 0.6.2 | No |
 
 ## Reporting a Vulnerability
 

--- a/deploy/helm/zion/Chart.yaml
+++ b/deploy/helm/zion/Chart.yaml
@@ -3,7 +3,7 @@ name: zion
 description: Zion Edge Gateway — high-performance Rust TLS reverse proxy with WAF
 type: application
 version: 0.2.2
-appVersion: "0.6.1"
+appVersion: "0.6.2"
 home: https://fabriziosalmi.github.io/zion
 sources:
   - https://github.com/fabriziosalmi/zion

--- a/docs/deploy/hot-reload.md
+++ b/docs/deploy/hot-reload.md
@@ -130,7 +130,7 @@ Two surfaces report the reload state:
 
   ```json
   {
-    "version": "0.6.1",
+    "version": "0.6.2",
     "timestamp_ms": 1714425600000,
     "uptime_secs": 3712,
     "config_generation": 5,

--- a/docs/security/supply-chain.md
+++ b/docs/security/supply-chain.md
@@ -46,8 +46,8 @@ You need the GitHub CLI (`gh >= 2.49`) and `cosign >= 2.2`.
 
 ```bash
 # 1. Download the artifact + SHA256SUMS from the release page.
-gh release download v0.6.1 -R fabriziosalmi/zion \
-    -p 'zion-v0.6.1-x86_64-unknown-linux-musl.tar.gz' \
+gh release download v0.6.2 -R fabriziosalmi/zion \
+    -p 'zion-v0.6.2-x86_64-unknown-linux-musl.tar.gz' \
     -p 'SHA256SUMS' \
     -p 'zion-sbom.cdx.json'
 
@@ -55,7 +55,7 @@ gh release download v0.6.1 -R fabriziosalmi/zion \
 sha256sum --check --ignore-missing SHA256SUMS
 
 # 3. Verify the SLSA build provenance bound to the artifact's hash.
-gh attestation verify zion-v0.6.1-x86_64-unknown-linux-musl.tar.gz \
+gh attestation verify zion-v0.6.2-x86_64-unknown-linux-musl.tar.gz \
     --owner fabriziosalmi
 
 # Step 3 fails if:
@@ -78,7 +78,7 @@ grype zion-sbom.cdx.json
 ## Verifying a container image
 
 ```bash
-IMAGE=ghcr.io/fabriziosalmi/zion:v0.6.1
+IMAGE=ghcr.io/fabriziosalmi/zion:v0.6.2
 
 # 1. Pin to the digest immediately — tags are mutable, digests are not.
 DIGEST=$(crane digest "$IMAGE")
@@ -120,7 +120,7 @@ deterministically, and pins the Rust toolchain via
 [`rust-toolchain.toml`](../../rust-toolchain.toml). To reproduce locally:
 
 ```bash
-git checkout v0.6.1
+git checkout v0.6.2
 export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)
 # Linux musl example — matches the release artifact byte-for-byte
 # (modulo strip's stable behavior on your distro).


### PR DESCRIPTION
Re-cut so the release container image is **cosign-signed + SBOM-attested** again. v0.6.1's release job failed at the multi-arch "verify each arch" step (`cannot overwrite digest`, fixed in #294), which gated the signing steps — so v0.6.1's image shipped unsigned. Tagging v0.6.2 runs the fixed `release.yml`.

Contents since v0.6.1: the ACME bootstrap-cert guard tests (#293) + the release verify-step fix (#294). No runtime code change. CHANGELOG `[0.6.2]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)