### PR TITLE
feat(import): caddy root/file_server → mode="static" convert (ADR-0015 follow-up)

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Client -> TLS 1.3 -> Security Gates -> Radix Router -> WAF Pipeline (5 gates) ->
 ```
 
 <!-- zion-stats:modules-lines (kept in sync by scripts/update-readme-stats.sh) -->
-47 modules, ~39,200 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
+47 modules, ~39,300 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
 
 ## Features
 
@@ -286,7 +286,7 @@ MODE=full bash benchmarks/baseline/run-baseline.sh   # → benchmarks/baseline/z
 ## Testing
 
 <!-- zion-stats:test-count (kept in sync by scripts/update-readme-stats.sh) -->
-**819 unit tests** run on every change; **23 integration tests** need a running Zion + a backend.
+**820 unit tests** run on every change; **23 integration tests** need a running Zion + a backend.
 
 ```bash
 cargo test                          # unit tests

--- a/src/config.rs
+++ b/src/config.rs
@@ -523,6 +523,7 @@ pub struct RouteConfig {
     #[serde(default)]
     pub hosts: Option<Vec<String>>,
 
+    #[serde(default)]
     pub upstream: String,
     #[serde(default)]
     pub mode: RouteMode,

--- a/src/import/caddy.rs
+++ b/src/import/caddy.rs
@@ -652,6 +652,10 @@ fn map_site(
     seen_upstreams: &mut BTreeSet<String>,
     findings: &mut Vec<Finding>,
 ) {
+    // A site with `root <dir>` + `file_server` serves files from disk
+    // (ADR-0015); it may coexist with proxy handlers as a static fallback.
+    let static_spec = detect_static(body);
+
     // Pass 1: site-level directives (headers, tls, encode, …). The site-level
     // header block yields a CSP that applies to every route unless a handler
     // overrides it.
@@ -676,12 +680,32 @@ fn map_site(
                 "log",
                 "structured JSON logging to stdout is built in",
             )),
-            "root" | "file_server" => findings.push(Finding::new(
-                Status::Unsupported,
-                node.line,
-                node.name.clone(),
-                "Zion serves nothing from disk (static serving is the product edge)",
-            )),
+            "root" | "file_server" => {
+                if static_spec.is_some() {
+                    findings.push(Finding::new(
+                        Status::Convert,
+                        node.line,
+                        node.name.clone(),
+                        "→ mode=static — files served from disk (ADR-0015)",
+                    ));
+                } else {
+                    findings.push(Finding::new(
+                        Status::Unsupported,
+                        node.line,
+                        node.name.clone(),
+                        "static serving needs both `root <dir>` and `file_server`",
+                    ));
+                }
+            }
+            "try_files" => {
+                let spa = static_spec.as_ref().map(|s| s.1).unwrap_or(false);
+                findings.push(Finding::new(
+                    if spa { Status::Convert } else { Status::Unsupported },
+                    node.line,
+                    "try_files",
+                    "SPA fallback (`… /index.html`) → spa_fallback; other try_files forms are unsupported",
+                ));
+            }
             "respond" => findings.push(Finding::new(
                 Status::Unsupported,
                 node.line,
@@ -742,7 +766,40 @@ fn map_site(
         }
     }
 
+    // A static site/route (root + file_server) becomes a catch-all mode=static
+    // route, emitted AFTER the proxy routes so a more-specific handler wins.
+    if let Some((dir, spa)) = static_spec {
+        doc.routes.push(RouteOut {
+            path: "/{*rest}".to_string(),
+            hosts: if hosts.is_empty() {
+                None
+            } else {
+                Some(hosts.to_vec())
+            },
+            upstream: String::new(),
+            websocket: false,
+            csp: site_csp.clone(),
+            waf: false,
+            serve_dir: Some(dir),
+            spa_fallback: spa,
+            annotations: Vec::new(),
+        });
+    }
+
     apply_site_acme(body, hosts, acme_email, cli_acme_email, doc, findings);
+}
+
+/// A site's `root <dir>` + `file_server` → `(serve_dir, spa_fallback)`, or
+/// `None` if it serves no files. `try_files … /index.html` sets the SPA flag.
+fn detect_static(body: &[Node]) -> Option<(String, bool)> {
+    if !body.iter().any(|n| n.name == "file_server") {
+        return None;
+    }
+    let dir = body.iter().find(|n| n.name == "root")?.args.last()?.clone();
+    let spa = body
+        .iter()
+        .any(|n| n.name == "try_files" && n.args.iter().any(|a| a.contains("index.html")));
+    Some((dir, spa))
 }
 
 /// Map a `header` block. Security headers Zion already injects → `auto`;
@@ -1089,6 +1146,8 @@ fn push_route(
         websocket: false,
         csp: csp.map(str::to_string),
         waf: false,
+        serve_dir: None,
+        spa_fallback: false,
         annotations: Vec::new(),
     });
 }
