### PR TITLE
ci+docs: native-arm container release + finish the docs polish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -462,16 +462,30 @@ jobs:
   # ════════════════════════════════════════════════════════════════════════
   # 3. Multi-arch container image — keyless-signed + SBOM-attested.
   # ════════════════════════════════════════════════════════════════════════
-  container:
-    name: container (multi-arch + cosign)
+  # Build each architecture on its OWN native runner (amd64 on ubuntu-latest,
+  # arm64 on the free ubuntu-24.04-arm hosted runner) — no QEMU emulation, so
+  # the arm64 leg drops from ~40 min to a few. Each leg pushes by digest; the
+  # `container` job below fuses the two digests into one multi-arch manifest.
+  container-build:
+    name: container build (${{ matrix.arch }})
     needs: [build]
     if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            arch: amd64
+            want: x86-64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
+            want: aarch64
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
-      packages: write          # push to GHCR
-      id-token: write          # cosign keyless OIDC
-      attestations: write
+      packages: write # push by digest to GHCR
     env:
       REGISTRY: ghcr.io
       IMAGE_NAME: ${{ github.repository }}
@@ -480,9 +494,6 @@ jobs:
 
       - name: Reproducible-build epoch
         run: echo "SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)" >> "$GITHUB_ENV"
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: Set up Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
@@ -494,8 +505,107 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Image metadata
+      - name: Image labels
         id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          labels: |
+            org.opencontainers.image.title=Zion Edge Gateway
+            org.opencontainers.image.description=High-performance Rust TLS reverse proxy with WAF
+            org.opencontainers.image.licenses=Apache-2.0
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.url=https://github.com/${{ github.repository }}
+            org.opencontainers.image.documentation=https://fabriziosalmi.github.io/zion
+
+      # Build the single native platform and push it by DIGEST (no tag). A clean
+      # single-platform manifest (provenance/sbom off) keeps the digest simple so
+      # `imagetools create` can fuse the two arches; SLSA provenance + SBOM are
+      # attested to the final manifest in the `container` job.
+      - name: Build & push by digest (${{ matrix.platform }})
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: false
+          sbom: false
+          cache-from: type=gha,scope=container-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=container-${{ matrix.arch }}
+          build-args: |
+            SOURCE_DATE_EPOCH=${{ env.SOURCE_DATE_EPOCH }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+
+      # Guard against the "arm64 manifest carries an amd64 binary" class of bug.
+      # Done on the NATIVE runner, so the extracted ELF is this arch with no QEMU
+      # and no manifest-list digest juggling — just build, extract, `file`.
+      - name: Verify this arch ships its own binary
+        run: |
+          REF="${REGISTRY}/${IMAGE_NAME}@${{ steps.build.outputs.digest }}"
+          docker create --name verify "$REF" >/dev/null
+          docker cp verify:/usr/local/bin/zion /tmp/zion >/dev/null
+          docker rm verify >/dev/null
+          got="$(file -b /tmp/zion)"
+          echo "${{ matrix.platform }}: ${got}"
+          case "$got" in
+            *"${{ matrix.want }}"*) ;;
+            *) echo "::error::${{ matrix.platform }} image binary is not ${{ matrix.want }}"; exit 1 ;;
+          esac
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          echo "${{ steps.build.outputs.digest }}" > "/tmp/digests/${{ matrix.arch }}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: container-digest-${{ matrix.arch }}
+          path: /tmp/digests/${{ matrix.arch }}
+          retention-days: 1
+          if-no-files-found: error
+
+  # Fuse the per-arch digests into one multi-arch manifest, then verify, sign
+  # (cosign keyless), and attest SBOM + SLSA provenance to the manifest digest.
+  container:
+    name: container (multi-arch manifest + cosign)
+    needs: [container-build]
+    if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write # push the manifest to GHCR
+      id-token: write # cosign keyless OIDC
+      attestations: write
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}
+    steps:
+      - name: Download per-arch digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: /tmp/digests
+          pattern: container-digest-*
+          merge-multiple: true
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Login to GHCR
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Image metadata (tags + labels)
+        id: meta
+        # Emit index-LEVEL annotations so the fused manifest list carries the
+        # OCI title/description/source that GHCR reads to link the package to
+        # this repo (a plain `imagetools create` would otherwise drop them).
+        env:
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: index
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
@@ -513,63 +623,42 @@ jobs:
             org.opencontainers.image.url=https://github.com/${{ github.repository }}
             org.opencontainers.image.documentation=https://fabriziosalmi.github.io/zion
 
-      - name: Build & push (linux/amd64,arm64)
-        id: push
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          provenance: mode=max
-          sbom: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          build-args: |
-            SOURCE_DATE_EPOCH=${{ env.SOURCE_DATE_EPOCH }}
-
-      # Guard against the "arm64 manifest carries an amd64 binary" class of
-      # bug (a Dockerfile that builds on $BUILDPLATFORM instead of
-      # $TARGETPLATFORM stamps one host-arch binary into every manifest). This
-      # is invisible to `imagetools inspect` — you have to look at the ELF.
-      - name: Verify each arch ships its own binary
+      - name: Create & push multi-arch manifest
+        id: manifest
         env:
-          DIGEST: ${{ steps.push.outputs.digest }}
+          META_JSON: ${{ steps.meta.outputs.json }}
         run: |
