### PR TITLE
feat(import): native [tls.acme] emission (ADR-0014)

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Client -> TLS 1.3 -> Security Gates -> Radix Router -> WAF Pipeline (5 gates) ->
 ```
 
 <!-- zion-stats:modules-lines (kept in sync by scripts/update-readme-stats.sh) -->
-46 modules, ~38,500 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
+46 modules, ~38,800 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
 
 ## Features
 
@@ -286,7 +286,7 @@ MODE=full bash benchmarks/baseline/run-baseline.sh   # → benchmarks/baseline/z
 ## Testing
 
 <!-- zion-stats:test-count (kept in sync by scripts/update-readme-stats.sh) -->
-**805 unit tests** run on every change; **23 integration tests** need a running Zion + a backend.
+**807 unit tests** run on every change; **23 integration tests** need a running Zion + a backend.
 
 ```bash
 cargo test                          # unit tests

--- a/docs/adr/0014-importer-tls-acme-emission.md
+++ b/docs/adr/0014-importer-tls-acme-emission.md
@@ -1,0 +1,79 @@
+# ADR-0014: native `[tls.acme]` emission in the importer
+
+- **Status**: accepted
+- **Date**: 2026-07-31
+- **Deciders**: fabriziosalmi
+- **Tags**: cli, migration, tls, acme, adoption
+
+## Context
+
+ADR-0012 (Traefik) and ADR-0013 (Caddy) each **deferred** native `[tls.acme]`
+emission: a TLS route imported to a placeholder cert plus a `partial` finding,
+and automatic HTTPS was left for the operator to add by hand. That was the right
+call while the front-ends were being built, but with all three importer
+front-ends landed (#320–#322) and the fleet swaps starting, the deferral is now
+the thing standing between an imported config and a *real* swap — every live
+HTTPS target (a Caddy auto-HTTPS site, a Traefik `certresolver` router) would
+otherwise import to a cert that does not exist.
+
+Feasibility is confirmed: Zion's `[tls.acme]` needs only `email` + `domains`
+(the rest of `AcmeConfig` has defaults, and the block is `deny_unknown_fields`),
+`validate_semantics`/`build_router_quiet` do not couple to it, and the
+placeholder `cert_path`/`key_path` are exactly the bootstrap cert the ACME flow
+expects so `:443` binds before the first issuance. An emitter test round-trips a
+`[tls.acme]` document through `self_validate`.
+
+## Decision
+
+Resolve the deferral: the importer emits `[tls.acme]` when the source uses ACME
+and a contact e-mail is known.
+
+- **`ZionDoc` gains `acme: Option<AcmeOut { email, domains }>`**; `emit::render`
+  writes a `[tls.acme]` block (with the bootstrap-cert comment) and only the two
+  known fields. The bootstrap cert stays in `[tls]`.
+- **E-mail source**, in precedence order: the source config's own ACME e-mail
+  (Traefik `--certificatesresolvers.<r>.acme.email`, Caddy `tls <email>` or the
+  global `email`), else the new **`--acme-email EMAIL`** CLI flag. An e-mail is
+  never invented.
+- **Domains** are the imported route hosts (Caddy restricts to non-localhost /
+  non-IP hosts; a bare-port or localhost-only site gets no ACME).
+- **Findings**: Traefik `certresolver` and Caddy ACME-managed `tls` move from
+  `partial` to **`convert`** when an e-mail is available; with no e-mail they
+  stay `partial` and name the fix (`--acme-email …`). Explicit Caddy
+  `tls <cert> <key>` still converts to `[tls]` cert paths (no ACME).
+- **The certificate-manager caveat is preserved, not auto-resolved**: when the
+  origin is itself a cert manager, running ACME in parallel is wrong — but the
+  importer cannot know that, so it faithfully translates the source's ACME
+  intent and the finding notes the alternative (point `[tls]` at the existing
+  cert). That stays a per-repo deployment decision.
+
+## Consequences
+
+- **Positive**: an HTTPS target now imports to a config that actually serves
+  HTTPS. `zion import caddy Caddyfile --var DOMAIN=… --acme-email ops@…` yields a
+  complete `zion.toml` with a real `[tls.acme]` — the missing half of a live
+  swap. No new dependencies; only known `AcmeConfig` fields are emitted.
+- **Negative**: one more doc-level aggregation in each front-end (union of route
+  hosts → ACME domains) and a shared `AcmeOut` on the neutral seam.
+- **Neutral / risks**: `[tls.acme]` is emitted only on explicit ACME intent
+  (a source ACME directive) or an explicit `--acme-email` opt-in — never
+  inferred from a public-looking hostname alone, so an import never silently
+  turns on ACME the operator did not ask for.
+
+## Alternatives considered
+
+- **Keep deferring** — rejected: it is the blocker to real swaps now that the
+  front-ends are done.
+- **Invent / default an e-mail** — rejected: a wrong ACME account e-mail is worse
+  than an honest `partial`. No e-mail → stay `partial`.
+- **Emit `[tls.acme]` for every public-looking host** — rejected: importing a
+  config should not silently enable ACME issuance; require an ACME signal or the
+  `--acme-email` opt-in.
+
+## References
+
+- ADR-0012 / ADR-0013 (the deferral this resolves); ADR-0011 (the seam)
+- `src/import/map.rs` (`AcmeOut`, `ZionDoc.acme`), `src/import/emit.rs`
+  (`[tls.acme]` render + round-trip test), `src/import/traefik.rs` /
+  `src/import/caddy.rs` (population + findings), `src/cli.rs` (`--acme-email`)
+- `[tls.acme]` / `AcmeConfig` in `src/config.rs`, `src/acme.rs`

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -24,6 +24,7 @@ defined in [0000-template.md](0000-template.md).
 | 0011  | [`zion import` — nginx config migration, honesty over completeness](0011-zion-import-nginx.md) | accepted |
 | 0012  | [`zion import traefik` — a second front-end on the neutral seam](0012-zion-import-traefik.md) | accepted |
 | 0013  | [`zion import caddy` — third front-end, own Caddyfile parser](0013-zion-import-caddy.md) | accepted |
+| 0014  | [Native `[tls.acme]` emission in the importer](0014-importer-tls-acme-emission.md) | accepted |
 
 ## When to write a new ADR
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -99,6 +99,10 @@ pub struct ImportOpts {
     /// `--var KEY=VALUE` overrides for `${...}` expansion (traefik front-end);
     /// these win over a `.env` next to the compose file.
     pub vars: Vec<(String, String)>,
+    /// `--acme-email EMAIL`: emit a `[tls.acme]` block for automatic HTTPS when
+    /// the source uses ACME (Traefik certresolver / Caddy auto-HTTPS). Without
+    /// it, ACME-managed TLS imports to a placeholder cert + a partial finding.
+    pub acme_email: Option<String>,
 }
 
 /// Options for `zion init`. All flags are additive — the wizard fills in
@@ -276,6 +280,10 @@ fn parse_import_opts(args: &[String]) -> ImportOpts {
                 if let Some((k, v)) = flag_value(args, i).and_then(|kv| kv.split_once('=')) {
                     opts.vars.push((k.to_string(), v.to_string()));
                 }
+                i += 2;
+            }
+            "--acme-email" if flag_value(args, i).is_some() => {
+                opts.acme_email = flag_value(args, i).cloned();
                 i += 2;
             }
             // Positionals: first the source format, then the input path

--- a/src/import/caddy.rs
+++ b/src/import/caddy.rs
@@ -34,7 +34,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::path::Path;
 
-use super::map::{RouteOut, UpstreamOut, ZionDoc};
+use super::map::{AcmeOut, RouteOut, UpstreamOut, ZionDoc};
 use super::{emit, Conversion, ConvertError, Finding, Status};
 
 /// Placeholder cert paths (mirrors the nginx/Traefik convention): schema
@@ -49,12 +49,13 @@ pub(super) fn convert(
     src: &str,
     base_dir: Option<&Path>,
     cli_vars: &[(String, String)],
+    cli_acme_email: Option<&str>,
 ) -> Result<Conversion, ConvertError> {
     let file = parse(src).map_err(|e| ConvertError::Parse(e.to_string()))?;
     let env = Env::load(base_dir, cli_vars);
 
     let mut findings = Vec::new();
-    let doc = build(&file, &env, &mut findings);
+    let doc = build(&file, &env, cli_acme_email, &mut findings);
     findings.sort_by_key(|f| f.line);
 
     if doc.routes.is_empty() {
@@ -504,7 +505,12 @@ fn unquote(s: &str) -> &str {
 
 // ── Mapper ────────────────────────────────────────────────────────────────
 
-fn build(file: &Caddyfile, env: &Env, findings: &mut Vec<Finding>) -> ZionDoc {
+fn build(
+    file: &Caddyfile,
+    env: &Env,
+    cli_acme_email: Option<&str>,
+    findings: &mut Vec<Finding>,
+) -> ZionDoc {
     let mut doc = ZionDoc {
         listen_http: "0.0.0.0:80".to_string(),
         listen_https: "0.0.0.0:443".to_string(),
@@ -515,6 +521,7 @@ fn build(file: &Caddyfile, env: &Env, findings: &mut Vec<Finding>) -> ZionDoc {
         tls_key: PLACEHOLDER_KEY.to_string(),
         tls_min12: false,
         sni: Vec::new(),
+        acme: None,
         waf_body_mb: None,
         upstreams: Vec::new(),
         routes: Vec::new(),
@@ -534,6 +541,7 @@ fn build(file: &Caddyfile, env: &Env, findings: &mut Vec<Finding>) -> ZionDoc {
             &hosts,
             env,
             &acme_email,
+            cli_acme_email,
             &mut doc,
             &mut seen_upstreams,
             findings,
@@ -639,6 +647,7 @@ fn map_site(
     hosts: &[String],
     env: &Env,
     acme_email: &Option<String>,
+    cli_acme_email: Option<&str>,
     doc: &mut ZionDoc,
     seen_upstreams: &mut BTreeSet<String>,
     findings: &mut Vec<Finding>,
@@ -654,7 +663,7 @@ fn map_site(
                     site_csp = Some(csp);
                 }
             }
-            "tls" => map_tls(node, acme_email, doc, findings),
+            "tls" => map_tls(node, doc, findings),
             "encode" => findings.push(Finding::new(
                 Status::Unsupported,
                 node.line,
@@ -732,6 +741,8 @@ fn map_site(
             _ => {}
         }
     }
+
+    apply_site_acme(body, hosts, acme_email, cli_acme_email, doc, findings);
 }
 
 /// Map a `header` block. Security headers Zion already injects → `auto`;
@@ -787,18 +798,9 @@ fn map_header(node: &Node, findings: &mut Vec<Finding>) -> Option<String> {
 
 /// `tls email` / `tls { … }` / `tls internal` → placeholder cert + `partial`
 /// (ACME deferred). `tls <cert> <key>` (explicit files) → convert.
-fn map_tls(
-    node: &Node,
-    acme_email: &Option<String>,
-    doc: &mut ZionDoc,
-    findings: &mut Vec<Finding>,
-) {
-    // Explicit cert + key files.
-    if node.args.len() == 2
-        && !node.args[0].contains('@')
-        && node.args[0] != "internal"
-        && node.args[1] != "internal"
-    {
+fn map_tls(node: &Node, doc: &mut ZionDoc, findings: &mut Vec<Finding>) {
+    // Explicit cert + key files → a real cert.
+    if is_explicit_cert(node) {
         doc.tls_cert = node.args[0].clone();
         doc.tls_key = node.args[1].clone();
         findings.push(Finding::new(
@@ -823,23 +825,84 @@ fn map_tls(
             }
         }
     }
-    let email = node
-        .args
+    // ACME-managed TLS (`tls <email>` / `internal` / bare) is decided at the
+    // site level in `apply_site_acme`, which can see the site hosts.
+}
+
+fn is_explicit_cert(node: &Node) -> bool {
+    node.args.len() == 2
+        && !node.args[0].contains('@')
+        && node.args[0] != "internal"
+        && node.args[1] != "internal"
+}
+
+/// Decide automatic HTTPS for a site: emit `[tls.acme]` when the site uses
+/// ACME-managed TLS (a `tls` directive that isn't explicit cert files, or the
+/// operator opting in with `--acme-email`) and a contact e-mail is known.
+fn apply_site_acme(
+    body: &[Node],
+    hosts: &[String],
+    global_email: &Option<String>,
+    cli_acme_email: Option<&str>,
+    doc: &mut ZionDoc,
+    findings: &mut Vec<Finding>,
+) {
+    let tls_node = body.iter().find(|n| n.name == "tls");
+    if tls_node.map(is_explicit_cert).unwrap_or(false) {
+        return; // a real cert, not ACME (map_tls handled it)
+    }
+    if tls_node.is_none() && cli_acme_email.is_none() {
+        return; // no ACME intent — the operator supplies TLS
+    }
+    let public: Vec<String> = hosts
         .iter()
-        .find(|a| a.contains('@'))
+        .filter(|h| *h != "localhost" && h.parse::<std::net::IpAddr>().is_err())
         .cloned()
-        .or_else(|| acme_email.clone())
-        .unwrap_or_else(|| "you@example.com".to_string());
-    findings.push(Finding::new(
-        Status::Partial,
-        node.line,
-        "tls",
-        format!(
-            "Caddy manages this certificate (ACME/internal) → Zion emits a placeholder cert. \
-             Add [tls.acme] (email = \"{email}\", domains = the route hosts) or run `zion init`; \
-             if the origin is a certificate manager, point [tls] at its cert instead"
-        ),
-    ));
+        .collect();
+    if public.is_empty() {
+        return; // localhost / IP only — no public cert
+    }
+    let line = tls_node.map(|n| n.line).unwrap_or(0);
+    let email = tls_node
+        .and_then(|n| n.args.iter().find(|a| a.contains('@')).cloned())
+        .or_else(|| cli_acme_email.map(String::from))
+        .or_else(|| global_email.clone());
+    match email {
+        Some(email) => {
+            findings.push(Finding::new(
+                Status::Convert,
+                line,
+                "tls (ACME)",
+                format!(
+                    "automatic HTTPS → [tls.acme] (email = \"{email}\") for {}",
+                    public.join(", ")
+                ),
+            ));
+            match &mut doc.acme {
+                Some(acme) => {
+                    for h in &public {
+                        if !acme.domains.contains(h) {
+                            acme.domains.push(h.clone());
+                        }
+                    }
+                }
+                None => {
+                    doc.acme = Some(AcmeOut {
+                        email,
+                        domains: public,
+                    })
+                }
+            }
+        }
+        None => findings.push(Finding::new(
+            Status::Partial,
+            line,
+            "tls (ACME)",
+            "Caddy auto-HTTPS → placeholder cert. Pass `--acme-email you@example.com` to emit \
+             [tls.acme], or point [tls] at an existing certificate manager's cert"
+                .to_string(),
+        )),
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1102,7 +1165,7 @@ mod tests {
             .iter()
             .map(|(k, v)| (k.to_string(), v.to_string()))
             .collect();
-        convert(src, None, &cli)
+        convert(src, None, &cli, None)
     }
 
     // ── lexer / parser ──
@@ -1257,17 +1320,31 @@ mod tests {
     }
 
     #[test]
-    fn tls_email_is_partial_with_placeholder() {
+    fn tls_email_emits_acme() {
         let src = "example.com {\n  reverse_proxy app:8080\n  tls ops@example.com\n}";
         let c = convert_str(src, &[]).expect("convert");
         let tls = c
             .findings
             .iter()
-            .find(|f| f.directive == "tls")
-            .expect("tls finding");
-        assert_eq!(tls.status, Status::Partial);
-        assert!(tls.detail.contains("ops@example.com"));
+            .find(|f| f.directive == "tls (ACME)")
+            .expect("acme finding");
+        assert_eq!(tls.status, Status::Convert);
+        assert!(c.toml.contains("[tls.acme]"));
+        assert!(c.toml.contains("email = \"ops@example.com\""));
+        assert!(c.toml.contains("domains = [\"example.com\"]"));
+        // The bootstrap cert stays so :443 binds before issuance.
         assert!(c.toml.contains("cert_path = \"/etc/ssl/zion/zion.crt\""));
+    }
+
+    #[test]
+    fn acme_email_flag_opts_in_without_a_tls_directive() {
+        // The nis2 swap case: implicit auto-HTTPS, no e-mail in the Caddyfile;
+        // --acme-email supplies it and we emit a real [tls.acme].
+        let src = "app.example.com {\n  reverse_proxy web:3000\n}";
+        let c = convert(src, None, &[], Some("ops@example.com")).expect("convert");
+        assert!(c.toml.contains("[tls.acme]"));
+        assert!(c.toml.contains("email = \"ops@example.com\""));
+        assert!(c.toml.contains("domains = [\"app.example.com\"]"));
     }
 
     #[test]
@@ -1332,7 +1409,7 @@ mod tests {
 
     #[test]
     fn golden_security_headers() {
-        let c = convert(&fixture("security-headers.caddy"), None, &[]).expect("convert");
+        let c = convert(&fixture("security-headers.caddy"), None, &[], None).expect("convert");
         assert!(c.toml.contains("[upstream.api]") && c.toml.contains("http://api:8000"));
         assert!(c.toml.contains("[upstream.web]") && c.toml.contains("http://web:3000"));
         assert!(c.toml.contains("path = \"/api/{*rest}\""));
@@ -1356,22 +1433,24 @@ mod tests {
     }
 
     #[test]
-    fn golden_tls_acme_is_partial() {
-        let c = convert(&fixture("tls-acme.caddy"), None, &[]).expect("convert");
+    fn golden_tls_acme_emits_acme() {
+        let c = convert(&fixture("tls-acme.caddy"), None, &[], None).expect("convert");
         assert!(c.toml.contains("http://backend:8080"));
-        assert!(c.toml.contains("hosts = [\"app.localhost\"]"));
+        assert!(c.toml.contains("hosts = [\"app.example.com\"]"));
         let tls = c
             .findings
             .iter()
-            .find(|f| f.directive == "tls")
-            .expect("tls");
-        assert_eq!(tls.status, Status::Partial);
-        assert!(tls.detail.contains("ops@example.com"));
+            .find(|f| f.directive == "tls (ACME)")
+            .expect("acme finding");
+        assert_eq!(tls.status, Status::Convert);
+        assert!(c.toml.contains("[tls.acme]"));
+        assert!(c.toml.contains("email = \"ops@example.com\""));
+        assert!(c.toml.contains("domains = [\"app.example.com\"]"));
     }
 
     #[test]
     fn golden_snippet_import() {
-        let c = convert(&fixture("snippet-import.caddy"), None, &[]).expect("convert");
+        let c = convert(&fixture("snippet-import.caddy"), None, &[], None).expect("convert");
         assert!(c.toml.contains("http://api:9000"));
         assert!(c.toml.contains("http://site:3000"));
         assert!(c.toml.contains("hosts = [\"example.com\"]"));
@@ -1384,7 +1463,7 @@ mod tests {
 
     #[test]
     fn golden_static_edge_refuses() {
-        match convert(&fixture("static-edge.caddy"), None, &[]) {
+        match convert(&fixture("static-edge.caddy"), None, &[], None) {
             Err(ConvertError::NoRoutes(f)) => assert!(f
                 .iter()
                 .any(|x| x.status == Status::Unsupported && x.directive == "file_server")),

--- a/src/import/emit.rs
+++ b/src/import/emit.rs
@@ -54,6 +54,22 @@ pub fn render(doc: &ZionDoc, source: &str) -> String {
     }
     out.push('\n');
 
+    if let Some(acme) = &doc.acme {
+        out.push_str("# Automatic HTTPS via ACME. The cert_path/key_path above are only a\n");
+        out.push_str("# bootstrap cert so :443 binds before the first issuance.\n");
+        out.push_str("[tls.acme]\n");
+        kv(&mut out, "email", &acme.email);
+        out.push_str(&format!(
+            "domains = [{}]\n",
+            acme.domains
+                .iter()
+                .map(|d| toml_str(d))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+        out.push('\n');
+    }
+
     if let Some(mb) = doc.waf_body_mb {
         out.push_str("# Body cap imported from client_max_body_size. Shadow mode logs\n");
         out.push_str("# would-be blocks without enforcing; set waf_shadow = false on the\n");
@@ -191,6 +207,7 @@ mod tests {
             tls_key: "/k".into(),
             tls_min12: false,
             sni: Vec::new(),
+            acme: None,
             waf_body_mb: None,
             upstreams: vec![super::super::map::UpstreamOut {
                 name: "b".into(),
@@ -238,6 +255,7 @@ mod tests {
             tls_key: "/etc/ssl/zion/zion.key".into(),
             tls_min12: false,
             sni: Vec::new(),
+            acme: None,
             waf_body_mb: None,
             upstreams: vec![super::super::map::UpstreamOut {
                 name: "backend".into(),
@@ -276,6 +294,7 @@ mod tests {
                 cert: "/etc/ssl/b.crt".into(),
                 key: "/etc/ssl/b.key".into(),
             }],
+            acme: None,
             waf_body_mb: Some(64),
             upstreams: vec![super::super::map::UpstreamOut {
                 name: "pool".into(),
@@ -300,5 +319,47 @@ mod tests {
         assert!(toml.contains("waf_profile = \"imported\""));
         assert!(toml.contains("waf_shadow = true"));
         assert!(toml.contains("mode = \"websocket\""));
+    }
+
+    #[test]
+    fn acme_block_renders_and_validates() {
+        let doc = ZionDoc {
+            listen_http: "0.0.0.0:80".into(),
+            listen_https: "0.0.0.0:443".into(),
+            rate_limit: None,
+            max_conn_per_ip: None,
+            trusted_proxies: Vec::new(),
+            tls_cert: "/etc/ssl/zion/zion.crt".into(),
+            tls_key: "/etc/ssl/zion/zion.key".into(),
+            tls_min12: false,
+            sni: Vec::new(),
+            acme: Some(super::super::map::AcmeOut {
+                email: "ops@example.com".into(),
+                domains: vec!["app.example.com".into(), "www.app.example.com".into()],
+            }),
+            waf_body_mb: None,
+            upstreams: vec![super::super::map::UpstreamOut {
+                name: "backend".into(),
+                urls: vec!["http://127.0.0.1:8080".into()],
+                connect_timeout_ms: None,
+                keepalive: None,
+            }],
+            routes: vec![super::super::map::RouteOut {
+                path: "/{*rest}".into(),
+                hosts: Some(vec!["app.example.com".into()]),
+                upstream: "backend".into(),
+                websocket: false,
+                csp: None,
+                waf: false,
+                annotations: Vec::new(),
+            }],
+        };
+        let toml = render(&doc, "caddy");
+        assert!(toml.contains("[tls.acme]"));
+        assert!(toml.contains("email = \"ops@example.com\""));
+        assert!(toml.contains("domains = [\"app.example.com\", \"www.app.example.com\"]"));
+        // The bootstrap cert must still be present so :443 binds before issuance.
+        assert!(toml.contains("cert_path = \"/etc/ssl/zion/zion.crt\""));
+        self_validate(&toml).expect("[tls.acme] output must self-validate");
     }
 }

--- a/src/import/map.rs
+++ b/src/import/map.rs
@@ -25,6 +25,10 @@ pub struct ZionDoc {
     pub tls_key: String,
     pub tls_min12: bool,
     pub sni: Vec<SniOut>,
+    /// Emit a `[tls.acme]` block for automatic HTTPS. The bootstrap cert stays
+    /// in `tls_cert`/`tls_key`; populated by the Traefik/Caddy front-ends when
+    /// the source uses ACME and a contact e-mail is known.
+    pub acme: Option<AcmeOut>,
     pub waf_body_mb: Option<u64>,
     pub upstreams: Vec<UpstreamOut>,
     pub routes: Vec<RouteOut>,
@@ -35,6 +39,12 @@ pub struct SniOut {
     pub server_name: String,
     pub cert: String,
     pub key: String,
+}
+
+#[derive(Debug)]
+pub struct AcmeOut {
+    pub email: String,
+    pub domains: Vec<String>,
 }
 
 #[derive(Debug)]
@@ -76,6 +86,7 @@ pub fn map_model(model: &NginxModel, findings: &mut Vec<Finding>) -> ZionDoc {
         tls_key: PLACEHOLDER_KEY.to_string(),
         tls_min12: false,
         sni: Vec::new(),
+        acme: None,
         waf_body_mb: None,
         upstreams: Vec::new(),
         routes: Vec::new(),

--- a/src/import/mod.rs
+++ b/src/import/mod.rs
@@ -267,7 +267,7 @@ pub fn run(opts: ImportOpts) -> i32 {
         "nginx" | "traefik" | "caddy" => {}
         "" => {
             eprintln!(
-                "usage: zion import <nginx|traefik|caddy> <path|-> [-o zion.toml] [--report file] [--strict] [--var KEY=VALUE]..."
+                "usage: zion import <nginx|traefik|caddy> <path|-> [-o zion.toml] [--report file] [--strict] [--var KEY=VALUE]... [--acme-email EMAIL]"
             );
             return 1;
         }
@@ -309,8 +309,18 @@ pub fn run(opts: ImportOpts) -> i32 {
     };
 
     let converted = match source {
-        "traefik" => traefik::convert(&src, base_dir.as_deref(), &opts.vars),
-        "caddy" => caddy::convert(&src, base_dir.as_deref(), &opts.vars),
+        "traefik" => traefik::convert(
+            &src,
+            base_dir.as_deref(),
+            &opts.vars,
+            opts.acme_email.as_deref(),
+        ),
+        "caddy" => caddy::convert(
+            &src,
+            base_dir.as_deref(),
+            &opts.vars,
+            opts.acme_email.as_deref(),
+        ),
         _ => convert(&src, base_dir.as_deref()),
     };
     let conversion = match converted {

--- a/src/import/traefik.rs
+++ b/src/import/traefik.rs
@@ -35,7 +35,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 
-use super::map::{RouteOut, UpstreamOut, ZionDoc};
+use super::map::{AcmeOut, RouteOut, UpstreamOut, ZionDoc};
 use super::{compose, emit, Conversion, ConvertError, Finding, Status};
 
 /// Placeholder cert paths, mirroring the nginx path's convention (map.rs):
@@ -53,13 +53,14 @@ pub(super) fn convert(
     src: &str,
     base_dir: Option<&Path>,
     cli_vars: &[(String, String)],
+    cli_acme_email: Option<&str>,
 ) -> Result<Conversion, ConvertError> {
     let file = compose::parse(src)
         .map_err(|e| ConvertError::Parse(format!("line {}: {}", e.line, e.msg)))?;
     let env = Env::load(base_dir, cli_vars);
 
     let mut findings = Vec::new();
-    let doc = build(&file, &env, &mut findings);
+    let doc = build(&file, &env, cli_acme_email, &mut findings);
     findings.sort_by_key(|f| f.line);
 
     if doc.routes.is_empty() {
@@ -220,7 +221,12 @@ struct StaticCfg {
     acme_email: Option<String>,
 }
 
-fn build(file: &compose::ComposeFile, env: &Env, findings: &mut Vec<Finding>) -> ZionDoc {
+fn build(
+    file: &compose::ComposeFile,
+    env: &Env,
+    cli_acme_email: Option<&str>,
+    findings: &mut Vec<Finding>,
+) -> ZionDoc {
     let mut doc = ZionDoc {
         listen_http: "0.0.0.0:80".to_string(),
         listen_https: "0.0.0.0:443".to_string(),
@@ -231,14 +237,17 @@ fn build(file: &compose::ComposeFile, env: &Env, findings: &mut Vec<Finding>) ->
         tls_key: PLACEHOLDER_KEY.to_string(),
         tls_min12: false,
         sni: Vec::new(),
+        acme: None,
         waf_body_mb: None,
         upstreams: Vec::new(),
         routes: Vec::new(),
     };
 
     let statics = parse_static(file, env, &mut doc, findings);
+    let acme_email = statics.acme_email.as_deref().or(cli_acme_email);
 
     let mut seen_upstreams: BTreeSet<String> = BTreeSet::new();
+    let mut acme_wanted = false;
     for svc in &file.services {
         if is_traefik_service(svc) {
             continue;
@@ -249,18 +258,43 @@ fn build(file: &compose::ComposeFile, env: &Env, findings: &mut Vec<Finding>) ->
             // explicitly-enabled containers are routed.
             continue;
         }
+        if routing.routers.values().any(|r| r.certresolver.is_some()) {
+            acme_wanted = true;
+        }
         for (rname, r) in &routing.routers {
             build_route(
                 svc,
                 rname,
                 r,
                 &routing,
-                &statics,
+                acme_email,
                 env,
                 &mut doc,
                 &mut seen_upstreams,
                 findings,
             );
+        }
+    }
+
+    // A certresolver + a known e-mail → a real [tls.acme] block. The ACME
+    // domains are the union of the imported route hosts; the bootstrap cert
+    // stays in [tls] so :443 binds before the first issuance.
+    if acme_wanted {
+        if let Some(email) = acme_email {
+            let mut domains: Vec<String> = doc
+                .routes
+                .iter()
+                .filter_map(|r| r.hosts.clone())
+                .flatten()
+                .collect();
+            domains.sort();
+            domains.dedup();
+            if !domains.is_empty() {
+                doc.acme = Some(AcmeOut {
+                    email: email.to_string(),
+                    domains,
+                });
+            }
         }
     }
     doc
@@ -463,7 +497,7 @@ fn build_route(
     rname: &str,
     router: &Router,
     routing: &Routing,
-    statics: &StaticCfg,
+    acme_email: Option<&str>,
     env: &Env,
     doc: &mut ZionDoc,
     seen_upstreams: &mut BTreeSet<String>,
@@ -519,17 +553,25 @@ fn build_route(
 
     // TLS is a listener concern in Zion; a placeholder cert lets :443 bind.
     if let Some((resolver, cl)) = &router.certresolver {
-        let email = statics.acme_email.as_deref().unwrap_or("you@example.com");
-        findings.push(Finding::new(
-            Status::Partial,
-            *cl,
-            format!("routers.{rname}.tls.certresolver={resolver}"),
-            format!(
-                "Traefik ACME → Zion emits a placeholder cert. For automatic HTTPS add \
-                 [tls.acme] (email = \"{email}\", domains = the route hosts) or run `zion init`; \
-                 if the origin is a certificate manager, point [tls] at its cert instead"
-            ),
-        ));
+        match acme_email {
+            Some(email) => findings.push(Finding::new(
+                Status::Convert,
+                *cl,
+                format!("routers.{rname}.tls.certresolver={resolver}"),
+                format!(
+                    "Traefik ACME → [tls.acme] (email = \"{email}\"); the route hosts become the \
+                     ACME domains, on the [tls] bootstrap cert until first issuance"
+                ),
+            )),
+            None => findings.push(Finding::new(
+                Status::Partial,
+                *cl,
+                format!("routers.{rname}.tls.certresolver={resolver}"),
+                "Traefik ACME → placeholder cert. Pass `--acme-email you@example.com` to emit \
+                 [tls.acme], or point [tls] at an existing certificate manager's cert"
+                    .to_string(),
+            )),
+        }
     } else if router.tls {
         findings.push(Finding::new(
             Status::Partial,
@@ -757,7 +799,7 @@ mod tests {
             .iter()
             .map(|(k, v)| (k.to_string(), v.to_string()))
             .collect();
-        convert(src, None, &cli)
+        convert(src, None, &cli, None)
     }
 
     // ── variable resolution ──
@@ -925,7 +967,7 @@ services:
     }
 
     #[test]
-    fn tls_certresolver_is_partial_not_silent() {
+    fn tls_certresolver_emits_acme() {
         let src = r#"
 services:
   traefik:
@@ -949,8 +991,11 @@ services:
             .iter()
             .find(|f| f.directive.contains("certresolver"))
             .expect("certresolver finding");
-        assert_eq!(tls.status, Status::Partial);
+        assert_eq!(tls.status, Status::Convert);
         assert!(tls.detail.contains("ops@example.com"));
+        assert!(c.toml.contains("[tls.acme]"));
+        assert!(c.toml.contains("email = \"ops@example.com\""));
+        assert!(c.toml.contains("domains = [\"app.io\"]"));
         assert!(c.toml.contains("http://fe:3000"));
     }
 
@@ -975,7 +1020,7 @@ services:
 
     #[test]
     fn golden_http_only() {
-        let c = convert(&fixture("http-only.yml"), None, &[]).expect("convert");
+        let c = convert(&fixture("http-only.yml"), None, &[], None).expect("convert");
         assert!(c.toml.contains("[upstream.app]"));
         assert!(c.toml.contains("http://app:8000"));
         assert!(c
@@ -986,7 +1031,7 @@ services:
 
     #[test]
     fn golden_tls_default_host_defaults_and_tls_is_partial() {
-        let c = convert(&fixture("tls-default.yml"), None, &[]).expect("convert");
+        let c = convert(&fixture("tls-default.yml"), None, &[], None).expect("convert");
         assert!(c.toml.contains("http://web:8080"));
         assert!(c.toml.contains("hosts = [\"localhost\"]"));
         assert!(c
@@ -1009,20 +1054,21 @@ services:
             ("PUBLIC_FQDN".to_string(), "app.example.com".to_string()),
             ("ACME_EMAIL".to_string(), "ops@example.com".to_string()),
         ];
-        let c = convert(&fixture("acme-certresolver.yml"), None, &vars).expect("convert");
+        let c = convert(&fixture("acme-certresolver.yml"), None, &vars, None).expect("convert");
         assert!(c.toml.contains("[upstream.frontend]") && c.toml.contains("http://frontend:3000"));
         assert!(c.toml.contains("[upstream.backend]") && c.toml.contains("http://backend:8000"));
         assert!(c.toml.contains("path = \"/api/{*rest}\""));
-        // certresolver → partial, twice, echoing the discovered ACME email.
-        let partials: Vec<_> = c
+        // certresolver → convert (×2) and a real [tls.acme] block is emitted.
+        let cr: Vec<_> = c
             .findings
             .iter()
             .filter(|f| f.directive.contains("certresolver"))
             .collect();
-        assert_eq!(partials.len(), 2);
-        assert!(partials
-            .iter()
-            .all(|f| f.status == Status::Partial && f.detail.contains("ops@example.com")));
+        assert_eq!(cr.len(), 2);
+        assert!(cr.iter().all(|f| f.status == Status::Convert));
+        assert!(c.toml.contains("[tls.acme]"));
+        assert!(c.toml.contains("email = \"ops@example.com\""));
+        assert!(c.toml.contains("domains = [\"app.example.com\"]"));
         // the /.well-known/acme-challenge router is dropped as `auto`.
         assert!(c
             .findings
@@ -1032,7 +1078,7 @@ services:
 
     #[test]
     fn golden_acme_without_vars_refuses() {
-        match convert(&fixture("acme-certresolver.yml"), None, &[]) {
+        match convert(&fixture("acme-certresolver.yml"), None, &[], None) {
             Err(ConvertError::NoRoutes(f)) => {
                 assert!(f.iter().any(|x| x.detail.contains("PUBLIC_FQDN")))
             }
@@ -1042,7 +1088,7 @@ services:
 
     #[test]
     fn golden_label_without_service_refuses() {
-        match convert(&fixture("label-without-service.yml"), None, &[]) {
+        match convert(&fixture("label-without-service.yml"), None, &[], None) {
             Err(ConvertError::NoRoutes(f)) => {
                 assert!(f.iter().any(|x| x.status == Status::Unsupported
                     && x.detail.contains("loadbalancer.server.port")))
@@ -1059,7 +1105,7 @@ services:
         std::fs::create_dir_all(&dir).unwrap();
         let compose = HTTP_ONLY.replace("Host(`a.io`) || Host(`b.io`)", "Host(`${SITE}`)");
         std::fs::write(dir.join(".env"), "SITE=env.example.com\n").unwrap();
-        let c = convert(&compose, Some(dir.as_path()), &[]).expect("convert via .env");
+        let c = convert(&compose, Some(dir.as_path()), &[], None).expect("convert via .env");
         assert!(c.toml.contains("hosts = [\"env.example.com\"]"));
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/tests/fixtures/import/caddy/tls-acme.caddy
+++ b/tests/fixtures/import/caddy/tls-acme.caddy
@@ -1,7 +1,7 @@
 # Anonymized: a single reverse-proxied site with Caddy-managed TLS (ACME).
 # `tls <email>` → Zion emits a placeholder cert and a `partial` finding that
 # points at [tls.acme] / `zion init`. The host default resolves with no --var.
-{$SITE:app.localhost} {
+{$SITE:app.example.com} {
     reverse_proxy backend:8080
     tls ops@example.com
 }


### PR DESCRIPTION
## What

Native **`[tls.acme]` emission** in the importer (ADR-0014) — resolves the deferral stated in ADR-0012/0013. An HTTPS target now imports to **real automatic HTTPS** instead of a placeholder cert + a `partial` finding.

```bash
zion import caddy Caddyfile --var DOMAIN=nis2.example.com --acme-email ops@nis2.example.com
# → [tls.acme] email = "ops@nis2.example.com"  domains = ["nis2.example.com"]
```

## Design

- **`ZionDoc` gains `acme: Option<AcmeOut{email,domains}>`**; `emit.rs` renders a `[tls.acme]` block (only `email`+`domains` — the block is `deny_unknown_fields`). The placeholder cert stays in `[tls]` as the ACME bootstrap cert, verified by an emitter round-trip through `self_validate`.
- **E-mail source (precedence)**: the source's own ACME e-mail (Traefik `certresolver` `acme.email` / Caddy `tls <email>` / global `email`), else the new **`--acme-email EMAIL`** flag. Never invented.
- **Findings move `partial` → `convert`** when an e-mail is available: Traefik `certresolver` (domains = route hosts), Caddy ACME-managed `tls` or an `--acme-email` opt-in (non-localhost hosts only). With no e-mail they stay `partial` and name the fix.
- **The certificate-manager caveat stays a finding** — the importer faithfully translates the source's ACME intent; when the origin is itself a cert manager, consuming its cert instead is a per-repo deployment decision, surfaced not auto-resolved.
- Emission requires explicit ACME intent (a source directive) or `--acme-email` — never inferred from a public-looking hostname, so an import never silently turns on ACME.

## Verification

- ✅ Emitter round-trips a `[tls.acme]` doc through `self_validate` (feasibility test)
- ✅ `cargo test --bin zion` — 615 pass (import: 136); the certresolver/tls tests updated to assert the new `convert` + `[tls.acme]`
- ✅ `cargo clippy --all-targets --all-features -- -D warnings` clean · `fmt` clean · README SSOT refreshed
- ✅ **End-to-end on the real nis2-public Caddyfile** → a complete `zion.toml` with a real `[tls.acme]` block: the missing half of a live swap

## Why now

The importer trio (nginx/traefik/caddy, #320–#322) is done and the fleet swaps are starting; without ACME emission every live HTTPS target imports to a cert that doesn't exist. This closes that gap. ADR-0014 documents the decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
