### PR TITLE
Add cleanup trap to ensure backend/Zion processes are killed on failure

### DIFF
--- a/benchmarks/bench-pgo.sh
+++ b/benchmarks/bench-pgo.sh
@@ -14,6 +14,18 @@ cd "$(dirname "$0")/.."
 PGO_DIR="/tmp/zion-pgo"
 MERGED_PROF="${PGO_DIR}/merged.profdata"
 
+# Cleanup function for backgrounded processes
+cleanup() {
+  # Kill backgrounded processes if still running
+  [[ -n "${ZION_PID:-}" ]] && kill "$ZION_PID" 2>/dev/null || true
+  [[ -n "${BACKEND_PID:-}" ]] && kill "$BACKEND_PID" 2>/dev/null || true
+  wait "$ZION_PID" 2>/dev/null || true
+  wait "$BACKEND_PID" 2>/dev/null || true
+}
+
+# Ensure cleanup runs on exit (including errors)
+trap cleanup EXIT
+
 echo "┌─────────────────────────────────────────┐"
 echo "│  ZION PGO BUILD PIPELINE                │"
 echo "└─────────────────────────────────────────┘"
@@ -53,11 +65,9 @@ wrk -c 50 -d 10s -t 4 --timeout 5s -H "Host: bench.local" \
 wrk -c 50 -d 10s -t 4 --timeout 5s -H "Host: bench.local" \
     "https://127.0.0.1:4430/page" 2>/dev/null | tail -2
 
-# Stop servers
+# Stop servers (cleanup trap will handle this, but explicit kill is safer and faster)
 kill "$ZION_PID" 2>/dev/null || true
 kill "$BACKEND_PID" 2>/dev/null || true
-wait "$ZION_PID" 2>/dev/null || true
-wait "$BACKEND_PID" 2>/dev/null || true
 sleep 1
 
 # Merge profiles


### PR DESCRIPTION
### FabGPT — code quality

**File:** `benchmarks/bench-pgo.sh`

**Rationale:** If the script fails mid-execution (e.g., due to `set -e` triggering on a non-zero exit from `wrk` or `cargo`), the backgrounded backend and Zion processes may remain running, causing port conflicts, resource leaks, or false positives in subsequent runs. Adding an explicit trap ensures deterministic cleanup regardless of how the script exits.

_Proposed by FabGPT OS and approved by a human before opening._

---
🤖 **FabGPT OS** · source `quality` · model `qwen3-coder-next` · task `fc619b3110f414b3` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"fc619b3110f414b3","source":"quality","model":"qwen3-coder-next","severity":"INFO","iterations":1,"inference_s":20.22,"prompt_sha":"bb39b045284c1022","triage":"INFO"} -->