### PR TITLE
Add validation to ensure NEW version is newer than OLD

### DIFF
--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -42,6 +42,20 @@ if [[ "$OLD" == "$NEW" ]]; then
   exec scripts/check-version-sync.sh
 fi
 
+# Validate that NEW is strictly newer than OLD using semver comparison.
+# Split into major.minor.patch and compare numerically.
+IFS='.' read -r OLD_MAJOR OLD_MINOR OLD_PATCH <<< "$OLD"
+IFS='.' read -r NEW_MAJOR NEW_MINOR NEW_PATCH <<< "$NEW"
+
+# Strip prerelease/build metadata for numeric comparison (only compare core version)
+OLD_PATCH="${OLD_PATCH%%[-+]*}"
+NEW_PATCH="${NEW_PATCH%%[-+]*}"
+
+if (( 1000000 * NEW_MAJOR + 1000 * NEW_MINOR + NEW_PATCH <= 1000000 * OLD_MAJOR + 1000 * OLD_MINOR + OLD_PATCH )); then
+  echo "error: new version '$NEW' is not newer than current '$OLD'" >&2
+  exit 2
+fi
+
 echo "Bumping $OLD → $NEW"
 
 # Portable in-place sed (works on both BSD/macOS and GNU).


### PR DESCRIPTION
### FabGPT — code quality

**File:** `scripts/bump-version.sh`

**Rationale:** The script currently allows bumping to an older or equal version (e.g., from 1.2.3 to 1.2.2), which violates semantic versioning best practices and can cause confusion or broken releases. Adding a version comparison ensures only forward progress, preventing accidental downgrades.

_Proposed by FabGPT OS and approved by a human before opening._

---
🤖 **FabGPT OS** · source `quality` · model `qwen3-coder-next` · task `b4d5e1bc22cb2a7d` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"b4d5e1bc22cb2a7d","source":"quality","model":"qwen3-coder-next","severity":"WARN","iterations":1,"inference_s":21.54,"prompt_sha":"a075c1a10c3cd93e","triage":"WARN"} -->