### PR TITLE
feat(import): zion import caddy — third front-end, own Caddyfile parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Client -> TLS 1.3 -> Security Gates -> Radix Router -> WAF Pipeline (5 gates) ->
 ```
 
 <!-- zion-stats:modules-lines (kept in sync by scripts/update-readme-stats.sh) -->
-45 modules, ~37,100 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
+46 modules, ~38,500 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
 
 ## Features
 
@@ -286,7 +286,7 @@ MODE=full bash benchmarks/baseline/run-baseline.sh   # → benchmarks/baseline/z
 ## Testing
 
 <!-- zion-stats:test-count (kept in sync by scripts/update-readme-stats.sh) -->
-**784 unit tests** run on every change; **23 integration tests** need a running Zion + a backend.
+**805 unit tests** run on every change; **23 integration tests** need a running Zion + a backend.
 
 ```bash
 cargo test                          # unit tests

--- a/docs/adr/0013-zion-import-caddy.md
+++ b/docs/adr/0013-zion-import-caddy.md
@@ -1,0 +1,134 @@
+# ADR-0013: `zion import caddy` — third front-end, own Caddyfile parser
+
+- **Status**: accepted
+- **Date**: 2026-07-30
+- **Deciders**: fabriziosalmi
+- **Tags**: cli, migration, caddy, config, adoption
+
+## Context
+
+ADR-0011 established the importer's neutral seam — a source-agnostic `ZionDoc`
+plus a gated emitter — and its **honesty over completeness** contract. ADR-0012
+added a Traefik front-end on that seam. Caddy is the third proxy an operator in
+this fleet actually runs, and unlike Traefik (whose dynamic config is container
+labels read via the compose reader), a **Caddyfile has its own grammar**. So the
+Caddy front-end must carry a parser, not just a mapper.
+
+Two Caddyfile-specific properties shape the work:
+
+1. **`{` is overloaded.** It opens a block *and* begins a placeholder token
+   (`{$DOMAIN}`, `{$DOMAIN:localhost}`, `{http.request.host}`). A naive brace
+   scan reads a site address of `{$DOMAIN:localhost}` as "open an empty block".
+2. **Directives are newline-terminated**, with an optional trailing `{ … }`
+   block — unlike nginx's `;` terminator.
+
+## Decision
+
+We added `zion import caddy <Caddyfile>` as a third front-end that builds the
+**same `ZionDoc`** and reuses ADR-0011's emitter, self-validation gate and
+findings report unchanged (the `source` name was already threaded through
+`emit::render`/`report_text` by ADR-0012). No shared-code change.
+
+- **A tolerant Caddyfile reader** (`src/import/caddy.rs`), in the `nginx.rs`
+  tradition: std-only, no directive whitelist (the mapper decides what Zion
+  supports), line-preserving, `ParseError { line, msg }` on genuinely malformed
+  input, and an anti-panic property test. The lexer disambiguates `{` at the
+  point a token starts: a `{` immediately followed by a non-blank is a
+  placeholder word read to its matching `}`; a `{` followed by whitespace /
+  `}` / EOF is a block opener. Directive arguments are the tokens on the
+  directive's own line; an immediately-following `{` opens its block. It parses
+  the global-options block, snippet definitions `(name){…}` resolved by
+  `import`, and site blocks.
+- **`{$VAR}` / `{$VAR:default}` resolution** at import time from a `.env` next to
+  the file plus `--var KEY=VALUE` (reused from the Traefik front-end); an
+  unresolved required placeholder is a named `unsupported` finding, never an
+  invented value.
+- **TLS follows ADR-0012**: `tls <email>` / `tls internal` / `tls {…}` → a
+  placeholder cert + a `partial` finding pointing at `[tls.acme]` / `zion init`;
+  native ACME emission stays deferred. Explicit `tls <cert> <key>` files
+  convert.
+
+## Consequences
+
+- **Positive**: the third fleet proxy becomes "one command + review" on the same
+  trust contract. A pleasing result falls out of Zion's design: the Caddy
+  `header` block **almost evaporates** — Zion already injects the same security
+  headers, so `X-Content-Type-Options` / `X-Frame-Options` / `Referrer-Policy` /
+  `Permissions-Policy` / `-Server` all land in `auto`, and `Content-Security-Policy`
+  converts to `route.csp`. Zero new dependencies; the golden corpus
+  `tests/fixtures/import/caddy/` is the executable spec.
+- **Negative**: we own a ~400-line Caddyfile parser (bounded: the grammar is
+  small). It reads a *declared subset* — the address-less single-site shorthand
+  and mid-word `{$…}` placeholders are out of v0 and would be added when a real
+  target needs them.
+- **Neutral / risks**:
+  - **Static serving is the product edge, stated loudly.** `root` / `file_server`
+    (Zion serves nothing from disk), `handle_path` (no path rewriting) and
+    `respond` (no static responses) are `unsupported`; a handler that only does
+    these drops its route rather than emitting a wrong one.
+  - **`{$}` resolution is mandatory**; a Caddyfile depending on runtime env the
+    operator cannot supply at import time yields `unsupported` findings.
+  - Third-party Caddy plugins (`waf`, `rule_file`, `cache`, …) are `unsupported`
+    — Zion has no plugin surface to map them onto.
+
+## Mapping contract (normative)
+
+Statuses as in ADR-0011: **convert** / **partial** / **auto** / **unsupported**.
+
+| Caddyfile | Status | Zion mapping / policy |
+|---|---|---|
+| site address `example.com` / `{$DOMAIN}` | convert | `hosts` (resolved from `.env` / `--var`) |
+| site address `:80` / `:443` / `*` | convert | hostless route (Zion shared/default layer) |
+| `handle [/matcher] { reverse_proxy up }` | convert | route (path from matcher) + upstream |
+| bare `reverse_proxy [/matcher] up…` | convert | route + upstream (multiple targets → LB `urls`) |
+| `/api/*` matcher | convert | `path = "/api/{*rest}"` |
+| `/exact` matcher | convert | `path = "/exact"` |
+| `@name` named matcher | unsupported | not converted (v0) |
+| `reverse_proxy https://host` | convert | https upstream URL |
+| `header X-Content-Type-Options` / `X-Frame-Options` / `Referrer-Policy` / `Permissions-Policy` | auto | Zion injects these built-in |
+| `header -Server` | auto | Zion always strips `Server` |
+| `header Strict-Transport-Security …` | partial | Zion sets HSTS built-in with a fixed `max-age` (63072000; not configurable) |
+| `header Content-Security-Policy …` | convert | `route.csp` (site- or handler-scoped) |
+| `header X-XSS-Protection …` | unsupported | not set (a no-op on modern browsers) |
+| other `header …` | unsupported | no generic header-manipulation target |
+| `tls <email>` / `tls internal` / `tls { … }` | partial | placeholder cert; add `[tls.acme]` / `zion init` |
+| `tls <cert> <key>` | convert | `[tls]` `cert_path` / `key_path` |
+| `protocols tls1.2 …` (in `tls`) | convert | `tls.min_version = "1.2"` |
+| `import <snippet>` | convert | snippet inlined (same idea as nginx `include`) |
+| `log { … }` | auto | structured JSON to stdout is built in |
+| `auto_https` (global) | auto | driven by `[tls]`, not a global toggle |
+| `email` (global) | — | captured to name the e-mail in the `tls` finding |
+| `encode gzip zstd` | unsupported | Zion does not compress responses |
+| `root` / `file_server` | unsupported | serves nothing from disk — the product edge |
+| `handle_path /p/*` | unsupported | no path rewriting |
+| `respond "…" <code>` | unsupported | no static-response directive |
+| `redir …` | unsupported | HTTP→HTTPS is built in; no general redirect |
+| `waf` / `rule_file` / `cache` / other plugins | unsupported | no Caddy-plugin surface to map |
+
+**Report contract** (unchanged from ADR-0011/0012): one bucket per input;
+stderr summary + `--report <file>`; `--strict` exits 2 on any partial/
+unsupported; exit 0 converted, 1 fatal. `--var KEY=VALUE` supplies `{$VAR}`.
+
+## Alternatives considered
+
+- **A Caddyfile parser crate** — rejected against the ADR-0011 zero-dependency,
+  MSRV-1.82 posture; the block-style grammar a ~400-line reader covers is small
+  and stable, and the reader refuses rather than guessing.
+- **Parse Caddy's JSON config instead of the Caddyfile** — rejected: operators
+  write Caddyfiles; the JSON form is a compilation target they rarely hand-edit.
+- **Map `caddy-waf`'s `waf` directive onto Zion's WAF** — rejected for v0: the
+  rule semantics differ enough that an automatic mapping would be a guess.
+  `unsupported` with a note is the honest call; a deliberate mapping can be an
+  ADR of its own later.
+- **Native `[tls.acme]` emission** — deferred, identical to ADR-0012's reasoning
+  (it front-runs the cert-manager role case; a `partial` finding states the
+  delta today).
+
+## References
+
+- ADR-0011 (`zion import` — nginx, honesty over completeness) and ADR-0012
+  (Traefik front-end); the neutral `ZionDoc` seam and `emit::self_validate` gate
+- `src/import/caddy.rs` — Caddyfile reader + mapper; `src/import/nginx.rs` — the
+  tolerant-lexer pattern this follows
+- `tests/fixtures/import/caddy/` — golden corpus (the executable spec)
+- ADR-0007 (two-tier MSRV), ADR-0010 (host-based L7 routing)

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -23,6 +23,7 @@ defined in [0000-template.md](0000-template.md).
 | 0010  | [Host-based L7 routing (virtual hosting)](0010-host-based-l7-routing.md) | accepted |
 | 0011  | [`zion import` — nginx config migration, honesty over completeness](0011-zion-import-nginx.md) | accepted |
 | 0012  | [`zion import traefik` — a second front-end on the neutral seam](0012-zion-import-traefik.md) | accepted |