-          REF="${REGISTRY}/${IMAGE_NAME}@${DIGEST}"
-          fail=0
-          for entry in amd64:x86-64 arm64:aarch64; do
-            arch="${entry%%:*}"; want="${entry##*:}"
-            docker create --platform "linux/${arch}" --name "verify-${arch}" "$REF" >/dev/null
-            docker cp "verify-${arch}:/usr/local/bin/zion" "/tmp/zion-${arch}" >/dev/null
-            docker rm "verify-${arch}" >/dev/null
-            # Drop the locally-stored image before the next platform. `docker
-            # create --platform X image@<manifest-list-digest>` pulls the X image
-            # but stores it under the *manifest-list* digest; the next platform
-            # would then hit "cannot overwrite digest <same>" and abort. Removing
-            # it frees that digest slot so each arch pulls cleanly.
-            docker image rm "$REF" >/dev/null 2>&1 || true
-            got="$(file -b "/tmp/zion-${arch}")"
-            echo "linux/${arch}: ${got}"
-            case "$got" in
-              *"$want"*) ;;
-              *) echo "::error::linux/${arch} image binary is not ${want}"; fail=1 ;;
-            esac
-          done
-          [ "$fail" -eq 0 ] || { echo "multi-arch image is mislabeled — refusing to sign"; exit 1; }
+          set -euo pipefail
+          # Build the arg list as an array so tag/annotation values that contain
+          # spaces (the description) survive without word-splitting.
+          args=()
+          while IFS= read -r tag; do args+=(-t "$tag"); done < <(jq -r '.tags[]' <<< "$META_JSON")
+          while IFS= read -r ann; do args+=(--annotation "$ann"); done < <(jq -r '.annotations[]?' <<< "$META_JSON")
+          for f in /tmp/digests/*; do args+=("${REGISTRY}/${IMAGE_NAME}@$(cat "$f")"); done
+          printf 'imagetools create %s\n' "${args[*]}"
+          docker buildx imagetools create "${args[@]}"
+          first_tag="$(jq -r '.tags[0]' <<< "$META_JSON")"
+          manifest_digest="$(docker buildx imagetools inspect "$first_tag" --format '{{json .Manifest.Digest}}' | tr -d '"')"
+          echo "digest=${manifest_digest}" >> "$GITHUB_OUTPUT"
+          echo "ref=${REGISTRY}/${IMAGE_NAME}@${manifest_digest}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify the manifest lists both arches
+        run: |
+          set -euo pipefail
+          platforms="$(docker buildx imagetools inspect '${{ steps.manifest.outputs.ref }}' \
+            --format '{{range .Manifest.Manifests}}{{if .Platform}}{{.Platform.OS}}/{{.Platform.Architecture}} {{end}}{{end}}')"
+          echo "manifest platforms: ${platforms}"
+          echo "${platforms}" | grep -q 'linux/amd64' || { echo '::error::manifest missing linux/amd64'; exit 1; }
+          echo "${platforms}" | grep -q 'linux/arm64' || { echo '::error::manifest missing linux/arm64'; exit 1; }
 
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Sign image (keyless, Sigstore)
         env:
-          DIGEST: ${{ steps.push.outputs.digest }}
+          DIGEST: ${{ steps.manifest.outputs.digest }}
           TAGS: ${{ steps.meta.outputs.tags }}
         run: |
-          # Sign every tag@digest pair. Each signature is uploaded to Rekor
-          # and verifiable via:
-          #   cosign verify --certificate-identity-regexp ... ghcr.io/.../zion@sha256:...
           for tag in $TAGS; do
             cosign sign --yes "${tag}@${DIGEST}"
           done
@@ -577,14 +666,9 @@ jobs:
       - name: Generate CycloneDX SBOM (image)
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
         with:
-          image: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
+          image: ${{ steps.manifest.outputs.ref }}
           format: cyclonedx-json
           output-file: image-sbom.cdx.json
-          # The image SBOM is bound to the digest via cosign attestation
-          # in the next step. Don't double-attach it to the GitHub Release —
-          # that would (a) require `contents: write` here (this job is
-          # otherwise read-only) and (b) duplicate the binary SBOM that the
-          # `publish` job already attaches.
           upload-release-assets: false
           upload-artifact: false
 
@@ -592,7 +676,7 @@ jobs:
         uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          subject-digest: ${{ steps.push.outputs.digest }}
+          subject-digest: ${{ steps.manifest.outputs.digest }}
           sbom-path: image-sbom.cdx.json
           push-to-registry: true
 
@@ -600,5 +684,5 @@ jobs:
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          subject-digest: ${{ steps.push.outputs.digest }}
+          subject-digest: ${{ steps.manifest.outputs.digest }}
           push-to-registry: true

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ survives. See [zion.example.toml](zion.example.toml) for the full reference and
 
 ## Architecture
 
-```
+```text
 Client -> TLS 1.3 -> Security Gates -> Radix Router -> WAF Pipeline (5 gates) -> Proxy/Cache -> Upstream
                          |                                |
                     URI limit                  Aho-Corasick (~100 balanced / ~240 aggressive)

--- a/docs/adr/0007-bicapa-msrv.md
+++ b/docs/adr/0007-bicapa-msrv.md
@@ -53,7 +53,7 @@ binaries with.
   toolchain. Any transitive dep change that breaks the floor fails CI.
 - **Negative**: README / Cargo.toml carry a small "1.82 core / 1.88 full"
   caveat instead of a single number. We documented it explicitly:
-  ```
+  ```toml
   # MSRV is the *core* default-features build (TLS proxy + WAF + cache
   # + metrics). Opt-in features (acme, auth, init, http3) pull
   # crypto/i18n crates that have their own, faster-moving MSRV.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -34,7 +34,7 @@ defined in [0000-template.md](0000-template.md).
 When in doubt, write one. The cost of a stale ADR is "delete it";
 the cost of a missing ADR is a multi-week archaeology trip.
 
-## When NOT to write an ADR
+## When not to write an ADR
 
 - Pure refactors with no observable contract change.
 - Bug fixes.

--- a/docs/benchmarks/optimization.md
+++ b/docs/benchmarks/optimization.md
@@ -1,4 +1,4 @@
-# Optimization Log
+# Optimization log
 
 Changes made to improve throughput and latency, with rationale. Throughput claims reference the [`benchmarks/baseline/`](https://github.com/fabriziosalmi/zion/tree/master/benchmarks/baseline) harness.
 
@@ -12,14 +12,14 @@ Changes made to improve throughput and latency, with rationale. Throughput claim
 | Connection pool pre-warming | Fires GET to all upstreams before accept loop starts |
 | Thread-local route lookup cache | FNV hash of path maps to cached `Arc<ResolvedRoute>` (~5ns vs ~30ns radix tree) |
 
-## Compiler / Build
+## Compiler / build
 
 | Change | Rationale |
 |---|---|
 | `target-cpu=native` (.cargo/config.toml) | Unlocks NEON/AES-CE on Apple Silicon, AVX2/AES-NI on x86_64 |
 | PGO build script (`bench-pgo.sh`) | Two-phase profile-guided optimization for 10-20% additional throughput |
 
-## Hot Path Allocation Elimination
+## Hot path allocation elimination
 
 | Change | Rationale |
 |---|---|
@@ -28,7 +28,7 @@ Changes made to improve throughput and latency, with rationale. Throughput claim
 | WAF content-type: borrow from `parts.headers` | Eliminates `to_owned()` clone on POST/PUT/PATCH |
 | Cache key: `Arc::from()` direct | Skips intermediate `String` allocation on cache miss |
 
-## Lock / Contention Reduction
+## Lock / contention reduction
 
 | Change | Rationale |
 |---|---|
@@ -37,7 +37,7 @@ Changes made to improve throughput and latency, with rationale. Throughput claim
 | Histogram: non-cumulative differential buckets | 3 atomic ops per observation instead of 17; prefix sums at render time |
 | HTTP builder: `Arc<AutoBuilder>` | Per-connection clone is ref-count bump, not deep copy |
 
-## Data Structures
+## Data structures
 
 | Change | Rationale |
 |---|---|
@@ -46,7 +46,7 @@ Changes made to improve throughput and latency, with rationale. Throughput claim
 | Host validation: single-pass byte scan | Replaces 8 separate `contains()` calls |
 | CORS origin: FNV hash set | O(1) lookup replaces `Vec` linear scan; case-insensitive via pre-lowercased storage |
 
-## WAF Pipeline
+## WAF pipeline
 
 | Change | Rationale |
 |---|---|
@@ -140,7 +140,7 @@ Changes made to improve throughput and latency, with rationale. Throughput claim
 | Thread-local route LRU | FNV hash of path; O(1) get/insert/evict via intrusive doubly-linked list (capacity 256 per worker). Replaces a previous "first 256 then no more inserts" map that could be locked out by a flood of distinct paths. |
 | Connection pool pre-warming | Fires GET to all upstreams at startup |
 
-## Hyper Tuning
+## Hyper tuning
 
 | Change | Rationale |
 |---|---|

--- a/docs/config/auth.md
+++ b/docs/config/auth.md
@@ -8,7 +8,7 @@ Zion supports per-route JWT validation as an optional authentication gate. Token
 
 ## Configuration
 
-### HMAC (Symmetric)
+### HMAC (symmetric)
 
 For internal microservices using shared secrets:
 
@@ -21,7 +21,7 @@ audience = "api.internal"
 forward_claims = true
 ```
 
-### OIDC (Asymmetric)
+### OIDC (asymmetric)
 
 For external identity providers (Auth0, Keycloak, Okta):
 
@@ -34,7 +34,7 @@ audience = "api.example.com"
 forward_claims = true
 ```
 
-### Route Assignment
+### Route assignment
 
 ```toml
 [[route]]
@@ -55,7 +55,7 @@ waf = true
 | `audience` | string | — | Expected `aud` claim (optional) |
 | `forward_claims` | bool | `true` | Inject `X-Auth-Subject` and `X-Auth-Email` headers to upstream |
 
-## Supported Algorithms
+## Supported algorithms
 
 | Algorithm | Type | Use Case |
 |-----------|------|----------|
@@ -70,7 +70,7 @@ waf = true
 3. **Expired token**: Returns `401 Unauthorized` with body `token expired`
 4. **Valid token**: Request proceeds to upstream with optional claim headers
 
-### Claim Forwarding
+### Claim forwarding
 
 When `forward_claims = true`, decoded claims are injected as headers:
 
@@ -79,18 +79,18 @@ When `forward_claims = true`, decoded claims are injected as headers:
 | `X-Auth-Subject` | `sub` | User ID / subject |
 | `X-Auth-Email` | `email` | User email (if present in token) |
 
-### JWKS Refresh
+### JWKS refresh
 
 - JWKS is fetched at startup and refreshed every **1 hour**
 - On fetch failure, retries with **exponential backoff** (5s, 10s, 20s, ... up to 1h)
 - HTTP client failure is retried indefinitely (never gives up permanently)
 - Clock skew tolerance: **30 seconds** (leeway for distributed systems)
 
-## Bearer Token Extraction
+## Bearer token extraction
 
 The `Authorization` header is parsed case-insensitively per [RFC 6750 Section 2.1](https://datatracker.ietf.org/doc/html/rfc6750#section-2.1):
 
-```
+```http
 Authorization: Bearer eyJhbGciOiJSUzI1NiJ9...
 Authorization: bearer eyJhbGciOiJSUzI1NiJ9...    # also accepted
 Authorization: BEARER eyJhbGciOiJSUzI1NiJ9...    # also accepted

--- a/docs/config/cors.md
+++ b/docs/config/cors.md
@@ -14,7 +14,7 @@ upstream = "backend"
 cors     = { allowed_origins = ["https://app.example.com", "https://admin.example.com"], allowed_headers = ["Content-Type", "Authorization", "X-Requested-With"], max_age = 86400 }
 ```
 
-### Wildcard Origin
+### Wildcard origin
 
 ```toml
 [[route]]
@@ -33,17 +33,17 @@ When `*` is present, `Access-Control-Allow-Origin: *` is returned for all reques
 | `allowed_headers` | string[] | `["Content-Type", "Authorization", "X-Requested-With"]` | Headers allowed in requests |
 | `max_age` | u64 | `86400` (24 hours) | Seconds the browser may cache pre-flight results |
 
-## Allowed Methods
+## Allowed methods
 
 The following methods are always permitted when CORS is enabled:
 
-```
+```text
 GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS
 ```
 
 This list is not configurable -- it matches Zion's method whitelist.
 
-## Pre-flight Handling
+## Pre-flight handling
 
 When CORS is enabled and the request is `OPTIONS` with a matching `Origin` header:
 
@@ -54,7 +54,7 @@ When CORS is enabled and the request is `OPTIONS` with a matching `Origin` heade
 
 For non-OPTIONS requests with a matching origin, Zion adds `Access-Control-Allow-Origin` to the proxied response.
 
-## Origin Matching
+## Origin matching
 
 - Origins are compared as exact string matches against the `Origin` request header
 - If the origin is not in the allowed list, no CORS headers are added (browser enforces the restriction)

--- a/docs/config/http3.md
+++ b/docs/config/http3.md
@@ -6,7 +6,7 @@ Build with `--features http3` to enable HTTP/3 QUIC support.
 
 Zion supports HTTP/3 over QUIC alongside HTTP/1.1 and HTTP/2 on the same port. QUIC provides zero-RTT connection establishment, built-in encryption (TLS 1.3), and connection migration for mobile clients.
 
-## How It Works
+## How it works
 
 When `--features http3` is enabled:
 
@@ -15,7 +15,7 @@ When `--features http3` is enabled:
 3. HTTP/3 semantics via the `h3` library
 4. The `Alt-Svc` header is automatically injected on HTTP/1.1 and HTTP/2 responses to advertise HTTP/3 availability
 
-```
+```http
 Alt-Svc: h3=":443"; ma=86400
 ```
 
@@ -32,7 +32,7 @@ cargo build --release --features "http3,acme,auth"
 
 ## Architecture
 
-```
+```text
 Client (UDP)  ─── QUIC ───  Zion (:443 UDP)  ─── HTTP/1.1 ───  Upstream
 Client (TCP)  ─── TLS  ───  Zion (:443 TCP)  ─── HTTP/1.1 ───  Upstream
 ```
@@ -43,7 +43,7 @@ Both TCP (HTTP/1.1 + HTTP/2) and UDP (HTTP/3) listeners share:
 - The same WAF pipeline
 - The same security headers
 
-## TLS Certificate Hot-Reload
+## TLS certificate hot-reload
 
 When certificates are hot-reloaded, both the TCP TLS acceptor **and** the QUIC configuration are updated simultaneously via a `tokio::sync::watch` channel. Zero downtime for both protocols.
 

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -90,7 +90,7 @@ top-level `[cors]` section — see [CORS](./cors). Keys:
 | `allowed_headers` | string[] | `["Content-Type", "Authorization", "X-Requested-With"]` | Additional allowed headers |
 | `max_age` | u64 | `86400` | Pre-flight cache duration in seconds |
 
-## Environment Variables
+## Environment variables
 
 | Variable | Description |
 |---|---|

--- a/docs/config/routing.md
+++ b/docs/config/routing.md
@@ -2,7 +2,7 @@
 
 Zion routes requests using a radix tree (via the [`matchit`](https://crates.io/crates/matchit) crate -- the same engine used by Axum). Route lookup is ~15ns regardless of route count.
 
-## Route Patterns
+## Route patterns
 
 Routes are defined as `[[route]]` entries in `zion.toml`. Order does not matter -- the radix tree handles priority automatically.
 
@@ -27,7 +27,7 @@ path = "/{*rest}"
 upstream = "frontend"
 ```
 
-### Path Syntax
+### Path syntax
 
 | Pattern | Matches | Example |
 |---|---|---|
@@ -37,7 +37,7 @@ upstream = "frontend"
 
 More specific routes take priority over wildcards. `/api/v1/events/stream` matches before `/api/{*rest}`.
 
-## Host-Based Routing (Virtual Hosting)
+## Host-based routing (virtual hosting)
 
 Bind a route to one or more `hosts` to serve different backends for different domains on the same listener — the `Host` header (HTTP/1) or `:authority` (HTTP/2) selects the route. A route **without** `hosts` is *shared*: it matches every host and acts as a fallback.
 
@@ -63,7 +63,7 @@ internal_only = true
 
 The same path now serves different backends per host — `api.example.com/` and `app.example.com/` route independently, which a path-only router cannot express.
 
-### Matching Precedence
+### Matching precedence
 
 For a request authority, Zion resolves in this order:
 
@@ -73,7 +73,7 @@ For a request authority, Zion resolves in this order:
 
 An exact host beats a wildcard, and a matched host never falls through to *another* host's routes — only to the shared layer.
 
-### Host Normalization
+### Host normalization
 
 Authorities are normalized before matching: lowercased, port stripped (`api.example.com:8443` → `api.example.com`), and a trailing FQDN dot removed. Config `hosts` entries must be canonical bare hostnames — no scheme, path, port, or trailing dot (uppercase is folded). Only leading-label wildcards (`*.example.com`) are supported.
 
@@ -85,7 +85,7 @@ Authorities are normalized before matching: lowercased, port stripped (`api.exam
 
 Host routing is **opt-in and zero-cost when unused**: with no `hosts` anywhere, lookups skip authority extraction and behave exactly as the path-only router. When active, a lookup adds one hash-map probe plus authority normalization, and the thread-local route cache is keyed on `(host, path)` so different domains never share a cache slot.
 
-## Route Modes
+## Route modes
 
 | Mode | Behavior |
 |---|---|
@@ -94,7 +94,7 @@ Host routing is **opt-in and zero-cost when unused**: with no `hosts` anywhere, 
 | `static_cache` | Serves from in-memory cache on hit; fetches and caches on miss |
 | `websocket` | Explicit WebSocket mode (also auto-detected via `Upgrade: websocket` header on any route) |
 
-## Upstream Resolution
+## Upstream resolution
 
 Routes reference upstreams by name. Two formats are supported:
 
@@ -114,7 +114,7 @@ If both formats define the same name, the `[upstream.<name>]` format takes prece
 
 At startup, all upstream URLs are pre-parsed into `Scheme` + `Authority`. No URI parsing occurs on the hot path.
 
-## Internal-Only Routes
+## Internal-only routes
 
 ```toml
 [[route]]
@@ -130,7 +130,7 @@ When `internal_only = true`, requests from non-private IPs receive `403 Forbidde
 - `169.254.0.0/16` (link-local)
 - `::1` (IPv6 loopback)
 
-## Content-Security-Policy (Per-Route)
+## Content-Security-Policy (per-route)
 
 You can set a per-route `Content-Security-Policy` header:
 
@@ -153,13 +153,13 @@ upstream = "frontend"
 
 The CSP string is **pre-parsed** into a `HeaderValue` at startup — zero cost on the hot path (just a header clone).
 
-### When to Use
+### When to use
 
 - **Admin panels / internal tools**: Lock down with a strict CSP (`default-src 'self'`)
 - **SPA frontends**: Leave unset and let the frontend's own CSP pass through
 - **APIs**: Usually not needed (no HTML rendering)
 
-## Startup Validation
+## Startup validation
 
 Zion validates all routes at boot:
 

--- a/docs/config/tls.md
+++ b/docs/config/tls.md
@@ -2,7 +2,7 @@
 
 Zion terminates TLS using [rustls](https://github.com/rustls/rustls) with the aws-lc-rs cryptography backend. No OpenSSL dependency.
 
-## Basic Configuration
+## Basic configuration
 
 ```toml
 [tls]
@@ -12,7 +12,7 @@ key_path = "/etc/ssl/zion/tls.key"
 
 Both files must be PEM-encoded. The certificate file should contain the full chain (leaf + intermediates).
 
-## TLS Version Control
+## TLS version control
 
 ```toml
 [tls]
@@ -22,7 +22,7 @@ min_version = "1.3"   # Default: TLS 1.3 only (fastest handshake)
 
 TLS 1.3 is the default because it has a shorter handshake (1-RTT vs 2-RTT) and mandatory forward secrecy. Set `"1.2"` only if you need to support older clients.
 
-## ALPN Negotiation
+## ALPN negotiation
 
 ```toml
 [tls]
@@ -30,7 +30,7 @@ alpn = ["h2", "http/1.1"]   # Default: HTTP/2 preferred
 # alpn = ["http/1.1"]       # HTTP/1.1 only
 ```
 
-## Multi-Domain SNI
+## Multi-domain SNI
 
 For multiple domains on the same IP, add `[[tls.sni]]` entries:
 
@@ -59,7 +59,7 @@ Zion selects the resolver mode at boot:
 
 If the client's SNI does not match any entry, the default certificate is used as fallback.
 
-## Hot-Reload
+## Hot-reload
 
 ```toml
 [tls]
@@ -76,7 +76,7 @@ When enabled, Zion watches the certificate directory using `notify` (inotify on 
 
 If the reload fails (bad cert, missing file), the previous configuration is retained and an error is logged. No downtime in any case.
 
-## Session Resumption & 0-RTT
+## Session resumption & 0-RTT
 
 Zion configures aggressive session resumption by default:
 
@@ -88,7 +88,7 @@ Zion configures aggressive session resumption by default:
 
 Each cached/ticketed session avoids a full ECDHE key exchange (~1ms saved per resumed handshake).
 
-### 0-RTT Replay Protection
+### 0-RTT replay protection
 
 TLS 1.3 0-RTT allows clients to send data in the first flight on resumed connections, saving ~35% handshake latency. However, early data can be **replayed** by network attackers.
 
@@ -103,7 +103,7 @@ When a non-idempotent request arrives on early data, Zion responds with `425 Too
 
 The early data flag is consumed via an `AtomicBool` on first request per connection — only the first request can be 0-RTT, all subsequent requests on the same connection proceed normally.
 
-## TLS Handshake Timeout
+## TLS handshake timeout
 
 TLS handshakes are limited to 10 seconds. Connections that do not complete the handshake within this window are dropped. Failed handshakes are counted in `zion_tls_handshake_errors`.
 
@@ -134,7 +134,7 @@ renew_before_days = 30
 | `state_dir` | `/var/lib/zion/acme` | Directory for account credentials and cert/state persistence |
 | `renew_before_days` | `30` | Start renewal this many days before expiry |
 
-### How It Works
+### How it works
 
 1. Background task checks certificate expiry every 12 hours
 2. If cert expires within `renew_before_days`, initiates ACME order
@@ -143,11 +143,11 @@ renew_before_days = 30
 5. Writes cert + key to `cert_path` / `key_path`
 6. Hot-reloads TLS via `ArcSwap` — zero downtime
 
-### Account Persistence
+### Account persistence
 
 ACME account credentials are saved to `state_dir/account.json` on first run. Subsequent runs reuse the existing account.
 
-### Staging / Testing
+### Staging / testing
 
 For testing, use the Let's Encrypt staging environment:
 

--- a/docs/config/waf.md
+++ b/docs/config/waf.md
@@ -2,7 +2,7 @@
 
 The WAF is configured per-route via named profiles. Each profile controls the **detection mode** (which Aho-Corasick pattern set is scanned), the **entropy gate** (threshold + kill-switch), and the body inspection limits (size, JSON depth, string length, content-type allow-list).
 
-## Defining Profiles
+## Defining profiles
 
 ```toml
 [waf_profile.strict]
@@ -29,7 +29,7 @@ allowed_content_types = ["multipart/form-data", "application/octet-stream"]
 entropy_check = false        # binary uploads are high-entropy by nature
 ```
 
-## Assigning Profiles to Routes
+## Assigning profiles to routes
 
 ```toml
 [[route]]
@@ -43,7 +43,7 @@ upstream = "api"
 waf_profile = "upload"
 ```
 
-## Profile Parameters
+## Profile parameters
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
@@ -56,7 +56,7 @@ waf_profile = "upload"
 | `entropy_check` | bool | `true` | Enable Gate 4 (Shannon entropy). Disable on routes that legitimately accept high-entropy bodies (binary uploads, encrypted blobs). |
 | `entropy_threshold` | f64 | `6.5` | Bits/byte. Bodies above this are denied. Default sits above pure base64 (theoretical max 6.0); random/encrypted blobs land at 7.5–8.0. |
 
-## Detection Modes
+## Detection modes
 
 `mode` selects which pattern set Gate 3 scans. Both modes share the same fail-fast pipeline; only the Aho-Corasick automaton differs.
 
@@ -67,7 +67,7 @@ waf_profile = "upload"
 
 The two automata are built lazily (on first hit per process) and cached; switching profiles costs nothing at request time. A request denied by an aggressive-only pattern returns the same `400` body and `waf_denied` metric as a balanced denial — there is no separate counter.
 
-## Content-Type Enforcement
+## Content-Type enforcement
 
 When `deny_unknown_content_types = true` (default):
 
@@ -78,7 +78,7 @@ When `deny_unknown_content_types = true` (default):
 
 When set to `false`, requests with unlisted content types pass through without body inspection.
 
-## Legacy Configuration
+## Legacy configuration
 
 The older inline syntax is still supported:
 
@@ -92,7 +92,7 @@ max_body_mb = 10
 
 This creates an implicit profile with default values and the specified `max_body_mb`. Named profiles are recommended for new configurations.
 
-## WAF Behavior by HTTP Method
+## WAF behavior by HTTP method
 
 | Method | Body inspected | Gates applied |
 |---|---|---|
@@ -102,7 +102,7 @@ This creates an implicit profile with default values and the specified `max_body
 
 Empty bodies on POST/PUT/PATCH are allowed without inspection.
 
-## Tuning Guidelines
+## Tuning guidelines
 
 | Use case | `mode` | `max_body_mb` | `max_depth` | `entropy_check` | `deny_unknown_content_types` |
 |---|---|---|---|---|---|
@@ -114,11 +114,11 @@ Empty bodies on POST/PUT/PATCH are allowed without inspection.
 
 See [WAF Pipeline](/security/) for the full per-gate description and the source-of-truth pattern listing.
 
-## WAF Pipeline (5-Gate Architecture)
+## WAF pipeline (5-Gate architecture)
 
 Every request with a body passes through a **5-gate pipeline** in strict order. Each gate is O(N) or O(1). The pipeline **fail-fasts** — the first gate that triggers a violation returns `400 Bad Request` (or `413 Payload Too Large` for Gate 1) without executing subsequent gates.
 
-```
+```text
 Request → Gate 1 → Gate 2 → Gate 3 → Gate 4 → Gate 5 → Allow
               │         │         │         │         │
             Size    Content-  Injection  Entropy    JSON
@@ -135,7 +135,7 @@ Request → Gate 1 → Gate 2 → Gate 3 → Gate 4 → Gate 5 → Allow
 
 GET, HEAD, OPTIONS requests skip Gates 2–5 (no body to inspect). DELETE bodies are inspected (RFC 9110 allows them and some APIs use them).
 
-## Built-in Injection Patterns
+## Built-in injection patterns
 
 Gate 3 uses an [Aho-Corasick](https://en.wikipedia.org/wiki/Aho%E2%80%93Corasick_algorithm) automaton — a single O(N) pass over the body that scans all patterns simultaneously. No regex, no backtracking, no ReDoS risk.
 
@@ -175,11 +175,11 @@ Before declaring a body clean, Gate 3 runs the scanner over a **normalised** cop
 
 Earlier docs claimed Zion "rejects requests on detection of double encoding." That has never been the behaviour and would have been wrong: legitimate URLs can contain double-encoded characters (e.g., search queries about URL encoding itself). What Zion actually does is *re-scan after each decode pass*.
 
-## Extending the Pattern Set
+## Extending the pattern set
 
 Patterns are compiled into the binary at build time via two `OnceLock<AhoCorasick>` automata (one per mode), built lazily on first hit. To add custom patterns:
 
-### Step 1: Edit `src/waf.rs`
+### Step 1: edit `src/waf.rs`
 
 The two constants live near the top of the file:
 
@@ -204,13 +204,13 @@ const AGGRESSIVE_EXTRA_PATTERNS: &[&str] = &[
 
 The runtime entry point is `scanner_for(mode)` (replaced the older `get_scanner()` helper); both automata are accessed through it.
 
-### Step 2: Rebuild
+### Step 2: rebuild
 
 ```bash
 cargo build --release
 ```
 
-### Guidelines for Custom Patterns
+### Guidelines for custom patterns
 
 | Do | Don't |
 |---|---|
@@ -218,6 +218,6 @@ cargo build --release
 | Use lowercase (matching is ASCII case-insensitive) | Use regex syntax — not supported |
 | Test with `cargo test --release --bin zion` after adding | Match legitimate API payloads (run your real corpus through the scanner before committing) |
 
-### Performance Impact
+### Performance impact
 
 The Aho-Corasick automaton scans all patterns in a single pass regardless of count. Adding 10 or 100 patterns adds no per-request CPU cost — the automaton state machine grows in memory (≈50 bytes per pattern) but scan throughput stays O(N) in body length.

--- a/docs/deploy/index.md
+++ b/docs/deploy/index.md
@@ -94,7 +94,7 @@ docker run -d \
   --name zion zion
 ```
 
-## Config Validation
+## Config validation
 
 Zion validates the entire configuration at startup and exits with code 1 on any error. Checked items:
 
@@ -112,7 +112,7 @@ Run a dry validation by starting Zion and checking exit code:
 ZION_CONFIG=./zion.toml ./zion && echo "Config OK"
 ```
 
-## Graceful Shutdown
+## Graceful shutdown
 
 Zion handles `SIGINT` (Ctrl+C) and `SIGTERM`:
 
@@ -122,7 +122,7 @@ Zion handles `SIGINT` (Ctrl+C) and `SIGTERM`:
 
 This works by acquiring all semaphore permits (connection limit). When all active connections release their permits, the drain is complete.
 
-## Certificate Renewal
+## Certificate renewal
 
 With `hot_reload = true` (default), certificate renewal requires no restart:
 

--- a/docs/deploy/observability.md
+++ b/docs/deploy/observability.md
@@ -22,11 +22,11 @@ always respond even under load. `/metrics`, `/_zion/snapshot.json`, and
 `/_zion/cache/purge` are restricted to internal source IPs (external clients get
 `403`).
 
-## Prometheus Metrics
+## Prometheus metrics
 
 `GET /metrics` returns counters in Prometheus text exposition format (`text/plain; version=0.0.4`).
 
-### Counter Reference
+### Counter reference
 
 This table is the authoritative list — every counter `/metrics` emits appears
 here. All are lock-free atomic `u64` (a `fetch_add` with `Relaxed` ordering,
@@ -118,7 +118,7 @@ output they also carry trace-ID exemplars.
 | `zion_upstream_duration_seconds` | Time spent waiting on the upstream |
 | `zion_tls_handshake_duration_seconds` | TLS handshake duration |
 
-### Runtime Resource Gauges
+### Runtime resource gauges
 
 `/metrics` also exposes process self-introspection gauges, so you can watch the daemon's own footprint live — and catch a slow leak (for example ~1 MB per 1000 connections) by its RSS slope, without restarting under a profiler.
 
@@ -130,7 +130,7 @@ output they also carry trace-ID exemplars.
 
 The two `process_*` gauges are sampled from `/proc/self` **once per scrape** — the `/metrics` render is cached for one second, so the two small file reads never run on the hot connection path. The same values are surfaced in `/_zion/snapshot.json` and the `zion top` TUI ("rss" / "open fds" rows). They are Linux-only; on macOS/Windows they render as `0` so one dashboard works across hosts. Run `zion doctor` to confirm the host actually exposes `/proc/self/status` — a hardened container runtime that masks `/proc` will report `0` here, and the check warns you up front.
 
-### Prometheus Scrape Config
+### Prometheus scrape config
 
 ```yaml
 scrape_configs:
@@ -142,7 +142,7 @@ scrape_configs:
       insecure_skip_verify: true  # if using self-signed certs
 ```
 
-### Grafana Dashboard
+### Grafana dashboard
 
 An importable dashboard covering the whole fleet — golden signals, security,
 TLS/upstream, a **leak-watch** row (RSS slope + open FDs per instance), protocols
@@ -205,7 +205,7 @@ Every HTTPS response includes an `X-Request-ID` header for request tracing.
 
 The counter is a global atomic `u64`, ensuring uniqueness across all concurrent requests.
 
-## Structured Logging
+## Structured logging
 
 Configure log format in `[server]`:
 
@@ -214,15 +214,15 @@ Configure log format in `[server]`:
 log_format = "json"   # or "text" (default)
 ```
 
-### Text Format (default, development)
+### Text format (default, development)
 
-```
+```text
 config loaded from zion.toml
   route /api/{*rest} -> backend [waf=strict, cache=off]
 ZION ONLINE.
 ```
 
-### JSON Format (production)
+### JSON format (production)
 
 ```json
 {"ts":"1712000000","level":"info","event":"config","msg":"loaded from zion.toml"}
@@ -238,7 +238,7 @@ JSON logs are structured for ingestion by Loki, ELK, Datadog, or any log aggrega
 | `event` | Event category (e.g., `config`, `health`, `shutdown`, `tls`) |
 | `msg` | Human-readable message |
 
-## Upstream Health Monitoring
+## Upstream health monitoring
 
 Zion runs a background health checker that pings all unique upstream URLs every 30 seconds:
 

--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -3,9 +3,9 @@
 Zion is a single async Rust binary built on Tokio, Hyper, and rustls. <!-- zion-stats:modules-lines (kept in sync by scripts/update-readme-stats.sh) -->
 ~15,900 lines across 21 source files.
 
-## Module Map
+## Module map
 
-```
+```text
 src/
 ├── main.rs        # Entrypoint, HTTPS/HTTP listeners, connection handling, mTLS fingerprint extraction
 ├── dispatch.rs    # Request pipeline: routing (LRU + radix), WAF gates, cache, CORS, metrics; thread-local route LRU lives here
@@ -30,9 +30,9 @@ src/
 └── logging.rs     # Structured logging (text/JSON)
 ```
 
-## Request Lifecycle
+## Request lifecycle
 
-```
+```text
 Client
   │
   ├─ HTTP :80 ──────► ACME challenge proxy OR 301 → HTTPS
@@ -128,7 +128,7 @@ Client
   Client
 ```
 
-## Design Decisions
+## Design decisions
 
 | Decision | Rationale |
 |---|---|
@@ -151,11 +151,11 @@ Client
 | `SO_BUSY_POLL` (Linux) | Spin-poll NIC queue 50us for lower p99 latency |
 | Semaphore for connection limit | Bound from detected RAM: `(RAM_MB / 4) * 1024 / 50`, clamped 1k-100k |
 
-## Concurrency Model
+## Concurrency model
 
 Zion uses Tokio's multi-threaded runtime. Worker count is set to available CPU cores (N-1 on machines with >4 cores), pinned to physical cores via `core_affinity`. Each accepted connection is a spawned task. Total concurrent connections are bounded by a Tokio semaphore.
 
-## Optional Features
+## Optional features
 
 | Feature | Flag | Description |
 |---------|------|-------------|

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -22,7 +22,7 @@ Zion is a TLS reverse proxy with a built-in WAF, written in Rust. One binary, on
 | ML-augmented WAF (experimental) | 16-dim ONNX model on the WAF hot path, 200µs p99 budget. Score is a signal, never a hard gate; ships no bundled model. `--features ml-waf` |
 | AIMP mesh (v0.2.x) | Ed25519-signed UDP gossip of WAF + IP-reputation deltas across a fleet. Anti-entropy convergence. `--features sovereign-aimp` |
 
-## When to Use Zion
+## When to use Zion
 
 - You need a TLS termination proxy with integrated request inspection
 - You are proxying to internal HTTP services (APIs, SSR frameworks, SPAs)

--- a/docs/guide/observability.md
+++ b/docs/guide/observability.md
@@ -49,7 +49,7 @@ To verify export end-to-end without a collector, point `OTEL_EXPORTER_OTLP_ENDPO
 
 `/metrics` is now OpenMetrics-compatible. Histogram buckets gain a per-bucket exemplar suffix that links to the latest slow request:
 
-```
+```text
 zion_request_duration_seconds_bucket{le="0.512"} 17 # {trace_id="0af7651916cd43dd8448eb211c80319c"} 0.481234 1714896000.123
 ```
 
@@ -73,7 +73,7 @@ classified against the baked-in CIDR dataset (an O(log N) binary search
 + one relaxed `fetch_add` — no allocation, no syscall, no external GeoIP
 DB) and tallied:
 
-```
+```text
 zion_sovereign_classifications_total{class="eu"}              42891
 zion_sovereign_classifications_total{class="gov_eu"}            317
 zion_sovereign_classifications_total{class="residential_eu"}  18044
@@ -108,7 +108,7 @@ mesh-reputation threshold) into a hard `403` deny — e.g. `deny =
 classes pass (the sovereign allowlist *by complement*). Denials are
 counted, split by reason:
 
-```
+```text
 zion_enforcement_denied_total{reason="class"}       1043
 zion_enforcement_denied_total{reason="mesh_score"}    77
 ```
@@ -123,7 +123,7 @@ pays wall-clock and socket budget. A hard global ceiling (`max_concurrent`)
 sheds back to an immediate `403` at capacity, and is clamped at config-load
 to ¼ of the global connection pool so held connections can't pin admission.
 
-```
+```text
 zion_tarpit_active        12     # gauge: connections currently held
 zion_tarpit_total       4310     # counter: total ever held
 zion_tarpit_shed_total   118     # counter: shed to immediate 403 at the ceiling

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -8,7 +8,7 @@
 - A TLS certificate and key (PEM format)
 - An upstream HTTP service to proxy to
 
-## Build from Source
+## Build from source
 
 ```bash
 git clone https://github.com/fabriziosalmi/zion.git
@@ -18,7 +18,7 @@ cargo build --release
 
 The binary is at `target/release/zion` (~5 MB).
 
-## Minimal Configuration
+## Minimal configuration
 
 Create `zion.toml`:
 
@@ -44,7 +44,7 @@ path = "/{*rest}"
 upstream = "backend"
 ```
 
-## Generate a Self-Signed Certificate (dev only)
+## Generate a self-signed certificate (dev only)
 
 ```bash
 mkdir -p /etc/ssl/zion
@@ -66,7 +66,7 @@ ZION_CONFIG=/etc/zion/zion.toml ./target/release/zion
 
 On startup, Zion prints a platform detection matrix and route table:
 
-```
+```text
 ZION EDGE GATEWAY -- initializing...
   ┌────────────────────────────────────────────┐
   │ PLATFORM DETECTION                         │
@@ -98,7 +98,7 @@ curl -I http://localhost/
 # => 301 Moved Permanently, Location: https://...
 ```
 
-## Next Steps
+## Next steps
 
 - [Configuration Reference](/config/) -- all TOML sections
 - [WAF Configuration](/config/waf) -- profiles and tuning

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,7 +45,7 @@ features:
 
 <div class="benchmark-highlight">
 
-## Performance at a Glance
+## Performance at a glance
 
 <div class="stat-grid">
   <div class="stat-card">
@@ -85,7 +85,7 @@ Native benchmark on Apple M4, 5 runs x 10s, c=100. Rust backend. Tracked per-com
 | HTTP/3 QUIC | Patch | No | Yes | Yes | Yes | No | **Feature-gated** |
 | JWT/OIDC auth | No | No | Yes | Yes | Yes | No | **Feature-gated** |
 
-## Quick Start
+## Quick start
 
 ```bash
 cargo build --release

--- a/docs/mesh/integration.md
+++ b/docs/mesh/integration.md
@@ -209,7 +209,7 @@ checklist:
 5. **Clock skew?** AIMP envelopes include a timestamp; large skews
    may cause replays to be rejected. NTP is required.
 
-## Deferred / Tracked
+## Deferred / tracked
 
 Items listed in ADR-0008 "Negative consequences" or referenced above:
 

--- a/docs/perf/mesh-overhead.md
+++ b/docs/perf/mesh-overhead.md
@@ -61,7 +61,7 @@ The `(bench TODO)` rows will land alongside [#72 (Bench: --features
 mesh cost at idle and at saturation)](https://github.com/fabriziosalmi/zion/issues/72)
 once the mesh has a saturation workload to measure against.
 
-## What's NOT measured here
+## What's not measured here
 
 - **Tracing span overhead** — `tracing::info_span!` is gated by the
   active subscriber. Under `RUST_LOG=warn` (production default) the

--- a/docs/perf/microbench.md
+++ b/docs/perf/microbench.md
@@ -12,7 +12,7 @@ changes* (NUMA sharding, io_uring, kTLS, BPF, scanner tweaks).
 
 ## Layout
 
-```
+```text
 benches/
   waf_streaming.rs       — buffered vs StreamingScanner, 1KB→10MB sweep
   sovereign.rs           — record_classification + classify

--- a/docs/perf/pgo.md
+++ b/docs/perf/pgo.md
@@ -31,7 +31,7 @@ wire-up over a few release cycles — see [Future expansion](#future-expansion).
 
 ## How the build works
 
-```
+```text
             ┌────────────────────────────────────────────────────────┐
             │ Phase 1: instrumented build                            │
             │   RUSTFLAGS="-Cprofile-generate=$PGO_DIR"              │

--- a/docs/security/hardening.md
+++ b/docs/security/hardening.md
@@ -2,7 +2,7 @@
 
 Zion applies security defaults that can be overridden via configuration.
 
-## Response Headers
+## Response headers
 
 Every HTTPS response includes these security headers (stored as static `HeaderValue` constants):
 
@@ -15,21 +15,21 @@ Every HTTPS response includes these security headers (stored as static `HeaderVa
 | `Permissions-Policy` | `camera=(), microphone=(), geolocation=(), payment=()` | Disable browser APIs |
 | `Server` | *(removed)* | No server identification |
 
-## Method Whitelist
+## Method whitelist
 
 Only these HTTP methods are accepted. All others return `405 Method Not Allowed`:
 
-```
+```http
 GET  POST  PUT  PATCH  DELETE  HEAD  OPTIONS
 ```
 
 This blocks `TRACE` (cross-site tracing), `CONNECT` (proxy tunneling), and non-standard methods before any processing occurs.
 
-## URI Length Limit
+## URI length limit
 
 Requests with URI paths exceeding **8,192 bytes** return `414 URI Too Long`.
 
-## Header Limits
+## Header limits
 
 Hyper is configured with reduced header limits compared to defaults:
 
@@ -38,7 +38,7 @@ Hyper is configured with reduced header limits compared to defaults:
 | Max header count | 64 | 100 |
 | Max header buffer | 16 KB | 400 KB |
 
-## Rate Limiting
+## Rate limiting
 
 Per-IP rate limiting using `DashMap` with atomic counters:
 
@@ -59,17 +59,17 @@ When `rate_limit_rps = 0` (default), rate limiting is disabled — the code retu
 | Upstream connect | 3 seconds (configurable) | Fail fast on dead upstreams |
 | Connection pool idle | 30 seconds | Reclaim unused upstream connections |
 
-## Connection Limit
+## Connection limit
 
 Maximum concurrent connections are bounded by a `Semaphore` sized to available RAM:
 
-```
+```text
 conn_limit = (RAM_MB / 4) * 1024 / 50    # ~50KB per TLS connection estimate
 ```
 
 Clamped to 1,000–100,000. Connections beyond the limit are silently dropped at the TCP level.
 
-## HTTP to HTTPS Redirect
+## HTTP to HTTPS redirect
 
 Port 80 serves only two purposes:
 
@@ -80,18 +80,18 @@ The `Host` header is validated before use in the redirect URL:
 - Must be non-empty and <= 253 characters
 - Must not contain `/`, `\`, `@`, newlines, or spaces
 
-## Internal-Only Routes
+## Internal-only routes
 
 Routes marked with `internal_only = true` are restricted to private IPs:
 
-```
+```text
 127.0.0.0/8, 10.0.0.0/8, 172.16.0.0/12,
 192.168.0.0/16, 169.254.0.0/16, ::1
 ```
 
 External requests receive `403 Forbidden`.
 
-## Linux-Specific Options
+## Linux-specific options
 
 On Linux, Zion enables additional socket options when the kernel supports them:
 
@@ -99,22 +99,22 @@ On Linux, Zion enables additional socket options when the kernel supports them:
 - `TCP_FASTOPEN`: TFO for returning clients (requires kernel support)
 - `SO_REUSEPORT`: Kernel-level connection distribution across listeners
 
-## 0-RTT Replay Protection
+## 0-RTT replay protection
 
 TLS 1.3 0-RTT is enabled but gated by HTTP method. Non-idempotent methods (`POST`, `PUT`, `PATCH`, `DELETE`) on early data receive `425 Too Early` (RFC 8470). Only `GET` and `HEAD` are allowed on 0-RTT data.
 
 See [TLS Configuration → 0-RTT Replay Protection](../config/tls.md#_0-rtt-replay-protection) for details.
 
-## Hop-by-Hop Header Stripping
+## Hop-by-hop header stripping
 
 Zion strips the following hop-by-hop headers from upstream responses before forwarding to clients (RFC 7230 §6.1):
 
-```
+```text
 Connection, Keep-Alive, Proxy-Authenticate, Proxy-Authorization,
 TE, Trailer, Transfer-Encoding, Upgrade
 ```
 
-## X-Forwarded-For Policy (`xff_mode`)
+## X-Forwarded-For policy (`xff_mode`)
 
 Outbound XFF behaviour is configured at `[server]` level. The default (`append`) preserves the prior behaviour and is correct when Zion sits behind a sanitising edge (CDN/ALB) that has already vetted the inbound chain. When Zion is the **front edge**, the default is unsafe: a client can send `X-Forwarded-For: 1.2.3.4` and the leftmost entry in the chain forwarded to your upstream will be that attacker-controlled value. Downstream apps that read `XFF[0]` for ACL or audit will be tricked.
 
@@ -131,11 +131,11 @@ xff_mode = "rewrite"   # one of: "append" | "rewrite" | "drop"
 
 `X-Real-IP` is **always** set from the resolved client IP and never trusted from inbound headers, regardless of `xff_mode`. The "resolved client IP" is the output of `TrustedProxies::resolve_client_ip`: the rightmost X-Forwarded-For entry that is not a trusted-proxy CIDR, or the TCP peer IP when no proxies are configured.
 
-## mTLS Client Certificate Forwarding
+## mTLS client certificate forwarding
 
 When the TLS listener is configured with client-certificate verification (`client_ca_path` set, `client_auth = "required"` or `"optional"`), Zion extracts a stable identifier from the leaf peer certificate and forwards it to upstreams as:
 
-```
+```http
 X-Client-Cert-Fingerprint: sha256:<64 hex chars>
 ```
 

--- a/docs/security/index.md
+++ b/docs/security/index.md
@@ -1,12 +1,12 @@
-# WAF Pipeline
+# WAF pipeline
 
 Zion's WAF is a 5-gate pipeline. Each gate is fail-fast: the first denial terminates inspection and returns `400 Bad Request` (or `413` for size violations). No gate uses regex; pattern matching uses the [Aho-Corasick](https://en.wikipedia.org/wiki/Aho%E2%80%93Corasick_algorithm) algorithm — a deterministic finite automaton, no backtracking, immune to ReDoS by construction.
 
 The Aho-Corasick automaton has two pattern sets, selected per-profile via `mode = "balanced" | "aggressive"`. See [WAF Configuration → Detection Modes](../config/waf.md#detection-modes) for the full breakdown of what lives in each set.
 
-## Gate Architecture
+## Gate architecture
 
-```
+```text
 Request Body
     │
     ▼
@@ -64,7 +64,7 @@ GET, HEAD, OPTIONS skip Gates 2–5 (no body to inspect). DELETE bodies are insp
 
 Earlier versions of this page advertised a sixth "fixed-length profiling" gate and a SIMD pre-filter using `memchr3`. Neither was ever implemented; the descriptions have been removed to keep docs and code in lock-step.
 
-## Pattern Categories (Gate 3)
+## Pattern categories (Gate 3)
 
 The exact pattern lists are in [`src/waf.rs`](https://github.com/fabriziosalmi/zion/blob/master/src/waf.rs) (`BALANCED_PATTERNS` and `AGGRESSIVE_EXTRA_PATTERNS`). Summary by family:
 
@@ -84,7 +84,7 @@ The exact pattern lists are in [`src/waf.rs`](https://github.com/fabriziosalmi/z
 | NoSQL operators | — | `$gt`, `$ne`, `$regex`, `$where`, `$lookup`, `db.collection`, `.find({` |
 | Deserialization (RCE) | — | Java (`Runtime.getRuntime`, `ProcessBuilder`, `ObjectInputStream`); Python (`pickle.loads`, `__reduce__`, `__import__(`, `subprocess.call`, `os.system(`, `os.popen(`) |
 
-## Aho-Corasick Properties
+## Aho-Corasick properties
 
 - **Algorithm**: Aho-Corasick multi-pattern matching (DFA).
 - **Complexity**: O(N) where N is body length, regardless of pattern count. Adding patterns grows automaton memory (~50 bytes per pattern) but does not change scan time.
@@ -92,7 +92,7 @@ The exact pattern lists are in [`src/waf.rs`](https://github.com/fabriziosalmi/z
 - **Case sensitivity**: ASCII case-insensitive.
 - **No regex**: deterministic finite automaton, no backtracking.
 
-## Entropy Analysis (Gate 4)
+## Entropy analysis (Gate 4)
 
 Shannon entropy is a heuristic for "this body looks obfuscated / encrypted / packed rather than human text or normal JSON." The default threshold sits intentionally above the theoretical maximum of pure base64 (6.0 bits/byte) so that JWTs, signed URLs, and base64 payloads pass; only near-random / encrypted blobs (~7.5–8.0 bits/byte) are flagged.
 
@@ -108,7 +108,7 @@ For `application/json` content-types, the calculation is restricted to bytes **i
 
 The threshold is per-profile (`entropy_threshold`); the gate can be turned off per-profile (`entropy_check = false`).
 
-## JSON Validation (Gate 5)
+## JSON validation (Gate 5)
 
 Two-phase validation for `application/json` bodies:
 

--- a/docs/security/supply-chain.md
+++ b/docs/security/supply-chain.md
@@ -1,4 +1,4 @@
-# Supply Chain Security
+# Supply chain security
 
 Every Zion release ships with cryptographic evidence — provenance, SBOM, and
 signatures — that lets a consumer verify *what* they're running and *where it
@@ -215,7 +215,7 @@ releases. CI must run a `cargo-vet` that can read what your local one
 wrote — a newer CI tool reads an older lock fine, but an **older** CI
 tool rejects a newer lock with a hard parse error, e.g.:
 
-```
+```text
 ERROR × Failed to parse toml file
   ╰─▶ missing field `user-id` for key `publisher.<crate>` at imports.lock:NNNN
 ```

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -1,4 +1,4 @@
-# Threat Model — STRIDE
+# Threat model — STRIDE
 
 This document maps each major external surface of Zion to the six STRIDE
 categories — **S**poofing, **T**ampering, **R**epudiation, **I**nformation


### PR DESCRIPTION
Completes the follow-ups left after #296 — no half-measures.

## Release: native arm64 runners (no QEMU)
Split the single QEMU `container` job into:
- **`container-build`** (matrix): amd64 on `ubuntu-latest`, arm64 on the free **`ubuntu-24.04-arm`** hosted runner — each builds + pushes **by digest**, verifies its own ELF **natively** (no QEMU, no manifest-list digest collision).
- **`container`** (merge): `docker buildx imagetools create` fuses the two digests into one multi-arch manifest (with index-level OCI annotations so GHCR keeps the repo link), verifies both arches are present, cosign-signs, attests SBOM + SLSA provenance to the manifest digest.

Result: the arm64 leg stops emulating → the container job drops from **~75 min → a few**. YAML + actionlint clean; adversarially reviewed against the canonical docker multi-runner pattern (8/8 checks passed). It can't run without a tag, so it's validated on the next release.

## Docs: the two deferred polish items
- **Heading sweep**: 106 headings across 25 files → sentence case, preserving acronyms / proper nouns / header names (TLS, WAF, ACME, HTTP/3, Aho-Corasick, Content-Type, NIST/OWASP standard titles). VitePress slugs lowercase, so **no anchors break** (build confirms zero dead links).
- **Code fences**: a language added to all **24 untagged fences** (`text` for diagrams/output/trees, `http` for header snippets, `toml` for the MSRV block) — silences the highlight fallbacks; build is warning-free.

## Validation
vitepress build clean (no dead links, no warnings), gitleaks 0 leaks, README stats SSOT in sync, actionlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)