### PR TITLE
chore(release): v0.7.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,7 +21,7 @@ A clear and concise description of what you expected to happen.
 **Environment (please complete the following information):**
  - OS: [e.g. Linux, macOS]
  - Architecture: [e.g. arm64, amd64]
- - Zion Version: [e.g. 0.6.2]
+ - Zion Version: [e.g. 0.7.0]
 
 **Additional context**
 Add any other context about the problem here (e.g. logs with `RUST_LOG=trace`, upstream backend type like Go/Node).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,45 @@ All notable changes to Zion Edge Gateway are documented here.
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-07-31
+
+### Added
+- **`zion import` is now a three-front-end migration tool.** Alongside nginx
+  (v0.6.0) it converts **Traefik** (Docker-compose labels + static flags,
+  ADR-0012) and **Caddy** (its own zero-dependency Caddyfile parser, ADR-0013)
+  to a validated `zion.toml`, all on one neutral `ZionDoc` seam:
+  `zion import <nginx|traefik|caddy>`. A declared-subset Docker Compose reader
+  feeds the Traefik label source.
+- **Native `[tls.acme]` emission** (ADR-0014). HTTPS sources with a cert
+  resolver / ACME email import to Zion's real auto-HTTPS; the email comes from
+  the source config or `--acme-email`.
+- **`mode = "static"` — opt-in disk file serving** (ADR-0015). A new
+  `RouteMode::Static` + `serve_dir` + `spa_fallback` serves files from disk
+  behind a hardened path-safety core (`src/static_files.rs`: per-segment
+  percent-decode, dotfile / reserved-name refusal, `canonicalize` + containment,
+  GET/HEAD only, 64 MiB cap). This reverses the former "no disk serving" product
+  edge and unblocks the static-plus-proxy stacks.
+- **The importers map static serving to it**: Caddy `root` + `file_server`, and
+  nginx `root`/`try_files`/`index`/`alias` (ADR-0016), convert to
+  `mode = "static"` — a single-page-app build dir next to a proxied `/api`
+  imports in one pass. `serve_dir` is derived exactly: nginx `root` appends the
+  request URI while Zion strips the route prefix, so they cancel; `alias` maps
+  to `serve_dir` directly.
+
+### Fixed
+- **`mode = "static"` returned 503 for every request** — caught by a five-agent
+  adversarial review. The dispatch upstream-health gate ran before the
+  route-mode match and short-circuited on the (empty) static upstream, so the
+  file server was unreachable. Fixed to skip the gate for static routes; proven
+  live and guarded by an integration test. The same review fixed 15 more:
+  Caddyfile parser recursion depth cap, duplicate-route dedupe, inline
+  `header CSP` capture, HEAD-via-`metadata` + size cap, `U+007F` escaping, and
+  ACME/host dedupe edges.
+
+### Documentation
+- ADRs 0012–0016: the Traefik and Caddy front-ends, native `[tls.acme]`
+  emission, `mode = "static"`, and the nginx static mapping.
+
 ## [0.6.2] - 2026-07-07
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5458,7 +5458,7 @@ dependencies = [
 
 [[package]]
 name = "zion"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "aho-corasick",
  "aimp_node",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zion"
-version = "0.6.2"
+version = "0.7.0"
 edition = "2021"
 # MSRV is the *core* default-features build (TLS proxy + WAF + cache + metrics).
 # Opt-in features (acme, auth, init, http3) pull crypto/i18n crates that have

--- a/README.md
+++ b/README.md
@@ -315,12 +315,12 @@ Every release is signed and carries SLSA v1.0 build provenance — see
 
 ```bash
 # Binary release (Sigstore-backed provenance via gh CLI)
-gh release download v0.6.2 -R fabriziosalmi/zion -p '*x86_64-unknown-linux-musl*' -p 'SHA256SUMS'
+gh release download v0.7.0 -R fabriziosalmi/zion -p '*x86_64-unknown-linux-musl*' -p 'SHA256SUMS'
 sha256sum --check --ignore-missing SHA256SUMS
-gh attestation verify zion-v0.6.2-x86_64-unknown-linux-musl.tar.gz --owner fabriziosalmi
+gh attestation verify zion-v0.7.0-x86_64-unknown-linux-musl.tar.gz --owner fabriziosalmi
 
 # Container image (cosign keyless)
-cosign verify ghcr.io/fabriziosalmi/zion:v0.6.2 \
+cosign verify ghcr.io/fabriziosalmi/zion:v0.7.0 \
     --certificate-identity-regexp "^https://github.com/fabriziosalmi/zion/\\.github/workflows/release\\.yml@refs/tags/v" \
     --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ from their containing minor — i.e. the latest `0.4.x` is always patched.
 | Version | Supported |
 | ------- | --------- |
 | 0.4.x (latest minor) | Yes |
-| < 0.6.2 | No |
+| < 0.7.0 | No |
 
 ## Reporting a Vulnerability
 

--- a/deploy/helm/zion/Chart.yaml
+++ b/deploy/helm/zion/Chart.yaml
@@ -3,7 +3,7 @@ name: zion
 description: Zion Edge Gateway — high-performance Rust TLS reverse proxy with WAF
 type: application
 version: 0.2.2
-appVersion: "0.6.2"
+appVersion: "0.7.0"
 home: https://fabriziosalmi.github.io/zion
 sources:
   - https://github.com/fabriziosalmi/zion

--- a/docs/deploy/hot-reload.md
+++ b/docs/deploy/hot-reload.md
@@ -130,7 +130,7 @@ Two surfaces report the reload state:
 
   ```json
   {
-    "version": "0.6.2",
+    "version": "0.7.0",
     "timestamp_ms": 1714425600000,
     "uptime_secs": 3712,
     "config_generation": 5,

--- a/docs/security/supply-chain.md
+++ b/docs/security/supply-chain.md
@@ -46,8 +46,8 @@ You need the GitHub CLI (`gh >= 2.49`) and `cosign >= 2.2`.
 
 ```bash
 # 1. Download the artifact + SHA256SUMS from the release page.
-gh release download v0.6.2 -R fabriziosalmi/zion \
-    -p 'zion-v0.6.2-x86_64-unknown-linux-musl.tar.gz' \
+gh release download v0.7.0 -R fabriziosalmi/zion \
+    -p 'zion-v0.7.0-x86_64-unknown-linux-musl.tar.gz' \
     -p 'SHA256SUMS' \
     -p 'zion-sbom.cdx.json'
 
@@ -55,7 +55,7 @@ gh release download v0.6.2 -R fabriziosalmi/zion \
 sha256sum --check --ignore-missing SHA256SUMS
 
 # 3. Verify the SLSA build provenance bound to the artifact's hash.
-gh attestation verify zion-v0.6.2-x86_64-unknown-linux-musl.tar.gz \
+gh attestation verify zion-v0.7.0-x86_64-unknown-linux-musl.tar.gz \
     --owner fabriziosalmi
 
 # Step 3 fails if:
@@ -78,7 +78,7 @@ grype zion-sbom.cdx.json
 ## Verifying a container image
 
 ```bash
-IMAGE=ghcr.io/fabriziosalmi/zion:v0.6.2
+IMAGE=ghcr.io/fabriziosalmi/zion:v0.7.0
 
 # 1. Pin to the digest immediately — tags are mutable, digests are not.
 DIGEST=$(crane digest "$IMAGE")
@@ -120,7 +120,7 @@ deterministically, and pins the Rust toolchain via
 [`rust-toolchain.toml`](../../rust-toolchain.toml). To reproduce locally:
 
 ```bash
-git checkout v0.6.2
+git checkout v0.7.0
 export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)
 # Linux musl example — matches the release artifact byte-for-byte
 # (modulo strip's stable behavior on your distro).


### PR DESCRIPTION
Rolls up the **8 PRs on master since v0.6.2** into a release.

## Highlights
- `zion import` became a **three-front-end migration tool** — nginx + **Traefik** (#321, ADR-0012) + **Caddy** (#322, ADR-0013) on one neutral `ZionDoc` seam, fed by a declared-subset Compose reader (#320).
- Native **`[tls.acme]` emission** (#323, ADR-0014).
- **`mode = "static"`** — opt-in, hardened disk file server (#324, ADR-0015); both importers now target it (caddy #325, nginx #327 / ADR-0016).
- **Adversarial-review hardening** (#326): fixed a critical static-route 503 + 15 more.

## This PR
- `bump-version.sh 0.7.0` — Cargo.toml SSOT + all synced references (`check-version-sync` green).
- CHANGELOG `## [0.7.0]` entry.

Minor bump (new features, backward-compatible). On merge: tag `v0.7.0` → `release.yml` builds the platform tarballs + PGO + multi-arch cosign-signed container + SBOM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)