### PR TITLE
feat(config): mode="static" — opt-in disk file serving (ADR-0015)

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Client -> TLS 1.3 -> Security Gates -> Radix Router -> WAF Pipeline (5 gates) ->
 ```
 
 <!-- zion-stats:modules-lines (kept in sync by scripts/update-readme-stats.sh) -->
-46 modules, ~38,800 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
+47 modules, ~39,200 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
 
 ## Features
 
@@ -286,7 +286,7 @@ MODE=full bash benchmarks/baseline/run-baseline.sh   # → benchmarks/baseline/z
 ## Testing
 
 <!-- zion-stats:test-count (kept in sync by scripts/update-readme-stats.sh) -->
-**807 unit tests** run on every change; **23 integration tests** need a running Zion + a backend.
+**819 unit tests** run on every change; **23 integration tests** need a running Zion + a backend.
 
 ```bash
 cargo test                          # unit tests

--- a/docs/adr/0015-route-mode-static.md
+++ b/docs/adr/0015-route-mode-static.md
@@ -1,0 +1,88 @@
+# ADR-0015: `mode = "static"` — opt-in disk file serving
+
+- **Status**: accepted
+- **Date**: 2026-07-31
+- **Deciders**: fabriziosalmi
+- **Tags**: routing, static, security, adoption
+
+## Context
+
+ADR-0011/0012/0013 each stated "Zion serves nothing from disk" as the **product
+edge**, mapping nginx `root`/`try_files` and Caddy `root`/`file_server` to
+`unsupported`. That kept Zion a pure L7 proxy. But a large share of the fleet's
+stacks serve static assets *alongside* a proxy (a built SPA + an API backend),
+and the migration thesis is "one binary in place of the stack, not one more
+container". Swapping those stacks without regressing to an extra static-file
+container requires Zion to serve those files itself. With the importer front-ends
+and ACME emission landed, this is the next unblock.
+
+## Decision
+
+Relax the edge with an **opt-in** route mode; the default posture is unchanged (a
+route is a proxy unless it says otherwise).
+
+- **`RouteMode::Static`** + `RouteConfig.serve_dir` (the directory) and
+  `spa_fallback` (serve `index.html` for an unmatched path — single-page apps).
+  A static route has **no upstream**; validation requires `serve_dir` instead and
+  skips the upstream-reference check. The serve dir is *not* canonicalized at
+  load, so an imported config still validates offline; existence is a per-request
+  check.
+- **Serving** (`src/static_files.rs`): GET/HEAD only; a directory maps to its
+  `index.html`; MIME by a small closed extension table (no `mime_guess`
+  dependency); 404 on a miss (or the SPA `index.html` when `spa_fallback`).
+
+### Security model (the load-bearing part)
+
+The only property that matters is that a request can never read a file outside
+`serve_dir`. Defense in depth, all covered by adversarial tests:
+
+1. **Per-segment percent-decode**, refusing a decoded `/`, `\`, NUL byte or
+   invalid UTF-8 — so `%2f`, `%00` and encoded traversal cannot smuggle path
+   structure past the checks.
+2. **Refuse `..` and dotfile segments outright** — `..` is never normalized, and
+   any segment starting with `.` (`.env`, `.git`, `.ssh`) is refused.
+3. **`canonicalize` + containment** — the resolved path and the root are both
+   canonicalized and the resolved path must stay under the root. This is what
+   defeats a symlink inside the tree that points out of it (proven by a
+   `symlink_escaping_the_root_is_refused` integration test).
+
+No directory listing, no dotfiles, no methods beyond GET/HEAD. `sanitize` is pure
+and exhaustively unit-tested; the filesystem path is integration-tested against a
+real temp tree.
+
+## Consequences
+
+- **Positive**: the Tier B static-and-proxy stacks become swappable with a single
+  Zion binary. The default stays a proxy; static serving is opt-in per route.
+- **Negative**: a file server is new attack surface. It is mitigated by the
+  layered path defense, the GET/HEAD gate, the no-listing / no-dotfile policy, and
+  the closed MIME table — but it is surface that did not exist before, hence this
+  ADR and the adversarial test suite.
+- **Neutral / risks**: v1 reads each file fully into memory (fine for typical
+  static assets). Streaming, HTTP range requests and conditional GET (ETag /
+  If-Modified-Since) are deferred follow-ups. The importer still maps
+  `root`/`file_server`/`try_files` to `unsupported`; mapping them to `mode=static`
+  `convert` is a follow-up PR (this ADR unblocks it).
+
+## Relationship to the "no disk serving" edge
+
+This is a **follow-up** that relaxes the edge ADR-0011/0012/0013 stated — not a
+supersession. Those ADRs stay `accepted`; their "honesty over completeness"
+contract is untouched, and the importer's product-edge findings simply gain a
+faithful target to convert to.
+
+## Alternatives considered
+
+- **Keep the edge** — rejected: it blocks the Tier B swaps, which are the point.
+- **A sidecar static-file container** — rejected: it defeats "one binary, not one
+  more container".
+- **A static-file crate (`tower-http` `ServeDir`, …)** — rejected: new
+  dependencies against the zero-dep posture, and we want to *own* the
+  security-critical path-resolution rather than delegate it.
+
+## References
+
+- ADR-0011 / 0012 / 0013 (the "no disk serving" edge this relaxes)
+- `src/static_files.rs` (sanitize + serve + adversarial tests),
+  `src/config.rs` (`RouteMode::Static`, `serve_dir`, validation),
+  `src/dispatch.rs` (the `Static` arm)

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -25,6 +25,7 @@ defined in [0000-template.md](0000-template.md).
 | 0012  | [`zion import traefik` — a second front-end on the neutral seam](0012-zion-import-traefik.md) | accepted |
 | 0013  | [`zion import caddy` — third front-end, own Caddyfile parser](0013-zion-import-caddy.md) | accepted |
 | 0014  | [Native `[tls.acme]` emission in the importer](0014-importer-tls-acme-emission.md) | accepted |
+| 0015  | [`mode = "static"` — opt-in disk file serving](0015-route-mode-static.md) | accepted |
 
 ## When to write a new ADR
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -526,6 +526,13 @@ pub struct RouteConfig {
     pub upstream: String,
     #[serde(default)]
     pub mode: RouteMode,
+    /// For `mode = "static"`: the directory served from disk. Files under it are
+    /// served safely (no `..` traversal, no dotfiles); anything outside 404s.
+    pub serve_dir: Option<String>,
+    /// For `mode = "static"`: serve `index.html` for any path that maps to no
+    /// file (single-page-app fallback). Off by default.
+    #[serde(default)]
+    pub spa_fallback: bool,
     #[serde(default)]
     pub internal_only: bool,
 
@@ -567,6 +574,8 @@ pub enum RouteMode {
     SseStream,
     StaticCache,
     Websocket,
+    /// Serve files from a local directory (`serve_dir`); no upstream. ADR-0015.
+    Static,
 }
 
 // ============================================================================
@@ -581,6 +590,13 @@ pub struct ResolvedRoute {
     pub upstream_scheme: hyper::http::uri::Scheme,
     pub upstream_authority: hyper::http::uri::Authority,
     pub mode: RouteMode,
+    /// For `RouteMode::Static`: the serve directory (not canonicalized here —
+    /// existence is a per-request check so an imported config validates offline).
+    pub serve_dir: Option<std::path::PathBuf>,
+    /// SPA fallback (serve `index.html` on a miss) for `RouteMode::Static`.
+    pub spa_fallback: bool,
+    /// Literal path prefix stripped before the on-disk file lookup.
+    pub static_prefix: String,
     pub waf: Option<WafProfile>,
     /// True iff the route is in WAF shadow mode (log + count, no block).
     pub waf_shadow: bool,
@@ -802,15 +818,25 @@ fn semantic_errors(config: &ZionConfig) -> Vec<String> {
         errors.push("no [[route]] defined — at least one route is required".to_string());
     }
 
-    // Each route must reference a valid upstream
+    // Each route must reference a valid upstream — except a static route, which
+    // serves from disk and instead needs a serve_dir (ADR-0015).
     for route in &config.route {
-        let has_upstream = config.upstream.contains_key(&route.upstream)
-            || config.upstreams.contains_key(&route.upstream);
-        if !has_upstream {
-            errors.push(format!(
-                "route '{}' references unknown upstream '{}'",
-                route.path, route.upstream
-            ));
+        if route.mode == RouteMode::Static {
+            if route.serve_dir.as_deref().unwrap_or("").is_empty() {
+                errors.push(format!(
+                    "route '{}' is mode=static but has no serve_dir",
+                    route.path
+                ));
+            }
+        } else {
+            let has_upstream = config.upstream.contains_key(&route.upstream)
+                || config.upstreams.contains_key(&route.upstream);
+            if !has_upstream {
+                errors.push(format!(
+                    "route '{}' references unknown upstream '{}'",
+                    route.path, route.upstream
+                ));
+            }
         }
 
         // WAF profile reference must exist
@@ -1170,7 +1196,12 @@ pub fn build_router_quiet(config: &ZionConfig) -> Result<HostRouter, String> {
 /// path needs, computed once at build. Pure: no router insertion, so
 /// `build_router` can place the result into one or more host-scoped trees.
 fn resolve_route(config: &ZionConfig, route: &RouteConfig) -> Result<Arc<ResolvedRoute>, String> {
-    let upstream_url = resolve_upstream(config, &route.upstream)?;
+    // A static route (ADR-0015) serves from disk and needs no upstream.
+    let upstream_url = if route.mode == RouteMode::Static && route.upstream.is_empty() {
+        Vec::new()
+    } else {
+        resolve_upstream(config, &route.upstream)?
+    };
 
     // Resolve WAF: named profile > legacy bool flag
     let waf = if let Some(ref profile_name) = route.waf_profile {
@@ -1234,19 +1265,25 @@ fn resolve_route(config: &ZionConfig, route: &RouteConfig) -> Result<Arc<Resolve
         None
     };
 
-    // Pre-parse the FIRST upstream URI at startup for legacy fallback.
-    // In a true clustered setup with latency routing, we use the first to get the scheme.
-    let upstream_uri: hyper::Uri = upstream_url[0]
-        .parse()
-        .map_err(|e| format!("Invalid upstream URL '{}': {}", upstream_url[0], e))?;
-    let upstream_scheme = upstream_uri
-        .scheme()
-        .cloned()
-        .unwrap_or_else(|| "http".parse().unwrap());
-    let upstream_authority = upstream_uri
-        .authority()
-        .cloned()
-        .ok_or_else(|| format!("Upstream '{}' has no authority", upstream_url[0]))?;
+    // Pre-parse the FIRST upstream URI at startup for legacy fallback. A static
+    // route has no upstream, so it gets placeholder parts the Static dispatch
+    // arm never reads.
+    let (upstream_scheme, upstream_authority) = if upstream_url.is_empty() {
+        ("http".parse().unwrap(), "127.0.0.1".parse().unwrap())
+    } else {
+        let upstream_uri: hyper::Uri = upstream_url[0]
+            .parse()
+            .map_err(|e| format!("Invalid upstream URL '{}': {}", upstream_url[0], e))?;
+        let scheme = upstream_uri
+            .scheme()
+            .cloned()
+            .unwrap_or_else(|| "http".parse().unwrap());
+        let authority = upstream_uri
+            .authority()
+            .cloned()
+            .ok_or_else(|| format!("Upstream '{}' has no authority", upstream_url[0]))?;
+        (scheme, authority)
+    };
 
     // Pre-parse CSP at startup for zero-cost injection at runtime
     let csp = match route.csp.as_ref() {
@@ -1280,11 +1317,34 @@ fn resolve_route(config: &ZionConfig, route: &RouteConfig) -> Result<Arc<Resolve
         .as_ref()
         .map(|c| Arc::new(crate::security::CorsHeaders::from_config(c)));
 
+    // Static file serving (ADR-0015): the serve dir + the literal prefix to
+    // strip from the request path. Not canonicalized here — existence is a
+    // per-request check so an imported config validates offline.
+    let (serve_dir, static_prefix) = if route.mode == RouteMode::Static {
+        let dir = route
+            .serve_dir
+            .as_ref()
+            .ok_or_else(|| format!("route '{}' is mode=static but has no serve_dir", route.path))?;
+        let prefix = route
+            .path
+            .split("{*")
+            .next()
+            .unwrap_or("/")
+            .trim_end_matches('/')
+            .to_string();
+        (Some(std::path::PathBuf::from(dir)), prefix)
+    } else {
+        (None, String::new())
+    };
+
     Ok(Arc::new(ResolvedRoute {
         upstream_url,
         upstream_scheme,
         upstream_authority,
         mode: route.mode.clone(),
+        serve_dir,
+        spa_fallback: route.spa_fallback,
+        static_prefix,
         waf,
         waf_shadow: route.waf_shadow,
         cache,
@@ -1401,6 +1461,7 @@ fn render_route_tags(route: &RouteConfig, color: bool) -> String {
         RouteMode::SseStream => tags.push(format!("{cyan}sse{reset}")),
         RouteMode::Websocket => tags.push(format!("{cyan}ws{reset}")),
         RouteMode::StaticCache => tags.push(format!("{cyan}static{reset}")),
+        RouteMode::Static => tags.push(format!("{cyan}files{reset}")),
         RouteMode::Standard => {}
     }
     if route.waf || route.waf_profile.is_some() {
@@ -1447,6 +1508,8 @@ mod tests {
             hosts: None,
             upstream: "backend".into(),
             mode: RouteMode::Standard,
+            serve_dir: None,
+            spa_fallback: false,
             internal_only: false,
             waf_profile: None,
             cache_profile: None,
@@ -1457,6 +1520,53 @@ mod tests {
             waf_shadow: false,
             cors: None,
         }
+    }
+
+    #[test]
+    fn static_route_builds_without_an_upstream() {
+        let toml = r#"
+[server]
+listen_http = "0.0.0.0:80"
+listen_https = "0.0.0.0:443"
+[tls]
+cert_path = "/c"
+key_path = "/k"
+[[route]]
+path = "/assets/{*rest}"
+upstream = ""
+mode = "static"
+serve_dir = "/var/www/assets"
+spa_fallback = true
+"#;
+        let cfg = parse_schema(toml, "test").expect("parse");
+        validate_semantics(&cfg, "test").expect("semantics");
+        let router = build_router_quiet(&cfg).expect("build");
+        let r = router.at(None, "/assets/css/app.css").expect("route");
+        assert_eq!(r.mode, RouteMode::Static);
+        assert_eq!(
+            r.serve_dir.as_deref(),
+            Some(std::path::Path::new("/var/www/assets"))
+        );
+        assert!(r.spa_fallback);
+        assert_eq!(r.static_prefix, "/assets");
+    }
+
+    #[test]
+    fn static_route_without_serve_dir_is_rejected() {
+        let toml = r#"
+[server]
+listen_http = "0.0.0.0:80"
+listen_https = "0.0.0.0:443"
+[tls]
+cert_path = "/c"
+key_path = "/k"
+[[route]]
+path = "/{*rest}"
+upstream = ""
+mode = "static"
+"#;
+        let cfg = parse_schema(toml, "test").expect("parse");
+        assert!(validate_semantics(&cfg, "test").is_err());
     }
 
     #[test]

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -1192,6 +1192,18 @@ async fn process_request_inner(
                 )
                 .await?
             }
+            config::RouteMode::Static => {
+                let dir = rule
+                    .serve_dir
+                    .as_deref()
+                    .unwrap_or_else(|| std::path::Path::new("."));
+                let path = req.uri().path();
+                let tail = path
+                    .strip_prefix(rule.static_prefix.as_str())
+                    .unwrap_or(path)
+                    .trim_start_matches('/');
+                crate::static_files::serve(dir, tail, rule.spa_fallback, req.method()).await
+            }
         }
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,6 +68,7 @@ mod reload;
 mod security;
 #[cfg(any(feature = "geo-ita", feature = "geo-eu"))]
 mod sovereign;
+mod static_files;
 mod suggest;
 mod tarpit;
 mod tls;

--- a/src/static_files.rs
+++ b/src/static_files.rs
@@ -1,0 +1,326 @@
+//! Static file serving for `mode = "static"` (ADR-0015).
+//!
+//! The one security property that matters: a request must NEVER read a file
+//! outside the configured `serve_dir`. Defense in depth, in order:
+//!  1. per-segment percent-decode, refusing a decoded `/`, `\`, NUL or invalid
+//!     UTF-8 — so `%2f`, `%00` and encoded traversal cannot smuggle structure;
+//!  2. refuse any `..` or dotfile segment outright (no normalization of `..`);
+//!  3. `canonicalize` the resolved path AND the root and require the resolved
+//!     path to stay under the root — this is what defeats a symlink pointing out
+//!     of the tree.
+//!
+//! [`sanitize`] is pure (no I/O) and adversarially unit-tested; [`serve`] does
+//! the filesystem work on the tokio blocking pool via `tokio::fs`.
+
+use std::path::{Path, PathBuf};
+
+use bytes::Bytes;
+use http_body_util::{BodyExt, Full};
+use hyper::{Method, Response, StatusCode};
+
+use crate::proxy::ZionBody;
+
+/// Turn a request-path tail (already stripped of the route prefix) into a safe
+/// RELATIVE path under the serve root, or `None` if it must be refused. Pure —
+/// no filesystem access, so it is exhaustively unit-testable.
+pub fn sanitize(tail: &str) -> Option<PathBuf> {
+    let mut rel = PathBuf::new();
+    for raw in tail.split('/') {
+        if raw.is_empty() {
+            continue;
+        }
+        let seg = percent_decode(raw)?; // invalid UTF-8 → refuse
+        if seg == "." || seg.is_empty() {
+            continue;
+        }
+        // A decoded separator / NUL / traversal / dotfile is an attack, never a
+        // real filename we are willing to serve.
+        if seg == ".."
+            || seg.starts_with('.')
+            || seg.contains('/')
+            || seg.contains('\\')
+            || seg.contains('\0')
+        {
+            return None;
+        }
+        rel.push(seg);
+    }
+    Some(rel)
+}
+
+/// Percent-decode a single path segment to a UTF-8 `String`; `None` if the
+/// decoded bytes are not valid UTF-8. A malformed `%` escape is left literal.
+fn percent_decode(seg: &str) -> Option<String> {
+    let b = seg.as_bytes();
+    let mut out = Vec::with_capacity(b.len());
+    let mut i = 0;
+    while i < b.len() {
+        if b[i] == b'%' && i + 2 < b.len() {
+            if let (Some(h), Some(l)) = (hex(b[i + 1]), hex(b[i + 2])) {
+                out.push(h * 16 + l);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(b[i]);
+        i += 1;
+    }
+    String::from_utf8(out).ok()
+}
+
+fn hex(c: u8) -> Option<u8> {
+    match c {
+        b'0'..=b'9' => Some(c - b'0'),
+        b'a'..=b'f' => Some(c - b'a' + 10),
+        b'A'..=b'F' => Some(c - b'A' + 10),
+        _ => None,
+    }
+}
+
+fn resp(status: StatusCode) -> Response<ZionBody> {
+    Response::builder()
+        .status(status)
+        .body(Full::new(Bytes::new()).map_err(|n| match n {}).boxed())
+        .unwrap()
+}
+
+/// Serve `tail` from `root`. `method` gates to GET/HEAD; `spa_fallback` serves
+/// the root `index.html` for a miss (single-page apps).
+pub async fn serve(
+    root: &Path,
+    tail: &str,
+    spa_fallback: bool,
+    method: &Method,
+) -> Response<ZionBody> {
+    if method != Method::GET && method != Method::HEAD {
+        return resp(StatusCode::METHOD_NOT_ALLOWED);
+    }
+    // The root itself must resolve; a missing serve_dir is a 404, not a leak.
+    let canon_root = match tokio::fs::canonicalize(root).await {
+        Ok(r) => r,
+        Err(_) => return resp(StatusCode::NOT_FOUND),
+    };
+    let Some(rel) = sanitize(tail) else {
+        return resp(StatusCode::FORBIDDEN);
+    };
+
+    if let Some(path) = resolve_file(&canon_root, &rel).await {
+        return read_file(&path, method).await;
+    }
+    if spa_fallback {
+        if let Some(index) = resolve_file(&canon_root, Path::new("index.html")).await {
+            return read_file(&index, method).await;
+        }
+    }
+    resp(StatusCode::NOT_FOUND)
+}
+
+/// Resolve `rel` under `canon_root` to an existing regular file, staying inside
+/// the tree (`canonicalize` defeats a symlink escape). A directory maps to its
+/// `index.html`.
+async fn resolve_file(canon_root: &Path, rel: &Path) -> Option<PathBuf> {
+    let candidate = canon_root.join(rel);
+    let canon = tokio::fs::canonicalize(&candidate).await.ok()?;
+    if !canon.starts_with(canon_root) {
+        return None; // a symlink (or a race) escaped the tree
+    }
+    let meta = tokio::fs::metadata(&canon).await.ok()?;
+    if meta.is_dir() {
+        let index = canon.join("index.html");
+        let ci = tokio::fs::canonicalize(&index).await.ok()?;
+        if ci.starts_with(canon_root) && tokio::fs::metadata(&ci).await.ok()?.is_file() {
+            Some(ci)
+        } else {
+            None
+        }
+    } else if meta.is_file() {
+        Some(canon)
+    } else {
+        None // device / socket / fifo — never served
+    }
+}
+
+async fn read_file(path: &Path, method: &Method) -> Response<ZionBody> {
+    let data = match tokio::fs::read(path).await {
+        Ok(d) => d,
+        Err(_) => return resp(StatusCode::NOT_FOUND),
+    };
+    let len = data.len();
+    let body = if method == Method::HEAD {
+        Bytes::new()
+    } else {
+        Bytes::from(data)
+    };
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(hyper::header::CONTENT_TYPE, mime_for(path))
+        .header(hyper::header::CONTENT_LENGTH, len)
+        .body(Full::new(body).map_err(|n| match n {}).boxed())
+        .unwrap()
+}
+
+/// MIME type by extension — a small, closed table (no `mime_guess` dependency).
+fn mime_for(path: &Path) -> &'static str {
+    let ext = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    match ext.as_str() {
+        "html" | "htm" => "text/html; charset=utf-8",
+        "css" => "text/css; charset=utf-8",
+        "js" | "mjs" => "text/javascript; charset=utf-8",
+        "json" | "map" => "application/json",
+        "xml" => "application/xml",
+        "txt" => "text/plain; charset=utf-8",
+        "svg" => "image/svg+xml",
+        "png" => "image/png",
+        "jpg" | "jpeg" => "image/jpeg",
+        "gif" => "image/gif",
+        "webp" => "image/webp",
+        "avif" => "image/avif",
+        "ico" => "image/x-icon",
+        "woff2" => "font/woff2",
+        "woff" => "font/woff",
+        "ttf" => "font/ttf",
+        "wasm" => "application/wasm",
+        "pdf" => "application/pdf",
+        _ => "application/octet-stream",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn s(t: &str) -> Option<String> {
+        sanitize(t).map(|p| p.to_string_lossy().replace('\\', "/"))
+    }
+
+    #[test]
+    fn normal_paths_pass() {
+        assert_eq!(s("css/main.css").as_deref(), Some("css/main.css"));
+        assert_eq!(s("/index.html").as_deref(), Some("index.html"));
+        assert_eq!(s("").as_deref(), Some(""));
+        assert_eq!(s("a/b/c.js").as_deref(), Some("a/b/c.js"));
+        // collapse empty + `.` segments, never escaping.
+        assert_eq!(s("////a").as_deref(), Some("a"));
+        assert_eq!(s("a/./b").as_deref(), Some("a/b"));
+        // a legit space (percent-encoded) decodes and is served.
+        assert_eq!(s("my%20file.txt").as_deref(), Some("my file.txt"));
+    }
+
+    #[test]
+    fn dotdot_traversal_is_refused() {
+        assert_eq!(sanitize("../etc/passwd"), None);
+        assert_eq!(sanitize("a/../../etc/passwd"), None);
+        assert_eq!(sanitize("..").into_iter().count(), 0);
+    }
+
+    #[test]
+    fn encoded_traversal_is_refused() {
+        assert_eq!(sanitize("%2e%2e/secret"), None); // %2e%2e → ".."
+        assert_eq!(sanitize("%2e%2e%2fsecret"), None); // decodes to "../secret" → contains '/'
+        assert_eq!(sanitize("a%2f%2e%2e"), None); // "a/.." smuggled via %2f
+    }
+
+    #[test]
+    fn dotfiles_are_refused() {
+        assert_eq!(sanitize(".env"), None);
+        assert_eq!(sanitize(".git/config"), None);
+        assert_eq!(sanitize("ok/.ssh/id_rsa"), None);
+    }
+
+    #[test]
+    fn nul_backslash_and_bad_utf8_are_refused() {
+        assert_eq!(sanitize("a%00b"), None); // NUL
+        assert_eq!(sanitize("a\\b"), None); // backslash (Windows sep)
+        assert_eq!(sanitize("%ff%fe"), None); // invalid UTF-8
+    }
+
+    #[test]
+    fn mime_by_extension() {
+        assert_eq!(mime_for(Path::new("a/b.css")), "text/css; charset=utf-8");
+        assert_eq!(
+            mime_for(Path::new("app.js")),
+            "text/javascript; charset=utf-8"
+        );
+        assert_eq!(mime_for(Path::new("x.unknown")), "application/octet-stream");
+    }
+}
+
+#[cfg(all(test, unix))]
+mod serve_tests {
+    use super::*;
+
+    /// A throwaway serve root under the temp dir, cleaned up on drop.
+    struct Root(PathBuf);
+    impl Drop for Root {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+    fn root(tag: &str) -> Root {
+        let dir = std::env::temp_dir().join(format!("zion-static-{}-{}", std::process::id(), tag));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join("css")).unwrap();
+        std::fs::write(dir.join("index.html"), b"<h1>home</h1>").unwrap();
+        std::fs::write(dir.join("css/main.css"), b"body{}").unwrap();
+        std::fs::write(dir.join(".env"), b"SECRET=1").unwrap();
+        Root(dir)
+    }
+
+    async fn get(root: &Path, tail: &str, spa: bool) -> (StatusCode, String) {
+        let r = serve(root, tail, spa, &Method::GET).await;
+        let status = r.status();
+        let body = r.into_body().collect().await.unwrap().to_bytes();
+        (status, String::from_utf8_lossy(&body).into_owned())
+    }
+
+    #[tokio::test]
+    async fn serves_files_and_index() {
+        let root = root("ok");
+        assert_eq!(
+            get(&root.0, "css/main.css", false).await,
+            (StatusCode::OK, "body{}".into())
+        );
+        // a directory (root) → index.html
+        assert_eq!(get(&root.0, "", false).await.0, StatusCode::OK);
+        assert!(get(&root.0, "", false).await.1.contains("home"));
+    }
+
+    #[tokio::test]
+    async fn missing_is_404_unless_spa() {
+        let root = root("spa");
+        assert_eq!(
+            get(&root.0, "does/not/exist", false).await.0,
+            StatusCode::NOT_FOUND
+        );
+        // SPA fallback serves index.html for the unmatched path.
+        let (st, body) = get(&root.0, "some/app/route", true).await;
+        assert_eq!(st, StatusCode::OK);
+        assert!(body.contains("home"));
+    }
+
+    #[tokio::test]
+    async fn traversal_and_dotfiles_never_leak() {
+        let root = root("safe");
+        assert_eq!(
+            get(&root.0, "../../../etc/passwd", false).await.0,
+            StatusCode::FORBIDDEN
+        );
+        assert_eq!(get(&root.0, ".env", false).await.0, StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn symlink_escaping_the_root_is_refused() {
+        let root = root("symlink");
+        // A secret outside the root, and a symlink inside pointing at it.
+        let outside = std::env::temp_dir().join(format!("zion-secret-{}", std::process::id()));
+        std::fs::write(&outside, b"TOP SECRET").unwrap();
+        std::os::unix::fs::symlink(&outside, root.0.join("leak")).unwrap();
+        // Following the symlink must not escape the canonical root.
+        assert_eq!(get(&root.0, "leak", false).await.0, StatusCode::NOT_FOUND);
+        let _ = std::fs::remove_file(&outside);
+    }
+}


### PR DESCRIPTION
## What

`mode = "static"` — **opt-in disk file serving** (ADR-0015). Relaxes the "Zion serves nothing from disk" product edge (ADR-0011/0012/0013) with an opt-in route mode, so the fleet's static-and-proxy stacks swap to a single Zion binary instead of one more container. The default posture is unchanged: a route is a proxy unless it says `mode = "static"`.

```toml
[[route]]
path = "/{*rest}"
upstream = ""              # a static route has no upstream
mode = "static"
serve_dir = "/var/www"
spa_fallback = true        # serve index.html for unmatched paths (SPAs)
```

## 🔒 Security model (please review this part)

The one property that matters: **a request can never read a file outside `serve_dir`.** Defense in depth, all covered by adversarial tests:

1. **Per-segment percent-decode**, refusing a decoded `/`, `\`, NUL or invalid UTF-8 — so `%2f`, `%00` and encoded traversal cannot smuggle path structure.
2. **Refuse `..` and dotfile segments outright** — `..` is never normalized; any segment starting with `.` (`.env`, `.git`, `.ssh`) is refused.
3. **`canonicalize` + containment** — the resolved path and the root are both canonicalized and the resolved path must stay under the root; this is what defeats a symlink inside the tree pointing out of it.

GET/HEAD only · no directory listing · no dotfiles · MIME by a closed extension table (no `mime_guess` dep). `sanitize` is pure and exhaustively unit-tested; the filesystem path is integration-tested against a real temp tree, **including a `symlink_escaping_the_root_is_refused` test**.

## Design

- `src/static_files.rs` (new) — the file server; `sanitize` (pure) + `serve` (async, `tokio::fs`).
- `config.rs` — `RouteMode::Static`, `RouteConfig.serve_dir` / `spa_fallback`; a static route needs `serve_dir` (validation) and no upstream; `serve_dir` is **not** canonicalized at load so an imported config still validates offline.
- `dispatch.rs` — a `RouteMode::Static` arm that strips the route prefix and serves.

## Verification

- ✅ 10 `static_files` tests (6 adversarial `sanitize` + 4 async filesystem incl. symlink escape) + 2 config tests (builds without upstream; rejects missing `serve_dir`)
- ✅ `cargo test --bin zion` — 627 pass
- ✅ `cargo clippy --all-targets --all-features -- -D warnings` clean · `fmt` clean · README SSOT refreshed

## Scope / follow-up (noted in ADR-0015)

- The importer still maps `root`/`file_server`/`try_files` to `unsupported`; mapping them to `mode=static` `convert` is a **follow-up PR** (this unblocks it — it's the point).
- v1 reads each file into memory; streaming, HTTP range requests and conditional GET (ETag / If-Modified-Since) are deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