@@ -1356,14 +1415,29 @@ mod tests {
     }
 
     #[test]
-    fn file_server_site_has_no_routes() {
+    fn static_site_converts_to_mode_static() {
         let src = "example.com {\n  root * /var/www\n  file_server\n}";
-        match convert_str(src, &[]) {
-            Err(ConvertError::NoRoutes(f)) => assert!(f
-                .iter()
-                .any(|x| x.status == Status::Unsupported && x.directive == "file_server")),
-            other => panic!("expected NoRoutes, got {:?}", other.map(|c| c.toml)),
-        }
+        let c = convert_str(src, &[]).expect("static site should convert");
+        assert!(c.toml.contains("mode = \"static\""));
+        assert!(c.toml.contains("serve_dir = \"/var/www\""));
+        assert!(c.toml.contains("path = \"/{*rest}\""));
+        assert!(c
+            .findings
+            .iter()
+            .any(|f| f.status == Status::Convert && f.directive == "file_server"));
+    }
+
+    #[test]
+    fn hybrid_static_plus_proxy() {
+        // The Tier B shape: an API proxied, everything else served from disk
+        // with an SPA fallback.
+        let src = "example.com {\n  handle /api/* {\n    reverse_proxy api:8000\n  }\n  root * /srv\n  file_server\n  try_files {path} /index.html\n}";
+        let c = convert_str(src, &[]).expect("convert");
+        assert!(c.toml.contains("[upstream.api]") && c.toml.contains("http://api:8000"));
+        assert!(c.toml.contains("path = \"/api/{*rest}\""));
+        assert!(c.toml.contains("mode = \"static\""));
+        assert!(c.toml.contains("serve_dir = \"/srv\""));
+        assert!(c.toml.contains("spa_fallback = true"));
     }
 
     #[test]
@@ -1462,13 +1536,16 @@ mod tests {
     }
 
     #[test]
-    fn golden_static_edge_refuses() {
-        match convert(&fixture("static-edge.caddy"), None, &[], None) {
-            Err(ConvertError::NoRoutes(f)) => assert!(f
-                .iter()
-                .any(|x| x.status == Status::Unsupported && x.directive == "file_server")),
-            other => panic!("expected NoRoutes, got {:?}", other.map(|c| c.toml)),
-        }
+    fn golden_static_edge_converts() {
+        let c = convert(&fixture("static-edge.caddy"), None, &[], None)
+            .expect("static site converts to mode=static");
+        assert!(c.toml.contains("mode = \"static\""));
+        assert!(c.toml.contains("serve_dir = \"/srv/www\""));
+        // `encode` is still unsupported (Zion does not compress).
+        assert!(c
+            .findings
+            .iter()
+            .any(|f| f.status == Status::Unsupported && f.directive == "encode"));
     }
 }
 

--- a/src/import/emit.rs
+++ b/src/import/emit.rs
@@ -128,9 +128,17 @@ fn render_route(out: &mut String, route: &RouteOut) {
                 .join(", ")
         ));
     }
-    kv(out, "upstream", &route.upstream);
-    if route.websocket {
-        kv(out, "mode", "websocket");
+    if let Some(dir) = &route.serve_dir {
+        kv(out, "mode", "static");
+        kv(out, "serve_dir", dir);
+        if route.spa_fallback {
+            out.push_str("spa_fallback = true\n");
+        }
+    } else {
+        kv(out, "upstream", &route.upstream);
+        if route.websocket {
+            kv(out, "mode", "websocket");
+        }
     }
     if let Some(csp) = &route.csp {
         kv(out, "csp", csp);
@@ -222,6 +230,8 @@ mod tests {
                 websocket: false,
                 csp: None,
                 waf: false,
+                serve_dir: None,
+                spa_fallback: false,
                 annotations: vec!["evil\ninternal_only = false\n[admin]".into()],
             }],
         };