+| 0013  | [`zion import caddy` — third front-end, own Caddyfile parser](0013-zion-import-caddy.md) | accepted |
 
 ## When to write a new ADR
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -441,7 +441,7 @@ pub fn print_help() {
             {bin} top [opts]             live TUI dashboard\n  \
             {bin} init [opts]            generate zion.toml from prompts (or flags)\n  \
             {bin} suggest [opts]         synthesize a validated zion.toml from a detected/declared backend\n  \
-            {bin} import <nginx|traefik> convert an nginx or Traefik-compose config to a validated zion.toml (honest findings)\n  \
+            {bin} import <nginx|traefik|caddy> convert an nginx / Traefik-compose / Caddyfile config to a validated zion.toml (honest findings)\n  \
             {bin} doctor                 run environment diagnostic checks\n  \
             {bin} bootstrap              dump detected platform as JSON (for CI / automation)\n  \
             {bin} --version              print version\n  \

--- a/src/import/caddy.rs
+++ b/src/import/caddy.rs
@@ -1,0 +1,1419 @@
+//! Caddyfile → `ZionDoc` (ADR-0013, third front-end of `zion import`).
+//!
+//! Third front-end on the neutral seam established by ADR-0011/0012: this
+//! module owns a tolerant Caddyfile reader and a mapper that builds the *same*
+//! `ZionDoc` the nginx and Traefik paths emit; rendering, self-validation and
+//! reporting are unchanged.
+//!
+//! Unlike the Traefik front-end (which reads container labels via the compose
+//! reader), a Caddyfile has its own grammar, so this file carries a hand-rolled
+//! lexer + structural parser in the `nginx.rs` tradition: std-only, tolerant
+//! (no directive whitelist — deciding what Zion supports is the mapper's job),
+//! line-preserving, and `ParseError { line, msg }` on genuinely malformed input.
+//!
+//! ## The tokenizer's one subtlety
+//!
+//! `{` is a block opener OR the start of a placeholder token (`{$DOMAIN}`,
+//! `{$DOMAIN:localhost}`, `{http.request.host}`). A naive brace scan would read
+//! a site address of `{$DOMAIN:localhost}` as "open an empty block". We
+//! disambiguate at the point a token starts: a `{` immediately followed by a
+//! non-blank is a placeholder word read to its matching `}`; a `{` followed by
+//! whitespace / newline / `}` / EOF is a block opener.
+//!
+//! ## Honesty over completeness (ADR-0011)
+//!
+//! The interesting result, verified against real Caddyfiles, is that the
+//! `header` block almost evaporates: Zion already injects the same security
+//! headers, so they land in `auto`. `root`/`file_server` (Zion serves nothing
+//! from disk), `handle_path` (no path rewriting) and `respond` (no static
+//! responses) are the product edge and map to `unsupported`. `tls`/ACME follows
+//! the Traefik front-end: a placeholder cert + a `partial` finding, with native
+//! `[tls.acme]` emission deferred.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+use std::path::Path;
+
+use super::map::{RouteOut, UpstreamOut, ZionDoc};
+use super::{emit, Conversion, ConvertError, Finding, Status};
+
+/// Placeholder cert paths (mirrors the nginx/Traefik convention): schema
+/// validation does not require the files to exist, so a TLS route validates
+/// and `:443` binds; the operator supplies the real cert (or `[tls.acme]`).
+const PLACEHOLDER_CERT: &str = "/etc/ssl/zion/zion.crt";
+const PLACEHOLDER_KEY: &str = "/etc/ssl/zion/zion.key";
+
+/// Convert a Caddyfile into a validated zion.toml. `base_dir` locates the
+/// adjacent `.env`; `cli_vars` are `--var KEY=VALUE` overrides (for `{$VAR}`).
+pub(super) fn convert(
+    src: &str,
+    base_dir: Option<&Path>,
+    cli_vars: &[(String, String)],
+) -> Result<Conversion, ConvertError> {
+    let file = parse(src).map_err(|e| ConvertError::Parse(e.to_string()))?;
+    let env = Env::load(base_dir, cli_vars);
+
+    let mut findings = Vec::new();
+    let doc = build(&file, &env, &mut findings);
+    findings.sort_by_key(|f| f.line);
+
+    if doc.routes.is_empty() {
+        return Err(ConvertError::NoRoutes(findings));
+    }
+
+    let toml = emit::render(&doc, "caddy");
+    emit::self_validate(&toml).map_err(|e| {
+        ConvertError::Internal(format!(
+            "emitted config failed self-validation — this is an importer bug, \
+             please report it: {e}"
+        ))
+    })?;
+    Ok(Conversion { toml, findings })
+}
+
+// ── Parse tree ────────────────────────────────────────────────────────────
+
+/// One Caddyfile directive: `name args… { block }`. `block` is `Some` (even if
+/// empty) when the directive opened a `{ … }`.
+#[derive(Debug, Clone)]
+struct Node {
+    name: String,
+    args: Vec<String>,
+    block: Option<Vec<Node>>,
+    line: u32,
+}
+
+#[derive(Debug, Default)]
+struct Caddyfile {
+    /// Global options block (leading `{ … }`), if any.
+    global: Vec<Node>,
+    /// Snippet definitions `(name) { … }`, resolved by `import name`.
+    snippets: BTreeMap<String, Vec<Node>>,
+    sites: Vec<Site>,
+}
+
+#[derive(Debug)]
+struct Site {
+    addresses: Vec<String>,
+    body: Vec<Node>,
+    line: u32,
+}
+
+#[derive(Debug, Clone)]
+pub struct ParseError {
+    pub line: u32,
+    pub msg: String,
+}
+
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "line {}: {}", self.line, self.msg)
+    }
+}
+
+fn perr(line: u32, msg: impl Into<String>) -> ParseError {
+    ParseError {
+        line,
+        msg: msg.into(),
+    }
+}
+
+// ── Lexer ─────────────────────────────────────────────────────────────────
+
+#[derive(Debug)]
+enum Tok {
+    Word(String),
+    Open,
+    Close,
+    Eof,
+}
+
+#[derive(PartialEq)]
+enum Kind {
+    Word,
+    Open,
+    Close,
+    Eof,
+}
+
+struct Lexer<'a> {
+    chars: std::iter::Peekable<std::str::Chars<'a>>,
+    line: u32,
+    pending: Option<(Tok, u32)>,
+}
+
+impl<'a> Lexer<'a> {
+    fn new(src: &'a str) -> Self {
+        Lexer {
+            chars: src.chars().peekable(),
+            line: 1,
+            pending: None,
+        }
+    }
+
+    fn bump(&mut self) -> Option<char> {
+        let c = self.chars.next();
+        if c == Some('\n') {
+            self.line += 1;
+        }
+        c
+    }
+
+    /// Whitespace and `#` comments (a comment only starts where a token may).
+    fn skip_trivia(&mut self) {
+        loop {
+            match self.chars.peek() {
+                Some(c) if c.is_whitespace() => {
+                    self.bump();
+                }
+                Some('#') => {
+                    while let Some(c) = self.bump() {
+                        if c == '\n' {
+                            break;
+                        }
+                    }
+                }
+                _ => return,
+            }
+        }
+    }
+
+    fn fill(&mut self) -> Result<(), ParseError> {
+        if self.pending.is_none() {
+            self.pending = Some(self.lex_one()?);
+        }
+        Ok(())
+    }
+
+    fn peek_kind(&mut self) -> Result<(Kind, u32), ParseError> {
+        self.fill()?;
+        let (tok, line) = self.pending.as_ref().unwrap();
+        let kind = match tok {
+            Tok::Word(_) => Kind::Word,
+            Tok::Open => Kind::Open,
+            Tok::Close => Kind::Close,
+            Tok::Eof => Kind::Eof,
+        };
+        Ok((kind, *line))
+    }
+
+    fn next_tok(&mut self) -> Result<(Tok, u32), ParseError> {
+        self.fill()?;
+        Ok(self.pending.take().unwrap())
+    }
+
+    fn lex_one(&mut self) -> Result<(Tok, u32), ParseError> {
+        self.skip_trivia();
+        let line = self.line;
+        let c = match self.chars.peek() {
+            None => return Ok((Tok::Eof, line)),
+            Some(c) => *c,
+        };
+        match c {
+            '}' => {
+                self.bump();
+                Ok((Tok::Close, line))
+            }
+            '{' => {
+                self.bump();
+                // Placeholder token vs block opener: a `{` immediately followed
+                // by a non-blank (`$`, a letter, …) is `{…}` read to its `}`.
+                match self.chars.peek() {
+                    Some(ch) if !ch.is_whitespace() && *ch != '}' => {
+                        let mut s = String::from("{");
+                        loop {
+                            match self.bump() {
+                                Some('}') => {
+                                    s.push('}');
+                                    break;
+                                }
+                                Some(ch) => s.push(ch),
+                                None => return Err(perr(line, "unterminated `{…}` placeholder")),
+                            }
+                        }
+                        Ok((Tok::Word(s), line))
+                    }
+                    _ => Ok((Tok::Open, line)),
+                }
+            }
+            '"' => self.read_quoted('"', line),
+            '`' => self.read_quoted('`', line),
+            _ => Ok((Tok::Word(self.read_bare()), line)),
+        }
+    }
+
+    /// Quoted (`"`) or raw (`` ` ``) string. `"` honors `\"` / `\\`; the raw
+    /// form is verbatim to the closing backtick.
+    fn read_quoted(&mut self, quote: char, line: u32) -> Result<(Tok, u32), ParseError> {
+        self.bump(); // opening quote
+        let mut s = String::new();
+        loop {
+            match self.bump() {
+                None => return Err(perr(line, "unterminated quoted string")),
+                Some(c) if c == quote => break,
+                Some('\\') if quote == '"' => match self.bump() {
+                    Some('"') => s.push('"'),
+                    Some('\\') => s.push('\\'),
+                    Some('n') => s.push('\n'),
+                    Some('t') => s.push('\t'),
+                    Some(other) => {
+                        s.push('\\');
+                        s.push(other);
+                    }
+                    None => return Err(perr(line, "unterminated escape in quoted string")),
+                },
+                Some(c) => s.push(c),
+            }
+        }
+        Ok((Tok::Word(s), line))
+    }
+
+    /// A bare word: runs to whitespace or a structural `{` / `}`. An embedded
+    /// `{$…}` placeholder at word start is handled in `lex_one`; mid-word braces
+    /// terminate the word (rare in practice).
+    fn read_bare(&mut self) -> String {
+        let mut s = String::new();
+        while let Some(&c) = self.chars.peek() {
+            if c.is_whitespace() || c == '{' || c == '}' || c == '"' || c == '`' {
+                break;
+            }
+            s.push(c);
+            self.bump();
+        }
+        s
+    }
+}
+
+// ── Parser ────────────────────────────────────────────────────────────────
+
+fn parse(src: &str) -> Result<Caddyfile, ParseError> {
+    let mut lx = Lexer::new(src);
+    let mut file = Caddyfile::default();
+
+    // A leading `{` (before any site) is the global options block.
+    if let (Kind::Open, _) = lx.peek_kind()? {
+        lx.next_tok()?;
+        file.global = parse_block(&mut lx)?;
+    }
+
+    loop {
+        match lx.peek_kind()? {
+            (Kind::Eof, _) => break,
+            (Kind::Close, line) => return Err(perr(line, "unexpected `}`")),
+            (Kind::Open, line) => {
+                return Err(perr(
+                    line,
+                    "unexpected `{` (global options must be the first block)",
+                ))
+            }
+            (Kind::Word, head_line) => {
+                // Address / snippet-name tokens run until the opening `{`.
+                let mut heads = Vec::new();
+                while let (Kind::Word, _) = lx.peek_kind()? {
+                    if let (Tok::Word(w), _) = lx.next_tok()? {
+                        heads.push(w);
+                    }
+                }
+                match lx.peek_kind()? {
+                    (Kind::Open, _) => {
+                        lx.next_tok()?;
+                        let body = parse_block(&mut lx)?;
+                        if heads.len() == 1
+                            && heads[0].starts_with('(')
+                            && heads[0].ends_with(')')
+                            && heads[0].len() >= 2
+                        {
+                            let name = heads[0][1..heads[0].len() - 1].to_string();
+                            file.snippets.insert(name, body);
+                        } else {
+                            let addresses = heads
+                                .iter()
+                                .flat_map(|h| h.split(','))
+                                .map(|a| a.trim().to_string())
+                                .filter(|a| !a.is_empty())
+                                .collect();
+                            file.sites.push(Site {
+                                addresses,
+                                body,
+                                line: head_line,
+                            });
+                        }
+                    }
+                    (_, line) => {
+                        return Err(perr(
+                            line,
+                            "expected `{` to open a site block after the address",
+                        ))
+                    }
+                }
+            }
+        }
+    }
+    Ok(file)
+}
+
+/// Parse directives until the matching `}` (which it consumes).
+fn parse_block(lx: &mut Lexer) -> Result<Vec<Node>, ParseError> {
+    let mut nodes = Vec::new();
+    loop {
+        match lx.peek_kind()? {
+            (Kind::Close, _) => {
+                lx.next_tok()?;
+                break;
+            }
+            (Kind::Eof, line) => return Err(perr(line, "unexpected end of input — unclosed `{`")),
+            (Kind::Open, line) => return Err(perr(line, "unexpected `{` with no directive")),
+            (Kind::Word, line) => {
+                let name = match lx.next_tok()? {
+                    (Tok::Word(w), _) => w,
+                    _ => unreachable!(),
+                };
+                // Arguments are the tokens on the directive's own line.
+                let mut args = Vec::new();
+                loop {
+                    match lx.peek_kind()? {
+                        (Kind::Word, l) if l == line => {
+                            if let (Tok::Word(w), _) = lx.next_tok()? {
+                                args.push(w);
+                            }
+                        }
+                        _ => break,
+                    }
+                }
+                // An immediately-following `{` opens this directive's block.
+                let block = match lx.peek_kind()? {
+                    (Kind::Open, _) => {
+                        lx.next_tok()?;
+                        Some(parse_block(lx)?)
+                    }
+                    _ => None,
+                };
+                nodes.push(Node {
+                    name,
+                    args,
+                    block,
+                    line,
+                });
+            }
+        }
+    }
+    Ok(nodes)
+}
+
+// ── Environment placeholders (`{$VAR}` / `{$VAR:default}`) ─────────────────
+
+struct Env {
+    map: BTreeMap<String, String>,
+}
+
+impl Env {
+    fn load(base_dir: Option<&Path>, cli_vars: &[(String, String)]) -> Self {
+        let mut map = BTreeMap::new();
+        if let Some(dir) = base_dir {
+            if let Ok(content) = std::fs::read_to_string(dir.join(".env")) {
+                for raw in content.lines() {
+                    let line = raw.trim();
+                    if line.is_empty() || line.starts_with('#') {
+                        continue;
+                    }
+                    let line = line.strip_prefix("export ").unwrap_or(line);
+                    if let Some((k, v)) = line.split_once('=') {
+                        map.insert(k.trim().to_string(), unquote(v.trim()).to_string());
+                    }
+                }
+            }
+        }
+        for (k, v) in cli_vars {
+            map.insert(k.clone(), v.clone());
+        }
+        Env { map }
+    }
+
+    fn get(&self, name: &str) -> Option<&str> {
+        self.map
+            .get(name)
+            .map(String::as_str)
+            .filter(|v| !v.is_empty())
+    }
+}
+
+/// Expand every `{$VAR}` / `{$VAR:default}` in `raw`. Non-env placeholders
+/// (`{http.request.host}`) are left literal. An unresolved required `{$VAR}`
+/// becomes a named `unsupported` finding and returns `None`.
+fn resolve(
+    raw: &str,
+    env: &Env,
+    line: u32,
+    ctx: &str,
+    findings: &mut Vec<Finding>,
+) -> Option<String> {
+    let mut out = String::with_capacity(raw.len());
+    let mut rest = raw;
+    let mut ok = true;
+    while let Some(pos) = rest.find("{$") {
+        out.push_str(&rest[..pos]);
+        let after = &rest[pos + 2..];
+        match after.find('}') {
+            Some(end) => {
+                let inner = &after[..end];
+                let (name, default) = match inner.split_once(':') {
+                    Some((n, d)) => (n, Some(d)),
+                    None => (inner, None),
+                };
+                match env.get(name) {
+                    Some(v) => out.push_str(v),
+                    None => {
+                        match default {
+                            Some(d) => out.push_str(d),
+                            None => {
+                                findings.push(Finding::new(
+                                Status::Unsupported,
+                                line,
+                                format!("{ctx}: {{${name}}}"),
+                                format!("unresolved variable — pass `--var {name}=…` or set it in .env"),
+                            ));
+                                ok = false;
+                            }
+                        }
+                    }
+                }
+                rest = &after[end + 1..];
+            }
+            None => {
+                out.push_str("{$");
+                rest = after;
+            }
+        }
+    }
+    out.push_str(rest);
+    if ok {
+        Some(out)
+    } else {
+        None
+    }
+}
+
+fn unquote(s: &str) -> &str {
+    let b = s.as_bytes();
+    if b.len() >= 2 && (b[0] == b'"' || b[0] == b'\'') && b[b.len() - 1] == b[0] {
+        &s[1..s.len() - 1]
+    } else {
+        s
+    }
+}
+
+// ── Mapper ────────────────────────────────────────────────────────────────
+
+fn build(file: &Caddyfile, env: &Env, findings: &mut Vec<Finding>) -> ZionDoc {
+    let mut doc = ZionDoc {
+        listen_http: "0.0.0.0:80".to_string(),
+        listen_https: "0.0.0.0:443".to_string(),
+        rate_limit: None,
+        max_conn_per_ip: None,
+        trusted_proxies: Vec::new(),
+        tls_cert: PLACEHOLDER_CERT.to_string(),
+        tls_key: PLACEHOLDER_KEY.to_string(),
+        tls_min12: false,
+        sni: Vec::new(),
+        waf_body_mb: None,
+        upstreams: Vec::new(),
+        routes: Vec::new(),
+    };
+
+    let mut acme_email: Option<String> = None;
+    for node in &file.global {
+        apply_global(node, &mut acme_email, findings);
+    }
+
+    let mut seen_upstreams: BTreeSet<String> = BTreeSet::new();
+    for site in &file.sites {
+        let hosts = resolve_hosts(site, env, findings);
+        let body = expand_imports(&site.body, &file.snippets);
+        map_site(
+            &body,
+            &hosts,
+            env,
+            &acme_email,
+            &mut doc,
+            &mut seen_upstreams,
+            findings,
+        );
+    }
+    doc
+}
+
+fn apply_global(node: &Node, acme_email: &mut Option<String>, findings: &mut Vec<Finding>) {
+    match node.name.as_str() {
+        "email" => {
+            if let Some(e) = node.args.first() {
+                *acme_email = Some(e.clone());
+            }
+        }
+        "auto_https" => findings.push(Finding::new(
+            Status::Auto,
+            node.line,
+            "auto_https",
+            "TLS/HTTPS behavior is driven by Zion's [tls] block, not a global toggle",
+        )),
+        "admin" | "debug" | "log" | "order" | "grace_period" | "storage" => {
+            findings.push(Finding::new(
+                Status::Auto,
+                node.line,
+                node.name.clone(),
+                "global option — no routing effect",
+            ))
+        }
+        "servers" => findings.push(Finding::new(
+            Status::Partial,
+            node.line,
+            "servers",
+            "global server tuning (timeouts, protocols) has only partial Zion knobs",
+        )),
+        other => findings.push(Finding::new(
+            Status::Unsupported,
+            node.line,
+            other.to_string(),
+            "unrecognized global option",
+        )),
+    }
+}
+
+/// Resolve a site's addresses into hosts, folding `:80` / `:443` bare-port
+/// addresses into hostless routes. Invalid / unresolved addresses are findings.
+fn resolve_hosts(site: &Site, env: &Env, findings: &mut Vec<Finding>) -> Vec<String> {
+    let mut hosts = Vec::new();
+    for addr in &site.addresses {
+        let Some(resolved) = resolve(addr, env, site.line, "site address", findings) else {
+            continue; // finding already recorded
+        };
+        // Strip an optional scheme and a trailing :port.
+        let no_scheme = resolved
+            .strip_prefix("https://")
+            .or_else(|| resolved.strip_prefix("http://"))
+            .unwrap_or(&resolved);
+        let host = no_scheme.split('/').next().unwrap_or(no_scheme);
+        let host = match host.rsplit_once(':') {
+            // `:443` / `host:8080` → drop the port; a bare `:port` leaves nothing.
+            Some((h, port)) if port.chars().all(|c| c.is_ascii_digit()) => h,
+            _ => host,
+        };
+        if host.is_empty() || host == "*" {
+            // `:80`, `:443`, `*` → hostless (Zion's shared/default layer).
+            continue;
+        }
+        if host.contains('{') || host.contains('}') {
+            findings.push(Finding::new(
+                Status::Unsupported,
+                site.line,
+                "site address",
+                format!("runtime placeholder in host `{host}` cannot be a static route host"),
+            ));
+            continue;
+        }
+        hosts.push(host.to_string());
+    }
+    hosts
+}
+
+/// Inline `import <snippet>` directives (one level; unknown names are left as a
+/// node so the mapper reports them).
+fn expand_imports(body: &[Node], snippets: &BTreeMap<String, Vec<Node>>) -> Vec<Node> {
+    let mut out = Vec::new();
+    for node in body {
+        if node.name == "import" && node.block.is_none() {
+            if let Some(name) = node.args.first() {
+                if let Some(expanded) = snippets.get(name) {
+                    out.extend(expanded.iter().cloned());
+                    continue;
+                }
+            }
+        }
+        out.push(node.clone());
+    }
+    out
+}
+
+#[allow(clippy::too_many_arguments)]
+fn map_site(
+    body: &[Node],
+    hosts: &[String],
+    env: &Env,
+    acme_email: &Option<String>,
+    doc: &mut ZionDoc,
+    seen_upstreams: &mut BTreeSet<String>,
+    findings: &mut Vec<Finding>,
+) {
+    // Pass 1: site-level directives (headers, tls, encode, …). The site-level
+    // header block yields a CSP that applies to every route unless a handler
+    // overrides it.
+    let mut site_csp: Option<String> = None;
+    for node in body {
+        match node.name.as_str() {
+            "header" => {
+                if let Some(csp) = map_header(node, findings) {
+                    site_csp = Some(csp);
+                }
+            }
+            "tls" => map_tls(node, acme_email, doc, findings),
+            "encode" => findings.push(Finding::new(
+                Status::Unsupported,
+                node.line,
+                "encode",
+                "Zion does not compress responses — the backend should",
+            )),
+            "log" => findings.push(Finding::new(
+                Status::Auto,
+                node.line,
+                "log",
+                "structured JSON logging to stdout is built in",
+            )),
+            "root" | "file_server" => findings.push(Finding::new(
+                Status::Unsupported,
+                node.line,
+                node.name.clone(),
+                "Zion serves nothing from disk (static serving is the product edge)",
+            )),
+            "respond" => findings.push(Finding::new(
+                Status::Unsupported,
+                node.line,
+                "respond",
+                "Zion has no static-response directive",
+            )),
+            "redir" => findings.push(Finding::new(
+                Status::Unsupported,
+                node.line,
+                "redir",
+                "explicit redirects have no Zion equivalent (HTTP→HTTPS is built in)",
+            )),
+            "handle_path" => findings.push(Finding::new(
+                Status::Unsupported,
+                node.line,
+                "handle_path",
+                "path rewriting (prefix stripping) has no Zion equivalent",
+            )),
+            // Route-bearing directives are handled in pass 2.
+            "handle" | "reverse_proxy" | "route" => {}
+            other if other.starts_with('@') => findings.push(Finding::new(
+                Status::Unsupported,
+                node.line,
+                other.to_string(),
+                "named matchers are not converted (v0)",
+            )),
+            other => findings.push(Finding::new(
+                Status::Unsupported,
+                node.line,
+                other.to_string(),
+                "no Zion equivalent — review manually",
+            )),
+        }
+    }
+
+    // Pass 2: build routes from handle / reverse_proxy directives.
+    for node in body {
+        match node.name.as_str() {
+            "handle" | "route" => map_handle(
+                node,
+                hosts,
+                site_csp.as_deref(),
+                env,
+                doc,
+                seen_upstreams,
+                findings,
+            ),
+            "reverse_proxy" => map_reverse_proxy(
+                node,
+                hosts,
+                site_csp.as_deref(),
+                env,
+                doc,
+                seen_upstreams,
+                findings,
+            ),
+            _ => {}
+        }
+    }
+}
+
+/// Map a `header` block. Security headers Zion already injects → `auto`;
+/// `Content-Security-Policy` → returned as a route/site CSP (convert);
+/// HSTS → `partial` (Zion's value is fixed); the rest → `unsupported`.
+fn map_header(node: &Node, findings: &mut Vec<Finding>) -> Option<String> {
+    let mut csp = None;
+    // Fields come either as a block or as inline `header Field value` args.
+    let fields: Vec<(String, u32)> = match &node.block {
+        Some(block) => block.iter().map(|n| (n.name.clone(), n.line)).collect(),
+        None => node
+            .args
+            .first()
+            .map(|f| vec![(f.clone(), node.line)])
+            .unwrap_or_default(),
+    };
+    let csp_value = |n: &Node| n.args.first().cloned().unwrap_or_default();
+    if let Some(block) = &node.block {
+        for n in block {
+            if n.name.eq_ignore_ascii_case("Content-Security-Policy") {
+                csp = Some(csp_value(n));
+            }
+        }
+    }
+    for (field, line) in fields {
+        let f = field.trim_start_matches('-');
+        let (status, detail): (Status, &str) = match () {
+            _ if field.starts_with('-') => (Status::Auto, "Zion already strips this header"),
+            _ if f.eq_ignore_ascii_case("X-Content-Type-Options")
+                || f.eq_ignore_ascii_case("X-Frame-Options")
+                || f.eq_ignore_ascii_case("Referrer-Policy")
+                || f.eq_ignore_ascii_case("Permissions-Policy") =>
+            {
+                (Status::Auto, "Zion injects this security header built-in")
+            }
+            _ if f.eq_ignore_ascii_case("Strict-Transport-Security") => (
+                Status::Partial,
+                "Zion sets HSTS built-in with a fixed max-age (63072000; not configurable)",
+            ),
+            _ if f.eq_ignore_ascii_case("Content-Security-Policy") => {
+                continue; // handled as a route CSP, not a finding
+            }
+            _ if f.eq_ignore_ascii_case("X-XSS-Protection") => (
+                Status::Unsupported,
+                "Zion does not set X-XSS-Protection (a no-op on modern browsers)",
+            ),
+            _ => (Status::Unsupported, "no generic header-manipulation target"),
+        };
+        findings.push(Finding::new(status, line, format!("header {f}"), detail));
+    }
+    csp
+}
+
+/// `tls email` / `tls { … }` / `tls internal` → placeholder cert + `partial`
+/// (ACME deferred). `tls <cert> <key>` (explicit files) → convert.
+fn map_tls(
+    node: &Node,
+    acme_email: &Option<String>,
+    doc: &mut ZionDoc,
+    findings: &mut Vec<Finding>,
+) {
+    // Explicit cert + key files.
+    if node.args.len() == 2
+        && !node.args[0].contains('@')
+        && node.args[0] != "internal"
+        && node.args[1] != "internal"
+    {
+        doc.tls_cert = node.args[0].clone();
+        doc.tls_key = node.args[1].clone();
+        findings.push(Finding::new(
+            Status::Convert,
+            node.line,
+            "tls <cert> <key>",
+            "explicit certificate files → [tls] cert_path/key_path",
+        ));
+        return;
+    }
+    // `protocols tls1.2 …` inside the block → min version.
+    if let Some(block) = &node.block {
+        for n in block {
+            if n.name == "protocols" && n.args.iter().any(|p| p.contains("1.2")) {
+                doc.tls_min12 = true;
+                findings.push(Finding::new(
+                    Status::Convert,
+                    n.line,
+                    "tls.protocols",
+                    "tls.min_version = \"1.2\"",
+                ));
+            }
+        }
+    }
+    let email = node
+        .args
+        .iter()
+        .find(|a| a.contains('@'))
+        .cloned()
+        .or_else(|| acme_email.clone())
+        .unwrap_or_else(|| "you@example.com".to_string());
+    findings.push(Finding::new(
+        Status::Partial,
+        node.line,
+        "tls",
+        format!(
+            "Caddy manages this certificate (ACME/internal) → Zion emits a placeholder cert. \
+             Add [tls.acme] (email = \"{email}\", domains = the route hosts) or run `zion init`; \
+             if the origin is a certificate manager, point [tls] at its cert instead"
+        ),
+    ));
+}
+
+#[allow(clippy::too_many_arguments)]
+fn map_handle(
+    node: &Node,
+    hosts: &[String],
+    site_csp: Option<&str>,
+    env: &Env,
+    doc: &mut ZionDoc,
+    seen_upstreams: &mut BTreeSet<String>,
+    findings: &mut Vec<Finding>,
+) {
+    // `handle [matcher] { … }`. A named matcher we cannot convert.
+    let matcher = node.args.first().map(String::as_str);
+    if let Some(m) = matcher {
+        if m.starts_with('@') {
+            findings.push(Finding::new(
+                Status::Unsupported,
+                node.line,
+                format!("handle {m}"),
+                "named matchers are not converted (v0)",
+            ));
+            return;
+        }
+    }
+    let path = matcher_to_path(matcher);
+
+    let Some(block) = &node.block else {
+        findings.push(Finding::new(
+            Status::Unsupported,
+            node.line,
+            "handle",
+            "handle without a block does nothing convertible",
+        ));
+        return;
+    };
+
+    // A handler that serves files or responds statically is the product edge.
+    if let Some(bad) = block
+        .iter()
+        .find(|n| matches!(n.name.as_str(), "root" | "file_server" | "respond"))
+    {
+        findings.push(Finding::new(
+            Status::Unsupported,
+            bad.line,
+            format!("handle → {}", bad.name),
+            "this handler serves no upstream (static/respond) — route dropped",
+        ));
+        return;
+    }
+
+    // CSP from a nested header block overrides the site-level CSP.
+    let mut route_csp = site_csp.map(str::to_string);
+    for n in block {
+        if n.name == "header" {
+            if let Some(csp) = map_header(n, findings) {
+                route_csp = Some(csp);
+            }
+        }
+    }
+
+    let Some(rp) = block.iter().find(|n| n.name == "reverse_proxy") else {
+        findings.push(Finding::new(
+            Status::Unsupported,
+            node.line,
+            "handle",
+            "no reverse_proxy in this handler — nothing to route to",
+        ));
+        return;
+    };
+
+    push_route(
+        rp,
+        &path,
+        hosts,
+        route_csp.as_deref(),
+        env,
+        doc,
+        seen_upstreams,
+        findings,
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+fn map_reverse_proxy(
+    node: &Node,
+    hosts: &[String],
+    site_csp: Option<&str>,
+    env: &Env,
+    doc: &mut ZionDoc,
+    seen_upstreams: &mut BTreeSet<String>,
+    findings: &mut Vec<Finding>,
+) {
+    // Bare `reverse_proxy [matcher] upstream…` directly in a site.
+    let matcher = node
+        .args
+        .first()
+        .filter(|a| a.starts_with('/') || a.starts_with('@') || *a == "*")
+        .map(String::as_str);
+    if let Some(m) = matcher {
+        if m.starts_with('@') {
+            findings.push(Finding::new(
+                Status::Unsupported,
+                node.line,
+                format!("reverse_proxy {m}"),
+                "named matchers are not converted (v0)",
+            ));
+            return;
+        }
+    }
+    let path = matcher_to_path(matcher);
+    push_route(
+        node,
+        &path,
+        hosts,
+        site_csp,
+        env,
+        doc,
+        seen_upstreams,
+        findings,
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+fn push_route(
+    rp: &Node,
+    path: &str,
+    hosts: &[String],
+    csp: Option<&str>,
+    env: &Env,
+    doc: &mut ZionDoc,
+    seen_upstreams: &mut BTreeSet<String>,
+    findings: &mut Vec<Finding>,
+) {
+    // Upstreams are the reverse_proxy args that are not the leading matcher.
+    let targets: Vec<&String> = rp
+        .args
+        .iter()
+        .filter(|a| !a.starts_with('/') && !a.starts_with('@') && *a != "*")
+        .collect();
+    if targets.is_empty() {
+        findings.push(Finding::new(
+            Status::Unsupported,
+            rp.line,
+            "reverse_proxy",
+            "no upstream address — cannot build an upstream",
+        ));
+        return;
+    }
+
+    let mut urls = Vec::new();
+    for t in &targets {
+        let Some(resolved) = resolve(t, env, rp.line, "reverse_proxy", findings) else {
+            return; // unresolved variable already recorded
+        };
+        urls.push(to_url(&resolved));
+    }
+
+    // Name the upstream after the first target's host.
+    let up_name = sanitize_name(host_of(&urls[0]));
+    if seen_upstreams.insert(up_name.clone()) {
+        doc.upstreams.push(UpstreamOut {
+            name: up_name.clone(),
+            urls,
+            connect_timeout_ms: None,
+            keepalive: None,
+        });
+    }
+
+    findings.push(Finding::new(
+        Status::Convert,
+        rp.line,
+        "reverse_proxy",
+        format!("→ route {path} upstream '{up_name}'"),
+    ));
+    doc.routes.push(RouteOut {
+        path: path.to_string(),
+        hosts: if hosts.is_empty() {
+            None
+        } else {
+            Some(hosts.to_vec())
+        },
+        upstream: up_name,
+        websocket: false,
+        csp: csp.map(str::to_string),
+        waf: false,
+        annotations: Vec::new(),
+    });
+}
+
+// ── Small helpers ─────────────────────────────────────────────────────────
+
+/// A Caddy path matcher → a Zion route path. `/api/*` → `/api/{*rest}`;
+/// `/exact` → `/exact`; none / `*` → `/{*rest}`.
+fn matcher_to_path(matcher: Option<&str>) -> String {
+    match matcher {
+        None | Some("*") => "/{*rest}".to_string(),
+        Some(m) if m.ends_with('*') => {
+            let base = m.trim_end_matches('*').trim_end_matches('/');
+            if base.is_empty() {
+                "/{*rest}".to_string()
+            } else {
+                format!("{base}/{{*rest}}")
+            }
+        }
+        Some(m) => m.to_string(),
+    }
+}
+
+fn to_url(target: &str) -> String {
+    if target.contains("://") {
+        target.to_string()
+    } else {
+        format!("http://{target}")
+    }
+}
+
+fn host_of(url: &str) -> &str {
+    let no_scheme = url.split("://").last().unwrap_or(url);
+    let hostport = no_scheme.split('/').next().unwrap_or(no_scheme);
+    hostport
+        .rsplit_once(':')
+        .map(|(h, _)| h)
+        .unwrap_or(hostport)
+}
+
+fn sanitize_name(name: &str) -> String {
+    let s: String = name
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    if s.is_empty() {
+        "upstream".to_string()
+    } else {
+        s
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn env(pairs: &[(&str, &str)]) -> Env {
+        Env {
+            map: pairs
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
+        }
+    }
+
+    fn convert_str(src: &str, vars: &[(&str, &str)]) -> Result<Conversion, ConvertError> {
+        let cli: Vec<(String, String)> = vars
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+        convert(src, None, &cli)
+    }
+
+    // ── lexer / parser ──
+
+    #[test]
+    fn placeholder_is_a_word_not_a_brace() {
+        // The critical disambiguation: `{$DOMAIN:localhost}` is one token.
+        let f = parse("{$DOMAIN:localhost} {\n  reverse_proxy api:8000\n}").unwrap();
+        assert_eq!(f.sites.len(), 1);
+        assert_eq!(
+            f.sites[0].addresses,
+            vec!["{$DOMAIN:localhost}".to_string()]
+        );
+        assert_eq!(f.sites[0].body.len(), 1);
+        assert_eq!(f.sites[0].body[0].name, "reverse_proxy");
+    }
+
+    #[test]
+    fn global_block_then_site() {
+        let f = parse("{\n  email a@b.com\n}\nexample.com {\n  reverse_proxy app:80\n}").unwrap();
+        assert_eq!(f.global.len(), 1);
+        assert_eq!(f.global[0].name, "email");
+        assert_eq!(f.sites.len(), 1);
+        assert_eq!(f.sites[0].addresses, vec!["example.com".to_string()]);
+    }
+
+    #[test]
+    fn nested_blocks_and_quoted_values() {
+        let f = parse(
+            "example.com {\n  handle /api/* {\n    reverse_proxy api:8000\n    header {\n      Content-Security-Policy \"default-src 'none'\"\n    }\n  }\n}",
+        )
+        .unwrap();
+        let handle = &f.sites[0].body[0];
+        assert_eq!(handle.name, "handle");
+        assert_eq!(handle.args, vec!["/api/*".to_string()]);
+        let inner = handle.block.as_ref().unwrap();
+        assert_eq!(inner[0].name, "reverse_proxy");
+        let header = &inner[1];
+        assert_eq!(
+            header.block.as_ref().unwrap()[0].name,
+            "Content-Security-Policy"
+        );
+        assert_eq!(
+            header.block.as_ref().unwrap()[0].args,
+            vec!["default-src 'none'".to_string()]
+        );
+    }
+
+    #[test]
+    fn snippet_is_captured_not_a_site() {
+        let f = parse("(sec) {\n  header X-Frame-Options DENY\n}\nexample.com {\n  import sec\n  reverse_proxy app:80\n}").unwrap();
+        assert!(f.snippets.contains_key("sec"));
+        assert_eq!(f.sites.len(), 1);
+    }
+
+    #[test]
+    fn unterminated_block_is_a_parse_error() {
+        let e = parse("example.com {\n  reverse_proxy app:80\n").unwrap_err();
+        assert!(e.msg.contains("unclosed") || e.msg.contains("end of input"));
+    }
+
+    #[test]
+    fn comments_are_skipped() {
+        let f =
+            parse("# top comment\nexample.com {\n  reverse_proxy app:80  # trailing\n}").unwrap();
+        assert_eq!(f.sites[0].body.len(), 1);
+    }
+
+    // ── mapping ──
+
+    #[test]
+    fn matcher_paths() {
+        assert_eq!(matcher_to_path(None), "/{*rest}");
+        assert_eq!(matcher_to_path(Some("*")), "/{*rest}");
+        assert_eq!(matcher_to_path(Some("/api/*")), "/api/{*rest}");
+        assert_eq!(matcher_to_path(Some("/health")), "/health");
+    }
+
+    #[test]
+    fn resolve_default_and_unresolved() {
+        let e = env(&[("SET", "v")]);
+        let mut f = Vec::new();
+        assert_eq!(resolve("{$SET}", &e, 1, "x", &mut f).as_deref(), Some("v"));
+        assert_eq!(
+            resolve("{$UNSET:def}", &e, 1, "x", &mut f).as_deref(),
+            Some("def")
+        );
+        assert_eq!(resolve("{$MISSING}", &e, 9, "site address", &mut f), None);
+        assert_eq!(f.len(), 1);
+        assert_eq!(f[0].line, 9);
+        assert!(f[0].detail.contains("--var MISSING="));
+    }
+
+    const NIS2_SHAPE: &str = r#"
+{$DOMAIN:localhost} {
+    header {
+        Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+        X-Content-Type-Options    "nosniff"
+        X-Frame-Options           "DENY"
+        Referrer-Policy           "strict-origin-when-cross-origin"
+        X-XSS-Protection          "1; mode=block"
+        Permissions-Policy        "geolocation=(), camera=()"
+        -Server
+    }
+    handle /api/* {
+        reverse_proxy api:8000
+        header {
+            Content-Security-Policy "default-src 'none'; frame-ancestors 'none'"
+        }
+    }
+    handle {
+        reverse_proxy web:3000
+        header {
+            Content-Security-Policy "default-src 'self'"
+        }
+    }
+    encode gzip zstd
+    log {
+        output stdout
+        format json
+    }
+}
+"#;
+
+    #[test]
+    fn nis2_shape_converts_both_routes() {
+        let c = convert_str(NIS2_SHAPE, &[]).expect("should convert");
+        // Two upstreams, two routes, host defaulted to localhost.
+        assert!(c.toml.contains("[upstream.api]") && c.toml.contains("http://api:8000"));
+        assert!(c.toml.contains("[upstream.web]") && c.toml.contains("http://web:3000"));
+        assert!(c.toml.contains("path = \"/api/{*rest}\""));
+        assert!(c.toml.contains("hosts = [\"localhost\"]"));
+        // per-handler CSP became route csp
+        assert!(c.toml.contains("default-src 'none'"));
+        assert!(c.toml.contains("default-src 'self'"));
+        // the source header is honest
+        assert!(c.toml.contains("zion import caddy"));
+        // header block evaporated to auto; HSTS is partial; XSS + encode unsupported
+        assert!(c
+            .findings
+            .iter()
+            .any(|f| f.status == Status::Partial
+                && f.directive.contains("Strict-Transport-Security")));
+        assert!(c
+            .findings
+            .iter()
+            .any(|f| f.status == Status::Unsupported && f.directive.contains("X-XSS-Protection")));
+        assert!(c
+            .findings
+            .iter()
+            .any(|f| f.status == Status::Unsupported && f.directive == "encode"));
+    }
+
+    #[test]
+    fn tls_email_is_partial_with_placeholder() {
+        let src = "example.com {\n  reverse_proxy app:8080\n  tls ops@example.com\n}";
+        let c = convert_str(src, &[]).expect("convert");
+        let tls = c
+            .findings
+            .iter()
+            .find(|f| f.directive == "tls")
+            .expect("tls finding");
+        assert_eq!(tls.status, Status::Partial);
+        assert!(tls.detail.contains("ops@example.com"));
+        assert!(c.toml.contains("cert_path = \"/etc/ssl/zion/zion.crt\""));
+    }
+
+    #[test]
+    fn explicit_cert_files_convert() {
+        let src = "example.com {\n  reverse_proxy app:8080\n  tls /etc/ssl/a.crt /etc/ssl/a.key\n}";
+        let c = convert_str(src, &[]).expect("convert");
+        assert!(c.toml.contains("cert_path = \"/etc/ssl/a.crt\""));
+        assert!(c.toml.contains("key_path = \"/etc/ssl/a.key\""));
+    }
+
+    #[test]
+    fn file_server_site_has_no_routes() {
+        let src = "example.com {\n  root * /var/www\n  file_server\n}";
+        match convert_str(src, &[]) {
+            Err(ConvertError::NoRoutes(f)) => assert!(f
+                .iter()
+                .any(|x| x.status == Status::Unsupported && x.directive == "file_server")),
+            other => panic!("expected NoRoutes, got {:?}", other.map(|c| c.toml)),
+        }
+    }
+
+    #[test]
+    fn snippet_import_is_inlined() {
+        let src = "(sec) {\n  header X-Frame-Options DENY\n}\nexample.com {\n  import sec\n  reverse_proxy app:8080\n}";
+        let c = convert_str(src, &[]).expect("convert");
+        // X-Frame-Options from the snippet → auto finding
+        assert!(c
+            .findings
+            .iter()
+            .any(|f| f.status == Status::Auto && f.directive.contains("X-Frame-Options")));
+        assert!(c.toml.contains("http://app:8080"));
+    }
+
+    #[test]
+    fn unresolved_domain_without_default_refuses() {
+        let src = "{$PUBLIC} {\n  reverse_proxy app:8080\n}";
+        match convert_str(src, &[]) {
+            Err(ConvertError::NoRoutes(f)) => {
+                assert!(f.iter().any(|x| x.detail.contains("PUBLIC")))
+            }
+            // A hostless route could still emit; assert the finding exists instead.
+            Ok(c) => assert!(c.findings.iter().any(|x| x.detail.contains("PUBLIC"))),
+            Err(e) => panic!("unexpected: {e:?}"),
+        }
+    }
+
+    #[test]
+    fn var_resolves_the_domain() {
+        let src = "{$PUBLIC} {\n  reverse_proxy app:8080\n}";
+        let c = convert_str(src, &[("PUBLIC", "app.example.com")]).expect("convert");
+        assert!(c.toml.contains("hosts = [\"app.example.com\"]"));
+    }
+
+    // ── golden corpus (anonymized fleet shapes) ──
+
+    fn fixture(name: &str) -> String {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/import/caddy")
+            .join(name);
+        std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {name}: {e}"))
+    }
+
+    #[test]
+    fn golden_security_headers() {
+        let c = convert(&fixture("security-headers.caddy"), None, &[]).expect("convert");
+        assert!(c.toml.contains("[upstream.api]") && c.toml.contains("http://api:8000"));
+        assert!(c.toml.contains("[upstream.web]") && c.toml.contains("http://web:3000"));
+        assert!(c.toml.contains("path = \"/api/{*rest}\""));
+        assert!(c.toml.contains("hosts = [\"localhost\"]"));
+        assert!(c
+            .toml
+            .contains("csp = \"default-src 'none'; frame-ancestors 'none'\""));
+        // The header block evaporates: XFO / XCTO / Referrer / Permissions → auto.
+        assert!(
+            c.findings
+                .iter()
+                .filter(|f| f.status == Status::Auto && f.directive.starts_with("header"))
+                .count()
+                >= 4
+        );
+        assert!(c
+            .findings
+            .iter()
+            .any(|f| f.status == Status::Partial
+                && f.directive.contains("Strict-Transport-Security")));
+    }
+
+    #[test]
+    fn golden_tls_acme_is_partial() {
+        let c = convert(&fixture("tls-acme.caddy"), None, &[]).expect("convert");
+        assert!(c.toml.contains("http://backend:8080"));
+        assert!(c.toml.contains("hosts = [\"app.localhost\"]"));
+        let tls = c
+            .findings
+            .iter()
+            .find(|f| f.directive == "tls")
+            .expect("tls");
+        assert_eq!(tls.status, Status::Partial);
+        assert!(tls.detail.contains("ops@example.com"));
+    }
+
+    #[test]
+    fn golden_snippet_import() {
+        let c = convert(&fixture("snippet-import.caddy"), None, &[]).expect("convert");
+        assert!(c.toml.contains("http://api:9000"));
+        assert!(c.toml.contains("http://site:3000"));
+        assert!(c.toml.contains("hosts = [\"example.com\"]"));
+        // The snippet's X-Frame-Options is inlined → auto finding.
+        assert!(c
+            .findings
+            .iter()
+            .any(|f| f.status == Status::Auto && f.directive.contains("X-Frame-Options")));
+    }
+
+    #[test]
+    fn golden_static_edge_refuses() {
+        match convert(&fixture("static-edge.caddy"), None, &[]) {
+            Err(ConvertError::NoRoutes(f)) => assert!(f
+                .iter()
+                .any(|x| x.status == Status::Unsupported && x.directive == "file_server")),
+            other => panic!("expected NoRoutes, got {:?}", other.map(|c| c.toml)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod proptests {
+    use proptest::prelude::*;
+
+    proptest! {
+        // The reader tolerates arbitrary input: it may return Err, but never panics.
+        #[test]
+        fn reader_never_panics(s in ".*") {
+            let _ = super::parse(&s);
+        }
+
+        #[test]
+        fn reader_never_panics_structural(
+            s in prop::collection::vec(
+                prop_oneof![Just("{"), Just("}"), Just("example.com"), Just("reverse_proxy"),
+                            Just("app:80"), Just("{$X}"), Just("{$X:d}"), Just("\n"), Just(" "),
+                            Just("header"), Just("\""), Just("#c\n")],
+                0..64,
+            ).prop_map(|v| v.concat())
+        ) {
+            let _ = super::parse(&s);
+        }
+    }
+}

--- a/src/import/mod.rs
+++ b/src/import/mod.rs
@@ -8,6 +8,7 @@
 //! unsupported), and anything Zion cannot express faithfully is flagged
 //! loudly instead of silently mistranslated.
 
+mod caddy;
 mod compose;
 mod emit;
 mod map;
@@ -263,15 +264,17 @@ fn wildcard_match(pattern: &str, name: &str) -> bool {
 pub fn run(opts: ImportOpts) -> i32 {
     let source = opts.source.as_str();
     match source {
-        "nginx" | "traefik" => {}
+        "nginx" | "traefik" | "caddy" => {}
         "" => {
             eprintln!(
-                "usage: zion import <nginx|traefik> <path|-> [-o zion.toml] [--report file] [--strict] [--var KEY=VALUE]..."
+                "usage: zion import <nginx|traefik|caddy> <path|-> [-o zion.toml] [--report file] [--strict] [--var KEY=VALUE]..."
             );
             return 1;
         }
         other => {
-            eprintln!("zion import: unsupported source '{other}' (supported: nginx, traefik)");
+            eprintln!(
+                "zion import: unsupported source '{other}' (supported: nginx, traefik, caddy)"
+            );
             return 1;
         }
     }
@@ -307,6 +310,7 @@ pub fn run(opts: ImportOpts) -> i32 {
 
     let converted = match source {
         "traefik" => traefik::convert(&src, base_dir.as_deref(), &opts.vars),
+        "caddy" => caddy::convert(&src, base_dir.as_deref(), &opts.vars),
         _ => convert(&src, base_dir.as_deref()),
     };
     let conversion = match converted {

--- a/tests/fixtures/import/caddy/security-headers.caddy
+++ b/tests/fixtures/import/caddy/security-headers.caddy
@@ -1,0 +1,35 @@
+# Anonymized Caddy site: a global security-header block + per-handler CSP over
+# two backends. The interesting result is that the header block "evaporates" —
+# Zion injects the same security headers built-in, so they land in `auto`.
+{$DOMAIN:localhost} {
+    header {
+        Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+        X-Content-Type-Options    "nosniff"
+        X-Frame-Options           "DENY"
+        Referrer-Policy           "strict-origin-when-cross-origin"
+        X-XSS-Protection          "1; mode=block"
+        Permissions-Policy        "geolocation=(), camera=(), microphone=()"
+        -Server
+    }
+
+    handle /api/* {
+        reverse_proxy api:8000
+        header {
+            Content-Security-Policy "default-src 'none'; frame-ancestors 'none'"
+        }
+    }
+
+    handle {
+        reverse_proxy web:3000
+        header {
+            Content-Security-Policy "default-src 'self'; script-src 'self'"
+        }
+    }
+
+    encode gzip zstd
+
+    log {
+        output stdout
+        format json
+    }
+}

--- a/tests/fixtures/import/caddy/snippet-import.caddy
+++ b/tests/fixtures/import/caddy/snippet-import.caddy
@@ -1,0 +1,20 @@
+# Anonymized: a reusable security snippet imported into a site — exercises
+# snippet capture + `import` inlining, plus two path-routed backends.
+(security) {
+    header {
+        X-Frame-Options        "DENY"
+        X-Content-Type-Options "nosniff"
+    }
+}
+
+example.com {
+    import security
+
+    handle /api/* {
+        reverse_proxy api:9000
+    }
+
+    handle {
+        reverse_proxy site:3000
+    }
+}

--- a/tests/fixtures/import/caddy/static-edge.caddy
+++ b/tests/fixtures/import/caddy/static-edge.caddy
@@ -1,0 +1,7 @@
+# Product edge: a static file server. Zion serves nothing from disk, so `root`
+# and `file_server` are `unsupported` and no convertible route is emitted.
+example.com {
+    root * /srv/www
+    file_server
+    encode gzip
+}

--- a/tests/fixtures/import/caddy/tls-acme.caddy
+++ b/tests/fixtures/import/caddy/tls-acme.caddy
@@ -1,0 +1,7 @@
+# Anonymized: a single reverse-proxied site with Caddy-managed TLS (ACME).
+# `tls <email>` → Zion emits a placeholder cert and a `partial` finding that
+# points at [tls.acme] / `zion init`. The host default resolves with no --var.
+{$SITE:app.localhost} {
+    reverse_proxy backend:8080
+    tls ops@example.com
+}


### PR DESCRIPTION
## What

Third front-end of `zion import` (ADR-0013): a **Caddyfile → validated zion.toml** converter on the same neutral `ZionDoc` seam as nginx (#0011) and Traefik (#321). No shared-code change — the `source` name was already threaded through `emit`/`report` by ADR-0012.

```bash
zion import caddy Caddyfile --var DOMAIN=app.example.com -o zion.toml
```

## Design

Unlike the Traefik front-end (labels via the compose reader), a Caddyfile has its own grammar, so `caddy.rs` carries a **tolerant hand-rolled lexer + structural parser** in the `nginx.rs` tradition (std-only, `ParseError{line}`, anti-panic proptest).

- **The tokenizer's one subtlety**: `{` is both a block opener and the start of a placeholder token. `{$DOMAIN:localhost}` is read as **one word**; a `{` led by whitespace / newline / `}` / EOF is a block opener. Parses the global-options block, snippets `(name){…}` resolved by `import`, and site blocks.
- **`{$VAR}` / `{$VAR:default}`** resolved at import from a `.env` next to the file + `--var`; an unresolved required placeholder is a named `unsupported` finding.
- **The header block evaporates** (a pleasing consequence of Zion's design): the security headers Zion already injects → `auto`; `Content-Security-Policy` → `route.csp`; HSTS → `partial` (Zion's `max-age` is fixed); `X-XSS-Protection` → `unsupported`.
- **The product edge, stated loudly**: `root`/`file_server` (Zion serves nothing from disk), `handle_path` (no path rewriting), `respond` (no static responses) → `unsupported`; a handler that only does these drops its route rather than emitting a wrong one.
- **TLS follows ADR-0012**: `tls <email>` / `internal` / `{…}` → placeholder cert + a `partial` finding pointing at `[tls.acme]` / `zion init`; explicit `tls <cert> <key>` converts. Native ACME emission stays deferred.

## Verification

- ✅ `cargo test --bin zion import::caddy` — 21 tests (lexer/parser + mapper + golden corpus + 2 proptests); `--all-features import::` 134 total
- ✅ `cargo clippy --all-targets --all-features -- -D warnings` clean · `cargo fmt --check` clean
- ✅ README SSOT stats refreshed (46 modules, 805 unit tests)
- ✅ End-to-end smoke on all four fixtures (security-headers full-convert, tls-acme partial, snippet-import, static-edge refusal)

## Scope / follow-up

- New `src/import/caddy.rs`; `mod.rs` dispatch is now 3→4-way; `cli.rs` usage `<nginx|traefik|caddy>`.
- ADR-0013 documents the mapping contract (extends ADR-0011/0012); ADR-0012 is untouched (immutable once accepted).
- Deferred, as noted: native `[tls.acme]` emission; the address-less single-site shorthand and mid-word `{$…}` placeholders (out of the v0 declared subset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
