### PR TITLE
feat(import): nginx root/try_files/index → mode="static" (ADR-0016)

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Client -> TLS 1.3 -> Security Gates -> Radix Router -> WAF Pipeline (5 gates) ->
 ```
 
 <!-- zion-stats:modules-lines (kept in sync by scripts/update-readme-stats.sh) -->
-47 modules, ~39,600 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
+47 modules, ~40,000 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
 
 ## Features
 
@@ -286,7 +286,7 @@ MODE=full bash benchmarks/baseline/run-baseline.sh   # → benchmarks/baseline/z
 ## Testing
 
 <!-- zion-stats:test-count (kept in sync by scripts/update-readme-stats.sh) -->
-**831 unit tests** run on every change; **23 integration tests** need a running Zion + a backend.
+**844 unit tests** run on every change; **23 integration tests** need a running Zion + a backend.
 
 ```bash
 cargo test                          # unit tests

--- a/docs/adr/0016-importer-nginx-static-mapping.md
+++ b/docs/adr/0016-importer-nginx-static-mapping.md
@@ -1,0 +1,100 @@
+# ADR-0016: nginx `root`/`try_files`/`index`/`alias` → `mode = "static"`
+
+- **Status**: accepted
+- **Date**: 2026-07-31
+- **Deciders**: fabriziosalmi
+- **Tags**: import, static, nginx, adoption
+
+## Context
+
+ADR-0015 gave Zion an opt-in disk file server (`mode = "static"`), and the caddy
+front-end already maps `root` + `file_server` to it (#325). The nginx front-end
+(ADR-0011) still routed `root`/`try_files`/`index` to `unsupported` — the last
+place the "no disk serving" product edge survived in the importer.
+
+The dominant Tier B stack is the **nginx single-page app**: a build directory
+served with `try_files $uri $uri/ /index.html` under an inherited `root`, next to
+a proxied `/api`. Without this mapping such a stack imports to a config that
+serves nothing, and the "one binary in place of the stack" thesis breaks. This
+ADR completes the importer's static mapping so those stacks convert in one pass.
+
+## Decision
+
+A `location` with **no `proxy_pass`** but an explicit static signal
+(`try_files` / `root` / `alias` / `index` / `autoindex`) becomes a
+`mode = "static"` route. A proxy-less location with none of those (only
+`expires`/`access_log`) stays skipped — a catch-all static route already serves
+it at runtime.
+
+### serve_dir semantics — the load-bearing decision
+
+nginx `root R` and Zion `mode = "static"` treat the request path *differently*,
+and the difference cancels exactly:
+
+- nginx `root R` **appends the whole request URI** to `R`
+  (`/assets/app.js` → `R/assets/app.js`).
+- Zion `mode = "static"` **strips the route's static prefix**, then appends the
+  remainder to `serve_dir`.
+
+So `serve_dir = R joined with the location prefix` reproduces the identical
+on-disk path: `location /assets/ { root /srv; }` → `serve_dir = "/srv/assets"`,
+and `/assets/app.js` lands on `/srv/assets/app.js` under both. For the catch-all
+`location /` the prefix is empty and `serve_dir = R`.
+
+`alias A` is the other case: nginx `alias` **replaces** the location prefix (it
+already strips it, exactly like Zion), so it maps to `serve_dir = A` directly, no
+join. This is an exact translation, not an approximation — the ADR-0011 honesty
+contract holds.
+
+### spa_fallback and honest findings
+
+- `try_files` fallback (its last argument): `/index.html` → `spa_fallback = true`
+  (`convert`); `=404`/`=CODE` → no SPA (`convert`); a *different* file → SPA on,
+  plus a `partial` (Zion's fallback always serves the docroot `index.html`); a
+  named location `@name` → `partial`, no SPA (not modeled).
+- No `try_files` (just `root`/`index`) → directory serving; Zion serves
+  `index.html` for a directory, so `index index.html` is the default (`convert`)
+  and any other `index` is a `partial`.
+- `root` with an unresolved variable (`$host`) or empty → `unsupported`.
+- `autoindex on` → `partial` (no directory listing).
+- **Exact-match** static (`location = /x`) → `unsupported` (write it by hand);
+  regex locations are already excluded upstream.
+- A **server-level `root` that no static location consumed** → `unsupported`
+  ("set but no static location uses it — ignored"), so a defensive docroot on a
+  proxy-only server is not silently dropped.
+
+## Why the equivalence harness is not extended
+
+`tests/equivalence/` is a **routing-decision** differ: it replays a corpus and
+diffs *which backend answered*, request by request. Static serving is file I/O,
+not a routing decision — there is no backend to name. It is covered instead by
+`src/static_files.rs` (adversarial path-safety unit tests), the `t31` integration
+test (a static route serves a file, not a 503), and the deterministic import
+matrix in `src/import/mod.rs`. The `multi-vhost` corpus is pure proxy and is
+provably unaffected by this change (it contains no `root`/`try_files`/`index`). A
+byte-for-byte static **parity** leg (a shared docroot mounted into both nginx and
+Zion) belongs to the swap gates run on the host, and is deferred to that work
+rather than bolted onto the routing differ.
+
+## Consequences
+
+- **Positive**: the Tier B nginx SPA-plus-proxy stacks convert in a single pass;
+  the importer's product-edge findings for nginx now have a faithful target.
+- **Negative**: none new — this is a mapping onto the ADR-0015 file server, whose
+  attack surface and defenses are unchanged.
+- **Neutral / risks**: sub-path `root` joining is covered by tests, but v1 does
+  not convert exact-match static locations or rewrite paths (`strip_prefix` stays
+  out of scope per ADR-0011 until a real target needs it).
+
+## Relationship to earlier ADRs
+
+A **follow-up**, not a supersession. ADR-0011 (nginx import) stays `accepted`;
+this adds the static bucket to its mapping. ADR-0015 (`mode = "static"`) stays
+`accepted`; this is the nginx sibling of the caddy mapping (#325) that targets it.
+
+## References
+
+- ADR-0011 (nginx import contract), ADR-0015 (`mode = "static"`)
+- `src/import/map.rs` (`map_location` static branch, `classify_try_files`)
+- `src/import/mod.rs` (the `static_*` deterministic matrix)
+- `tests/fixtures/import/nginx/04-static-plus-proxy.conf` (the SPA-plus-proxy corpus)

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -26,6 +26,7 @@ defined in [0000-template.md](0000-template.md).
 | 0013  | [`zion import caddy` — third front-end, own Caddyfile parser](0013-zion-import-caddy.md) | accepted |
 | 0014  | [Native `[tls.acme]` emission in the importer](0014-importer-tls-acme-emission.md) | accepted |
 | 0015  | [`mode = "static"` — opt-in disk file serving](0015-route-mode-static.md) | accepted |
+| 0016  | [nginx `root`/`try_files`/`index` → `mode = "static"`](0016-importer-nginx-static-mapping.md) | accepted |
 
 ## When to write a new ADR
 

--- a/src/import/map.rs
+++ b/src/import/map.rs
@@ -985,6 +985,43 @@ struct ServerCtx {
     hdr_annotations: Vec<String>,
     waf: bool,
     connect_ms: Option<u64>,
+    /// Inherited docroot (`root <dir>`) that static locations serve from
+    /// (ADR-0015). nginx inheritance is replace-not-merge, but a location's own
+    /// `root`/`alias` simply overrides this at the location level.
+    root: Option<String>,
+    root_line: u32,
+    /// Inherited `index`. Zion serves `index.html` for directory requests, so a
+    /// non-default index becomes a partial finding when a static route uses it.
+    index: Option<String>,
+}
+
+/// Classify a static location's `try_files` fallback (its last argument) into
+/// `(spa_fallback, optional partial note)`. Zion's SPA fallback always serves
+/// the docroot's `index.html`, so a fallback to a *different* file converts with
+/// a note, a `=CODE` fallback means no SPA, and a named-location (`@name`)
+/// fallback is not modeled.
+fn classify_try_files(args: &[String]) -> (bool, Option<String>) {
+    match args.last() {
+        None => (
+            false,
+            Some("try_files has no fallback argument".to_string()),
+        ),
+        Some(last) if last.starts_with('=') => (false, None),
+        Some(last) if last.starts_with('@') => (
+            false,
+            Some(format!(
+                "try_files fallback to named location '{last}' is not modeled — \
+                 no SPA fallback set"
+            )),
+        ),
+        Some(last) if last == "/index.html" => (true, None),
+        Some(last) => (
+            true,
+            Some(format!(
+                "Zion's SPA fallback serves the docroot '/index.html', not '{last}'"
+            )),
+        ),
+    }
 }
 
 fn map_server(
@@ -1004,6 +1041,9 @@ fn map_server(
         hdr_annotations: Vec::new(),
         waf: false,
         connect_ms: None,
+        root: None,
+        root_line: 0,
+        index: None,
     };
 
     for d in &server.directives {
@@ -1108,22 +1148,69 @@ fn map_server(
                 &d.name,
                 "Zion auth profiles are JWT/OIDC, not basic auth",
             )),
-            "root" | "alias" | "try_files" | "index" | "autoindex" => {
-                findings.push(Finding::new(
+            // Inherited docroot context for static locations (ADR-0015). No
+            // finding here: it is consumed by a static location below, or
+            // reported as unused after the location loop.
+            "root" => match d.args.last() {
+                Some(dir) if !dir.is_empty() && !dir.contains('$') => {
+                    ctx.root = Some(dir.clone());
+                    ctx.root_line = d.line;
+                }
+                Some(_) => findings.push(Finding::new(
                     Status::Unsupported,
                     d.line,
-                    &d.name,
-                    "Zion serves no files from disk (it is a reverse proxy; \
-                     `mode = \"static_cache\"` caches upstream responses, it does \
-                     not serve a docroot)",
-                ));
-            }
+                    "root",
+                    "docroot contains an unresolved variable — not emitted",
+                )),
+                None => findings.push(Finding::new(
+                    Status::Unsupported,
+                    d.line,
+                    "root",
+                    "missing docroot path",
+                )),
+            },
+            "index" => ctx.index = d.args.first().cloned(),
+            "try_files" => findings.push(Finding::new(
+                Status::Partial,
+                d.line,
+                "try_files",
+                "server-level try_files is not modeled — move it into a `location` \
+                 to convert it to mode=static",
+            )),
+            "alias" => findings.push(Finding::new(
+                Status::Unsupported,
+                d.line,
+                "alias",
+                "server-level alias has no location prefix to serve",
+            )),
+            "autoindex" => findings.push(Finding::new(
+                Status::Unsupported,
+                d.line,
+                "autoindex",
+                "no directory listing — Zion serves index.html or 404",
+            )),
             _ => findings.push(Finding::unsupported_directive(d)),
         }
     }
 
+    // Static locations consume the inherited `ctx.root`; a docroot that none of
+    // them used is silently ignored by Zion — say so (ADR-0011 honesty).
+    let route_start = doc.routes.len();
     for loc in &server.locations {
         map_location(loc, hosts, &ctx, doc, reg, agg, findings, model);
+    }
+    if let Some(dir) = &ctx.root {
+        let used_static = doc.routes[route_start..]
+            .iter()
+            .any(|r| r.serve_dir.is_some());
+        if !used_static {
+            findings.push(Finding::new(
+                Status::Unsupported,
+                ctx.root_line,
+                "root",
+                format!("docroot '{dir}' set but no static location uses it — ignored"),
+            ));
+        }
     }
 }
 
@@ -1166,6 +1253,14 @@ fn map_location(
     let mut loc_connect: Option<u64> = None;
     let mut route_waf = ctx.waf;
     let mut static_only = Vec::new();
+    // Static-serving state (ADR-0015): a location with one of these and no
+    // proxy_pass becomes a mode=static route.
+    let mut loc_root: Option<String> = None;
+    let mut loc_alias: Option<String> = None;
+    let mut loc_index: Option<String> = None;
+    let mut loc_try_files: Option<(Vec<String>, u32)> = None;
+    let mut loc_autoindex: Option<u32> = None;
+    let mut static_bad: Option<(u32, &'static str)> = None; // unresolved/empty root|alias
 
     for d in &loc.directives {
         match d.name.as_str() {
@@ -1244,16 +1339,37 @@ fn map_location(
                 // Location-scoped cap: contributes to the shared imported profile.
                 map_body_size(d, doc, &mut route_waf, findings);
             }
-            "root" | "alias" | "try_files" | "index" | "autoindex" => {
+            // Static-serving directives: parsed into locals and resolved after
+            // the loop (a mode=static route if there is no proxy target).
+            "root" => {
                 static_only.push(d.line);
-                findings.push(Finding::new(
-                    Status::Unsupported,
-                    d.line,
-                    &d.name,
-                    "Zion serves no files from disk (it is a reverse proxy; \
-                     `mode = \"static_cache\"` caches upstream responses, it does \
-                     not serve a docroot)",
-                ));
+                match d.args.last() {
+                    Some(dir) if !dir.is_empty() && !dir.contains('$') => {
+                        loc_root = Some(dir.clone())
+                    }
+                    _ => static_bad = Some((d.line, "root")),
+                }
+            }
+            "alias" => {
+                static_only.push(d.line);
+                match d.args.last() {
+                    Some(dir) if !dir.is_empty() && !dir.contains('$') => {
+                        loc_alias = Some(dir.clone())
+                    }
+                    _ => static_bad = Some((d.line, "alias")),
+                }
+            }
+            "try_files" => {
+                static_only.push(d.line);
+                loc_try_files = Some((d.args.clone(), d.line));
+            }
+            "index" => {
+                static_only.push(d.line);
+                loc_index = d.args.first().cloned();
+            }
+            "autoindex" => {
+                static_only.push(d.line);
+                loc_autoindex = Some(d.line);
             }
             "expires" => findings.push(Finding::new(
                 Status::Unsupported,
@@ -1302,6 +1418,167 @@ fn map_location(
             }
             _ => findings.push(Finding::unsupported_directive(d)),
         }
+    }
+
+    // ── Static location → mode=static (ADR-0015) ────────────────────────────
+    // No proxy target, but an explicit static signal: serve files from disk.
+    // nginx `root` appends the whole request URI while Zion strips the route
+    // prefix, so `serve_dir = root joined with the location prefix` reproduces
+    // the same on-disk path; `alias` already strips the prefix, so it maps to
+    // `serve_dir` directly.
+    let has_static_signal = loc_try_files.is_some()
+        || loc_root.is_some()
+        || loc_alias.is_some()
+        || loc_index.is_some()
+        || loc_autoindex.is_some();
+    if proxy.is_none() && has_static_signal {
+        if let Some((line, kind)) = static_bad {
+            findings.push(Finding::new(
+                Status::Unsupported,
+                line,
+                kind,
+                "docroot is empty or contains an unresolved variable — not emitted",
+            ));
+            return;
+        }
+        if loc.modifier == LocMod::Exact {
+            findings.push(Finding::new(
+                Status::Unsupported,
+                loc.line,
+                "location",
+                format!(
+                    "exact-match static location '{}' is not converted — write it as \
+                     a prefix `mode=static` route by hand",
+                    loc.pattern
+                ),
+            ));
+            return;
+        }
+        let path = match location_path(loc, findings) {
+            Some(p) => p,
+            None => return,
+        };
+        // serve_dir: `alias` maps directly; `root` (own or inherited) joins the
+        // location prefix.
+        let serve_dir = if let Some(alias) = &loc_alias {
+            alias.trim_end_matches('/').to_string()
+        } else if let Some(root) = loc_root.as_ref().or(ctx.root.as_ref()) {
+            let root = root.trim_end_matches('/');
+            let prefix = loc.pattern.trim_matches('/');
+            if prefix.is_empty() {
+                root.to_string()
+            } else {
+                format!("{root}/{prefix}")
+            }
+        } else {
+            findings.push(Finding::new(
+                Status::Unsupported,
+                loc.line,
+                "location",
+                format!(
+                    "'{}': static location without a resolvable `root` or `alias` — skipped",
+                    loc.pattern
+                ),
+            ));
+            return;
+        };
+        let (spa_fallback, tf_note) = match &loc_try_files {
+            Some((args, _)) => classify_try_files(args),
+            None => (false, None),
+        };
+        // Same collision guard as the proxy path: a duplicate (host, path) would
+        // abort matchit at boot.
+        let route_hosts: Option<Vec<String>> = hosts.map(|h| h.to_vec());
+        let collision = doc.routes.iter().any(|r| {
+            r.path == path
+                && match (&r.hosts, &route_hosts) {
+                    (None, None) => true,
+                    (Some(a), Some(b)) => a.iter().any(|h| b.contains(h)),
+                    _ => false,
+                }
+        });
+        if collision {
+            findings.push(Finding::new(
+                Status::Unsupported,
+                loc.line,
+                "location",
+                format!(
+                    "'{}': duplicate path '{path}' for the same host — skipped",
+                    loc.pattern
+                ),
+            ));
+            return;
+        }
+        let signal = if loc_alias.is_some() {
+            "alias"
+        } else if loc_try_files.is_some() {
+            "try_files"
+        } else {
+            "root"
+        };
+        findings.push(Finding::new(
+            Status::Convert,
+            loc.line,
+            signal,
+            format!(
+                "route '{path}' → mode=static, serve_dir '{serve_dir}'{}",
+                if spa_fallback { " + spa_fallback" } else { "" }
+            ),
+        ));
+        if let Some(note) = tf_note {
+            let line = loc_try_files.as_ref().map(|(_, l)| *l).unwrap_or(loc.line);
+            findings.push(Finding::new(Status::Partial, line, "try_files", note));
+        }
+        if let Some(idx) = &loc_index {
+            if idx != "index.html" {
+                findings.push(Finding::new(
+                    Status::Partial,
+                    loc.line,
+                    "index",
+                    format!(
+                        "Zion serves 'index.html' for directory requests; custom index \
+                         '{idx}' is not honored"
+                    ),
+                ));
+            }
+        }
+        if let Some(line) = loc_autoindex {
+            findings.push(Finding::new(
+                Status::Partial,
+                line,
+                "autoindex",
+                "no directory listing — Zion serves index.html or 404",
+            ));
+        }
+        // CSP inheritance follows the same replace-not-merge rule as the proxy path.
+        let mut csp = if loc_has_add_header {
+            loc_csp.clone()
+        } else {
+            ctx.csp.clone()
+        };
+        if let Some(v) = &csp {
+            if hyper::header::HeaderValue::from_str(v).is_err() {
+                findings.push(Finding::new(
+                    Status::Unsupported,
+                    loc.line,
+                    "add_header",
+                    "Content-Security-Policy value is not a valid header value — dropped",
+                ));
+                csp = None;
+            }
+        }
+        doc.routes.push(RouteOut {
+            path,
+            hosts: route_hosts,
+            upstream: String::new(),
+            websocket: false,
+            csp,
+            waf: false,
+            serve_dir: Some(serve_dir),
+            spa_fallback,
+            annotations: Vec::new(),
+        });
+        return;
     }
 
     let (scheme, target, uri, pline) = match proxy {

--- a/src/import/mod.rs
+++ b/src/import/mod.rs
@@ -532,9 +532,16 @@ mod tests {
     #[test]
     fn corpus_04_static_spa_honesty() {
         let c = convert_fixture("04-static-plus-proxy.conf");
-        // Only /api converts; the URI part of its proxy_pass is dropped loudly.
+        // The SPA `location /` (inherited `root` + `try_files … /index.html`)
+        // now converts to a mode=static catch-all (ADR-0015); /api still proxies.
+        assert_eq!(c.toml.matches("[[route]]").count(), 2);
         assert!(c.toml.contains("path = \"/api/{*rest}\""));
-        assert_eq!(c.toml.matches("[[route]]").count(), 1);
+        assert!(c.toml.contains("mode = \"static\""));
+        assert!(c.toml.contains("serve_dir = \"/var/www/spa/dist\""));
+        assert!(c.toml.contains("spa_fallback = true"));
+        // try_files CONVERTS now — it is no longer an unsupported product edge.
+        assert!(has_finding(&c, Status::Convert, "try_files", "mode=static"));
+        // The /api proxy_pass URI part is still dropped loudly.
         assert!(has_finding(
             &c,
             Status::Unsupported,
@@ -542,13 +549,198 @@ mod tests {
             "URI part"
         ));
         assert!(c.toml.contains("# UNSUPPORTED: proxy_pass URI part"));
-        assert!(has_finding(&c, Status::Unsupported, "try_files", "files"));
+        // `/assets/` carries only expires/access_log (no static signal, no
+        // proxy) — still skipped; the catch-all serves it at runtime.
         assert!(has_finding(
             &c,
             Status::Unsupported,
             "location",
             "no convertible proxy target"
         ));
+    }
+
+    // ── 3a-nginx: root/try_files/index/alias → mode=static (ADR-0015) ────────
+    // Draconian, deterministic matrix. `conv_ok` converts an inline server and
+    // returns the single static route it produced (asserting there is exactly
+    // one), so each test pins serve_dir/spa_fallback exactly.
+
+    fn conv_ok(src: &str) -> Conversion {
+        convert(src, None).unwrap_or_else(|e| panic!("convert failed: {e:?}"))
+    }
+
+    #[test]
+    fn static_spa_catch_all_from_inherited_root() {
+        let c = conv_ok(
+            "server {\n  server_name a.test;\n  root /var/www/app;\n  \
+             location / { try_files $uri $uri/ /index.html; }\n}",
+        );
+        assert!(c.toml.contains("path = \"/{*rest}\""));
+        assert!(c.toml.contains("mode = \"static\""));
+        assert!(c.toml.contains("serve_dir = \"/var/www/app\""));
+        assert!(c.toml.contains("spa_fallback = true"));
+        assert!(has_finding(&c, Status::Convert, "try_files", "mode=static"));
+    }
+
+    #[test]
+    fn static_try_files_404_has_no_spa_fallback() {
+        let c = conv_ok(
+            "server {\n  server_name a.test;\n  root /srv;\n  \
+             location / { try_files $uri =404; }\n}",
+        );
+        assert!(c.toml.contains("mode = \"static\""));
+        assert!(c.toml.contains("serve_dir = \"/srv\""));
+        assert!(!c.toml.contains("spa_fallback"));
+    }
+
+    #[test]
+    fn static_subpath_root_joins_the_location_prefix() {
+        // nginx `root` appends the whole URI; Zion strips the route prefix — so
+        // serve_dir must be root + prefix to serve the same files.
+        let c = conv_ok(
+            "server {\n  server_name a.test;\n  \
+             location /assets/ { root /srv/app; try_files $uri =404; }\n}",
+        );
+        assert!(c.toml.contains("path = \"/assets/{*rest}\""));
+        assert!(c.toml.contains("serve_dir = \"/srv/app/assets\""));
+    }
+
+    #[test]
+    fn static_alias_maps_to_serve_dir_directly() {
+        // `alias` already strips the prefix (like Zion), so serve_dir = alias.
+        let c = conv_ok(
+            "server {\n  server_name a.test;\n  \
+             location /dl/ { alias /data/files/; }\n}",
+        );
+        assert!(c.toml.contains("path = \"/dl/{*rest}\""));
+        assert!(c.toml.contains("serve_dir = \"/data/files\""));
+        assert!(has_finding(&c, Status::Convert, "alias", "mode=static"));
+    }
+
+    #[test]
+    fn static_local_root_overrides_inherited() {
+        let c = conv_ok(
+            "server {\n  server_name a.test;\n  root /inherited;\n  \
+             location / { root /local; try_files $uri /index.html; }\n}",
+        );
+        assert!(c.toml.contains("serve_dir = \"/local\""));
+        assert!(!c.toml.contains("/inherited"));
+    }
+
+    #[test]
+    fn static_unresolved_root_variable_is_unsupported() {
+        let c = conv_ok(
+            "server {\n  server_name a.test;\n  \
+             location / { root /www/$host; try_files $uri /index.html; }\n  \
+             location /api/ { proxy_pass http://127.0.0.1:9000; }\n}",
+        );
+        assert!(has_finding(
+            &c,
+            Status::Unsupported,
+            "root",
+            "unresolved variable"
+        ));
+        assert!(!c.toml.contains("mode = \"static\""));
+        // the proxy route still converts
+        assert!(c.toml.contains("path = \"/api/{*rest}\""));
+    }
+
+    #[test]
+    fn static_named_fallback_is_partial_without_spa() {
+        let c = conv_ok(
+            "server {\n  server_name a.test;\n  root /srv;\n  \
+             location / { try_files $uri $uri/ @app; }\n}",
+        );
+        assert!(c.toml.contains("mode = \"static\""));
+        assert!(!c.toml.contains("spa_fallback"));
+        assert!(has_finding(
+            &c,
+            Status::Partial,
+            "try_files",
+            "named location"
+        ));
+    }
+
+    #[test]
+    fn static_custom_index_is_partial() {
+        let c = conv_ok(
+            "server {\n  server_name a.test;\n  \
+             location / { root /srv; index main.html; }\n}",
+        );
+        assert!(c.toml.contains("mode = \"static\""));
+        assert!(!c.toml.contains("spa_fallback"));
+        assert!(has_finding(&c, Status::Partial, "index", "index.html"));
+    }
+
+    #[test]
+    fn static_autoindex_is_partial() {
+        let c = conv_ok(
+            "server {\n  server_name a.test;\n  \
+             location /files/ { root /srv; autoindex on; }\n}",
+        );
+        assert!(c.toml.contains("path = \"/files/{*rest}\""));
+        assert!(has_finding(
+            &c,
+            Status::Partial,
+            "autoindex",
+            "directory listing"
+        ));
+    }
+
+    #[test]
+    fn static_exact_match_location_is_unsupported() {
+        let c = conv_ok(
+            "server {\n  server_name a.test;\n  \
+             location = /favicon.ico { root /srv; }\n  \
+             location /api/ { proxy_pass http://127.0.0.1:9000; }\n}",
+        );
+        assert!(has_finding(
+            &c,
+            Status::Unsupported,
+            "location",
+            "exact-match static"
+        ));
+        assert!(!c.toml.contains("mode = \"static\""));
+    }
+
+    #[test]
+    fn static_server_root_unused_by_proxy_only_is_reported() {
+        let c = conv_ok(
+            "server {\n  server_name a.test;\n  root /never/served;\n  \
+             location / { proxy_pass http://127.0.0.1:9000; }\n}",
+        );
+        assert!(!c.toml.contains("mode = \"static\""));
+        assert!(has_finding(
+            &c,
+            Status::Unsupported,
+            "root",
+            "no static location uses it"
+        ));
+    }
+
+    #[test]
+    fn static_and_proxy_coexist_in_one_server() {
+        let c = conv_ok(
+            "server {\n  server_name a.test;\n  root /var/www/app;\n  \
+             location / { try_files $uri /index.html; }\n  \
+             location /api/ { proxy_pass http://127.0.0.1:9000; }\n}",
+        );
+        assert_eq!(c.toml.matches("[[route]]").count(), 2);
+        assert!(c.toml.contains("mode = \"static\""));
+        assert!(c.toml.contains("path = \"/api/{*rest}\""));
+        assert!(c.toml.contains("upstream = \"127_0_0_1_9000\""));
+    }
+
+    #[test]
+    fn static_directory_serving_without_try_files() {
+        // Just `root` (+ no try_files): Zion serves index.html for the dir.
+        let c = conv_ok(
+            "server {\n  server_name a.test;\n  \
+             location / { root /srv/site; }\n}",
+        );
+        assert!(c.toml.contains("mode = \"static\""));
+        assert!(c.toml.contains("serve_dir = \"/srv/site\""));
+        assert!(!c.toml.contains("spa_fallback"));
+        assert!(has_finding(&c, Status::Convert, "root", "mode=static"));
     }
 
     #[test]

--- a/tests/fixtures/import/nginx/README.md
+++ b/tests/fixtures/import/nginx/README.md
@@ -1,7 +1,8 @@
 # `zion import nginx` — golden corpus
 
 Ten realistic nginx configs that together exercise every row of the ADR-0011
-mapping contract. This corpus is the executable spec for the importer: the
+mapping contract (plus the `mode = "static"` mapping of ADR-0016). This corpus
+is the executable spec for the importer: the
 corpus test converts every file and asserts (a) the output passes
 `config::parse_schema` + `validate_semantics`, (b) the findings match the
 expectations below. Add a fixture *before* teaching the mapper a new
@@ -15,7 +16,7 @@ auto / unsupported):
 | `01-nextjs.conf` | Next.js behind proxy, websocket HMR | `server_name` → hosts; `proxy_pass` (no URI part); Upgrade idiom → `mode = "websocket"` | XFF/X-Real-IP/XFP set_headers → auto; `Host $host` → unsupported; `proxy_cache_bypass` → unsupported |
 | `02-wordpress.conf` | Container WP, uploads, timeouts | hosts (2 names); `client_max_body_size 64m` → waf_profile partial; `proxy_connect_timeout` → `connect_timeout_ms` | `proxy_read_timeout`/`proxy_buffering` → unsupported; regex dotfile-deny location → unsupported (skipped) |
 | `03-api-gateway.conf` | One vhost, many locations, one limit_req zone | exact + prefix locations → distinct routes/upstreams; single `limit_req` policy → global `rate_limit_rps` partial | `add_header X-Gateway` → unsupported |
-| `04-static-plus-proxy.conf` | SPA static + `/api` proxied | `/api/` route (its `proxy_pass http://…:5000/` URI part under non-`/` location → unsupported finding, authority-only emission) | `root`/`index`/`try_files`/`expires`/`access_log off` → unsupported |
+| `04-static-plus-proxy.conf` | SPA static + `/api` proxied | `location /` (inherited `root` + `try_files … /index.html`) → `mode = "static"` + `serve_dir` + `spa_fallback` (ADR-0016); `/api/` route (`proxy_pass` URI part dropped, authority-only) | `expires` → unsupported; `/assets/` (only `expires`/`access_log off`, no static signal) → skipped, served by the catch-all |
 | `05-multi-vhost.conf` | 3 server blocks incl. `default_server _` | per-host routes on the same path; `_` catch-all → hostless shared route | partial: default-vhost scope widening (Zion's shared layer is also the path-miss fallback under named hosts) |
 | `06-upstream-lb.conf` | upstream pool | `urls` (3 backends); `keepalive 32` → keepalive | `least_conn`/`weight`/`backup`/`proxy_next_upstream` → unsupported |
 | `07-tls-termination.conf` | TLS + redirect pair | ssl cert/key → `[tls]`/`[[tls.sni]]`; `ssl_protocols TLSv1.2 …` → `min_version = "1.2"`; https upstream; port-80 `return 301 https://…` server → auto (dropped) | `ssl_ciphers`/`proxy_ssl_verify off`/HSTS `add_header` → auto/unsupported per table |


### PR DESCRIPTION
## What

Completes the importer's static mapping. The nginx front-end joins caddy (#325) in converting a docroot to Zion's `mode="static"` file server, so the **dominant Tier B stack** — an SPA build dir served with `try_files` next to a proxied `/api` — imports in one pass instead of losing its static half.

A proxy-less `location` with an explicit static signal (`try_files` / `root` / `alias` / `index` / `autoindex`) becomes a `mode="static"` route.

## The load-bearing decision: serve_dir is exact, not approximate

nginx `root` and Zion `mode="static"` treat the path differently, and the difference **cancels**:

- nginx `root R` **appends the whole request URI** (`/assets/app.js` → `R/assets/app.js`).
- Zion `mode="static"` **strips the route's static prefix**, then appends to `serve_dir`.

So `serve_dir = R` joined with the location prefix reproduces the identical on-disk path. `alias A` already strips the prefix (like Zion) → `serve_dir = A` directly. This is a 1:1 translation, honoring the ADR-0011 "no approximate translation" contract. Full rationale in [ADR-0016](docs/adr/0016-importer-nginx-static-mapping.md).

## Honesty (findings)

| input | result |
|---|---|
| `try_files … /index.html` | convert + `spa_fallback = true` |
| `try_files … =404` | convert, no SPA |
| `try_files … @named` | convert + **partial** (named fallback not modeled) |
| `try_files … /other.html` | convert + **partial** (Zion serves `index.html`) |
| `root` with `$var` / empty | **unsupported** |
| custom `index` | **partial** |
| `autoindex on` | **partial** |
| exact-match static (`location = /x`) | **unsupported** |
| server `root` no static location used | **unsupported** |

## Safety / scope

- The nginx **proxy path is untouched**; the equivalence corpus `multi-vhost` is pure proxy and provably unaffected (`git` shows no change to it).
- The equivalence harness is a *routing-decision* differ; static serving (file I/O) is covered by `static_files.rs` adversarial tests + `t31` + this PR's matrix. A byte-for-byte static parity leg is deferred to the host swap gates (ADR-0016 explains why `run.sh` is not touched).

## Coverage

- `corpus_04_static_spa_honesty` rewritten to the SPA-convert contract (2 routes, `mode="static"`, `serve_dir`, `spa_fallback`).
- **13-case deterministic matrix**: catch-all SPA, `=404`, sub-path root-join, alias, local-over-inherited root, unresolved var, `@named`, custom index, autoindex, exact-match, unused server root, static+proxy coexist, bare directory.
- **Proven live end-to-end**: a real nginx SPA conf → `zion import nginx` → a running Zion returns `index.html` for `/` and SPA misses, the real asset for `/app.js`, and **403** on encoded traversal + dotfiles.

Full suite green; clippy `--all-targets` clean; fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)