@@ -270,6 +280,8 @@ mod tests {
                 websocket: false,
                 csp: None,
                 waf: false,
+                serve_dir: None,
+                spa_fallback: false,
                 annotations: vec!["demo annotation".into()],
             }],
         };
@@ -309,6 +321,8 @@ mod tests {
                 websocket: true,
                 csp: Some("default-src 'self'".into()),
                 waf: true,
+                serve_dir: None,
+                spa_fallback: false,
                 annotations: Vec::new(),
             }],
         };
@@ -351,6 +365,8 @@ mod tests {
                 websocket: false,
                 csp: None,
                 waf: false,
+                serve_dir: None,
+                spa_fallback: false,
                 annotations: Vec::new(),
             }],
         };

--- a/src/import/map.rs
+++ b/src/import/map.rs
@@ -64,6 +64,11 @@ pub struct RouteOut {
     pub csp: Option<String>,
     /// Attach the shared `imported` WAF profile (body cap) in shadow mode.
     pub waf: bool,
+    /// `mode = "static"` serve directory (ADR-0015). When `Some`, the route
+    /// serves files from disk instead of proxying and `upstream` is ignored.
+    pub serve_dir: Option<String>,
+    /// SPA fallback for a static route (serve `index.html` on a miss).
+    pub spa_fallback: bool,
     /// Rendered as `# UNSUPPORTED: …` comment lines above the route.
     pub annotations: Vec<String>,
 }
@@ -1417,6 +1422,8 @@ fn map_location(
         websocket,
         csp,
         waf: route_waf,
+        serve_dir: None,
+        spa_fallback: false,
         annotations,
     });
 }

--- a/src/import/traefik.rs
+++ b/src/import/traefik.rs
@@ -600,6 +600,8 @@ fn build_route(
         websocket: false,
         csp: None,
         waf: false,
+        serve_dir: None,
+        spa_fallback: false,
         annotations: Vec::new(),
     });
 }

--- a/tests/fixtures/import/caddy/static-edge.caddy
+++ b/tests/fixtures/import/caddy/static-edge.caddy
@@ -1,5 +1,5 @@
-# Product edge: a static file server. Zion serves nothing from disk, so `root`
-# and `file_server` are `unsupported` and no convertible route is emitted.
+# A static file server: `root` + `file_server` convert to a mode=static route
+# (ADR-0015). `encode` stays unsupported (Zion does not compress).
 example.com {
     root * /srv/www
     file_server


### PR DESCRIPTION
## What

Now that `mode="static"` exists (#324), the **Caddy importer** maps `root` + `file_server` from `unsupported` to a `mode="static"` route — the follow-up ADR-0015 called for, unblocking the Tier B static-and-proxy stacks.

```
example.com { handle /api/* { reverse_proxy api:8000 }  root * /srv  file_server  try_files {path} /index.html }
```
→ an `/api/{*rest}` proxy route **+** a `/{*rest}` `mode="static"` route with `spa_fallback` (a more-specific handler wins).

## Design

- **ZionDoc seam**: `RouteOut` gains `serve_dir` + `spa_fallback`; `emit` renders `mode="static"` + `serve_dir` (+ `spa_fallback`) instead of `upstream`. `RouteConfig.upstream` is now `#[serde(default)]` so a static route's TOML omits it.
- **caddy**: a site with `root <dir>` + `file_server` → a catch-all `mode="static"` route (serve_dir from `root`'s last arg); `try_files … /index.html` → `spa_fallback`. Emitted **after** the proxy routes, so the Tier B hybrid (API proxied, everything else from disk) converts in one pass.

## Verification

- ✅ end-to-end: `static-edge.caddy` → one mode=static route; a hybrid site → an `/api` proxy route + a `/{*rest}` static+SPA route (smoke-tested on the binary)
- ✅ `cargo test --bin zion` — 628 pass (incl. `static_site_converts`, `hybrid_static_plus_proxy`, `golden_static_edge_converts`)
- ✅ `clippy --all-targets --all-features -- -D warnings` · `fmt` · README SSOT all clean

## Follow-up

The **nginx** path (`root` / `try_files` / `index` → mode=static) touches the equivalence golden corpus, so it's a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)