### PR TITLE
feat(cache): origin-side revalidation (stale → 304, closes #266)

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Client -> TLS 1.3 -> Security Gates -> Radix Router -> WAF Pipeline (5 gates) ->
 ```
 
 <!-- zion-stats:modules-lines (kept in sync by scripts/update-readme-stats.sh) -->
-47 modules, ~40,600 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
+47 modules, ~40,800 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
 
 ## Features
 
@@ -286,7 +286,7 @@ MODE=full bash benchmarks/baseline/run-baseline.sh   # → benchmarks/baseline/z
 ## Testing
 
 <!-- zion-stats:test-count (kept in sync by scripts/update-readme-stats.sh) -->
-**854 unit tests** run on every change; **23 integration tests** need a running Zion + a backend.
+**855 unit tests** run on every change; **23 integration tests** need a running Zion + a backend.
 
 ```bash
 cargo test                          # unit tests

--- a/docs/adr/0018-cache-origin-revalidation.md
+++ b/docs/adr/0018-cache-origin-revalidation.md
@@ -1,0 +1,82 @@
+# ADR-0018: Cache origin-side revalidation (RFC 9111 §4.3)
+
+- **Status**: accepted
+- **Date**: 2026-07-31
+- **Deciders**: fabriziosalmi
+- **Tags**: cache, performance, rfc-9111, standards
+
+## Context
+
+zion's two-level cache (ADR-0003) served fresh entries and, on expiry,
+**evicted and re-downloaded** the whole object. RFC 9111 §4.3 says a shared cache
+SHOULD instead **revalidate** a stale entry with a conditional request and, on a
+`304 Not Modified`, reuse the stored body — the common case for large, rarely-
+changing static assets behind a validator. The validators were already stored
+(`CachedMeta.etag` / `last_modified`, #262); only the revalidation flow was
+missing. Issue #266 flagged this as the **riskiest** cache change because it
+touches the perf-critical `get()` hot path and the singleflight machinery.
+
+## Decision
+
+### Lookup becomes three-valued
+
+`StaticCache::get()` returns `CacheLookup { Fresh(CacheHit) | Stale(CacheHit) |
+Miss }` instead of `Option<CacheHit>`. An expired entry is returned as **`Stale`
+and kept in place** (not evicted) so the caller can revalidate and revive it. The
+**L2 tier is the freshness authority**: the thread-local L1 still evicts its own
+expired/stale-generation entries and returns a fresh hit only, so an L1 miss
+falls through to L2, which decides Fresh vs Stale vs Miss. This keeps the change
+off L1's zero-contention fast path.
+
+`refresh(path, body, meta, freshness, age)` revives a stale entry by re-inserting
+the **stored body** with a new lifetime — a 304 keeps the body, so this reuses
+the battle-tested `insert` (L2 write + generation bump ⇒ L1 re-promotes) rather
+than adding a second mutation path across all tiers.
+
+### Dispatch flow (`handle_static_cache`)
+
+On `Stale` **with a validator**, zion adds `If-None-Match`/`If-Modified-Since`
+from the stored validators and reuses the existing origin-fetch + singleflight
+path as a conditional GET:
+
+- **`304`** → `refresh` the entry, signal singleflight waiters (they observe the
+  revived fresh entry), serve the stored body as `X-Zion-Cache: REVALIDATED`,
+  bump `zion_cache_revalidations`. No re-download.
+- **`200`** (or any non-304) → new content: fall through to the normal
+  store-and-serve, replacing the stale entry.
+- **Origin error** (unreachable / transport failure) → **stale-if-error**
+  (§4.2.4): serve the stored stale body as `X-Zion-Cache: STALE` rather than
+  propagate the error — a flapping origin does not take cached content down.
+
+A `Stale` entry with **no validator** falls through to a full fetch (a
+conditional GET would be pointless). `only-if-cached` (§5.2.1.7) still serves
+only a *fresh* entry (it must not contact the origin, so it cannot revalidate).
+
+## Consequences
+
+- **Positive**: standards-conformant revalidation; the origin↔zion transfer is
+  saved on the 304 path; stale-if-error adds resilience to origin blips. Proven
+  live end-to-end (MISS → HIT → REVALIDATED → HIT, `revalidations` counter moves,
+  body served from cache on the 304).
+- **Negative**: an expired entry now lingers (as `Stale`) until revalidated or
+  capacity-evicted, instead of being dropped at expiry — a small memory-residency
+  change, bounded by the existing sampled capacity eviction (it removes expired
+  entries first under pressure).
+- **Neutral**: full HTTP-date `If-Modified-Since` comparison and forwarding a
+  *client's* conditional through a 304 revalidation to answer the client with 304
+  too remain follow-ups; today a revalidated entry is served as a full `200`
+  (`REVALIDATED`).
+
+## Relationship to ADR-0003
+
+A follow-up, not a supersession. ADR-0003 (two-level cache with generation) stays
+`accepted`; its L1/L2/generation model is unchanged — this only makes expiry a
+revalidation trigger instead of an eviction, using the same generation bump to
+propagate a refresh.
+
+## References
+
+- ADR-0003 (two-level cache), RFC 9111 §4.3 / §4.2.4, RFC 9110 §13
+- `src/cache.rs` (`CacheLookup`, `get`, `refresh`), `src/dispatch.rs`
+  (`handle_static_cache`, `cache_response`, `add_conditional_headers`)
+- `docs/config/caching.md` (Origin-side revalidation), issue #266

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -28,6 +28,7 @@ defined in [0000-template.md](0000-template.md).
 | 0015  | [`mode = "static"` — opt-in disk file serving](0015-route-mode-static.md) | accepted |
 | 0016  | [nginx `root`/`try_files`/`index` → `mode = "static"`](0016-importer-nginx-static-mapping.md) | accepted |
 | 0017  | [Audit-log rotation with per-segment chain re-anchoring](0017-audit-log-rotation.md) | accepted |
+| 0018  | [Cache origin-side revalidation (RFC 9111 §4.3)](0018-cache-origin-revalidation.md) | accepted |
 
 ## When to write a new ADR
 

--- a/docs/config/caching.md
+++ b/docs/config/caching.md
@@ -61,8 +61,28 @@ The freshness lifetime is **origin-driven, clamped to the profile**:
 
 Every hit carries an **`Age`** header (RFC 9111 §4.2.3) — seeded from the upstream
 `Age` at insert plus time lived in zion's cache — and a `Cache-Control: max-age`
-so downstream caches compute the same expiry. A stale entry is not served; it is
-re-fetched (origin-side revalidation with `If-None-Match` is a roadmap item).
+so downstream caches compute the same expiry.
+
+## Origin-side revalidation (RFC 9111 §4.3)
+
+A stale entry is **revalidated**, not blindly re-fetched. When a stored entry is
+past its freshness and carries a validator, zion sends a **conditional GET** to
+the origin (`If-None-Match` from the stored `ETag`, `If-Modified-Since` from
+`Last-Modified`):
+
+- **`304 Not Modified`** → the stored entry is still good: zion revives its
+  freshness in place and serves the **cached body**, marked
+  `X-Zion-Cache: REVALIDATED` — no re-download. `zion_cache_revalidations`
+  counts these.
+- **`200 OK`** → the content changed: the new response replaces the stale entry
+  and is served + cached as a normal fetch.
+- **Origin error** (unreachable / 5xx during revalidation) → **stale-if-error**
+  (§4.2.4): zion serves the stale body (`X-Zion-Cache: STALE`) rather than
+  failing, so a flapping origin doesn't take cached content down.
+
+A stale entry with **no validator** can't be revalidated, so it is re-fetched in
+full (a normal miss). The stale body is kept in cache until it is revalidated or
+evicted by capacity — it is never served without one of the checks above.
 
 ## Request `Cache-Control` (RFC 9111 §5.2.1)
 
@@ -118,7 +138,7 @@ $ curl -sX POST 'http://127.0.0.1/_zion/cache/purge?prefix=/static/app.js'
 | Origin-driven freshness (`max-age` / `s-maxage`) + `Age` | 9111 §4.2 | Yes |
 | Request `Cache-Control` (no-cache/no-store/max-age=0/only-if-cached) | 9111 §5.2.1 | Yes |
 | Client conditional → `304` (If-None-Match / If-Modified-Since) | 9110 §13 | Yes |
-| Origin-side revalidation (stale → conditional GET) | 9111 §4.3 | Roadmap |
+| Origin-side revalidation (stale → conditional GET → 304) | 9111 §4.3 | Yes (`REVALIDATED`; stale-if-error §4.2.4) |
 
 See also [Hot-reload](/deploy/hot-reload) (cache survives config reloads) and the
 [two-level-cache ADR](/adr/0003-two-level-cache-with-generation).

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -49,6 +49,31 @@ pub struct CacheHit {
     pub max_age_secs: u64,
 }
 
+/// Outcome of a cache lookup (RFC 9111 §4.3). `Stale` returns the stored entry
+/// **without evicting it**, so the caller can revalidate with the origin and, on
+/// a `304 Not Modified`, revive it via [`StaticCache::refresh`] instead of
+/// re-downloading the body.
+pub enum CacheLookup {
+    /// Within its freshness lifetime — serve directly.
+    Fresh(CacheHit),
+    /// Past its freshness lifetime but still stored — revalidate before serving.
+    Stale(CacheHit),
+    /// Not stored.
+    Miss,
+}
+
+impl CacheLookup {
+    /// The fresh hit, if this lookup was `Fresh`. Ergonomic accessor for the
+    /// common "serve-now-or-nothing" callers (and tests); `Stale`/`Miss` → `None`.
+    #[inline]
+    pub fn fresh(self) -> Option<CacheHit> {
+        match self {
+            CacheLookup::Fresh(hit) => Some(hit),
+            _ => None,
+        }
+    }
+}
+
 /// L1 entry — with TTL from L2 (prevents stale data after expiry).
 struct L1Entry {
     body: Bytes,
@@ -307,53 +332,45 @@ impl StaticCache {
     }
 
     #[inline]
-    pub fn get(&self, path: &str) -> Option<CacheHit> {
+    pub fn get(&self, path: &str) -> CacheLookup {
+        use std::sync::atomic::Ordering::Relaxed;
         let l1_max = self.l1_max_entries;
 
-        // If Single-Core fallback is active, bypass L1/L2 distinction.
-        // The L2 becomes thread-local Hashmap (L1 speed for all misses).
-        // `let-else` binds l2 for the concurrent path below and diverges
-        // (returns) on the single-core path — this replaces a later
-        // `unreachable!()` that was a latent process-abort under panic=abort.
+        // Single-core fallback: LOCAL_L2 only. A stored-but-expired entry is
+        // returned as `Stale` (kept in place) so the caller can revalidate —
+        // RFC 9111 §4.3 — instead of the old evict-and-refetch.
         let Some(l2_concurrent) = &self.l2 else {
-            let mut expired = false;
-            let hit = LOCAL_L2.with(|map| {
+            return LOCAL_L2.with(|map| {
                 let m = map.borrow();
-                if let Some(entry) = m.get(path) {
-                    if Instant::now() >= entry.expires_at {
-                        expired = true;
-                        None
-                    } else {
-                        Some(CacheHit {
+                match m.get(path) {
+                    Some(entry) => {
+                        let hit = CacheHit {
                             body: entry.body.clone(),
                             meta: entry.meta.clone(),
                             age_secs: entry.initial_age_secs
                                 + entry.inserted_at.elapsed().as_secs(),
                             max_age_secs: entry.freshness_secs,
-                        })
+                        };
+                        if Instant::now() >= entry.expires_at {
+                            CacheLookup::Stale(hit)
+                        } else {
+                            crate::metrics::METRICS.cache_hits.fetch_add(1, Relaxed);
+                            CacheLookup::Fresh(hit)
+                        }
                     }
-                } else {
-                    None
+                    None => {
+                        crate::metrics::METRICS.cache_misses.fetch_add(1, Relaxed);
+                        CacheLookup::Miss
+                    }
                 }
             });
-            if expired {
-                LOCAL_L2.with(|map| map.borrow_mut().remove(path));
-            }
-            if hit.is_some() {
-                crate::metrics::METRICS
-                    .cache_hits
-                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-            } else {
-                crate::metrics::METRICS
-                    .cache_misses
-                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-            }
-            return hit;
         };
 
         let current_gen = self.generation.load(std::sync::atomic::Ordering::Acquire);
 
-        // L1: thread-local, zero contention
+        // L1: thread-local, zero contention. `L1Cache::get` returns a fresh hit
+        // only (it evicts its own expired / stale-generation entries), so a miss
+        // here falls through to L2 — the source of truth for freshness.
         let l1_hit = L1.with(|l1| {
             let mut l1 = l1.borrow_mut();
             let l1 = l1.get_or_insert_with(|| L1Cache::new(l1_max));
@@ -361,37 +378,35 @@ impl StaticCache {
         });
 
         if let Some(hit) = l1_hit {
-            crate::metrics::METRICS
-                .cache_hits
-                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-            return Some(hit);
+            crate::metrics::METRICS.cache_hits.fetch_add(1, Relaxed);
+            return CacheLookup::Fresh(hit);
         }
 
-        // L2: shared DashMap. A true absence is a miss and must be counted —
-        // the bare `?` here previously returned None without recording it, so
-        // on multi-core builds cache_misses was undercounted and the reported
-        // hit-rate inflated.
+        // L2: shared DashMap. Absent = Miss (counted — a bare `?` here once
+        // undercounted misses and inflated the hit-rate). Expired = Stale, kept
+        // in place for origin revalidation (§4.3), NOT evicted. Fresh = promote
+        // to L1 and serve.
         let Some(entry) = l2_concurrent.get(path) else {
-            crate::metrics::METRICS
-                .cache_misses
-                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-            return None;
+            crate::metrics::METRICS.cache_misses.fetch_add(1, Relaxed);
+            return CacheLookup::Miss;
         };
-        if Instant::now() >= entry.expires_at {
-            drop(entry);
-            l2_concurrent.remove(path);
-            crate::metrics::METRICS
-                .cache_misses
-                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-            return None;
-        }
         let body = entry.body.clone();
         let meta = entry.meta.clone();
+        let age_secs = entry.initial_age_secs + entry.inserted_at.elapsed().as_secs();
+        let freshness_secs = entry.freshness_secs;
+        if Instant::now() >= entry.expires_at {
+            drop(entry); // release the DashMap read lock; leave the entry stored
+            return CacheLookup::Stale(CacheHit {
+                body,
+                meta,
+                age_secs,
+                max_age_secs: freshness_secs,
+            });
+        }
         let key: Arc<str> = entry.key().clone();
         let inserted_at = entry.inserted_at;
         let expires_at = entry.expires_at;
         let initial_age_secs = entry.initial_age_secs;
-        let freshness_secs = entry.freshness_secs;
         drop(entry); // release DashMap read lock
 
         // Promote to L1 preserving the original birth time, TTL and generation.
@@ -410,15 +425,38 @@ impl StaticCache {
             );
         });
 
-        crate::metrics::METRICS
-            .cache_hits
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        Some(CacheHit {
+        crate::metrics::METRICS.cache_hits.fetch_add(1, Relaxed);
+        CacheLookup::Fresh(CacheHit {
             body,
             meta,
-            age_secs: initial_age_secs + inserted_at.elapsed().as_secs(),
+            age_secs,
             max_age_secs: freshness_secs,
         })
+    }
+
+    /// Revalidation refresh (RFC 9111 §4.3): after the origin answers a
+    /// conditional request with `304 Not Modified`, re-stamp the stored entry
+    /// with a fresh freshness lifetime, reusing the body the caller already
+    /// holds (from a [`CacheLookup::Stale`]). A 304 keeps the same body, so this
+    /// is an `insert` of the stored bytes with a new lifetime — reviving the
+    /// entry across all tiers (L2 write + generation bump ⇒ L1 re-promotes).
+    pub fn refresh(
+        &self,
+        path: &str,
+        body: Bytes,
+        meta: CachedMeta,
+        freshness_secs: u64,
+        initial_age_secs: u64,
+        max_entries: usize,
+    ) {
+        self.insert(
+            path,
+            body,
+            meta,
+            freshness_secs,
+            initial_age_secs,
+            max_entries,
+        );
     }
 
     /// Insert into L2 (source of truth). L1 populated lazily on next get.
@@ -627,7 +665,7 @@ mod tests {
             0,
             100,
         );
-        let hit = cache.get("/style.css").unwrap();
+        let hit = cache.get("/style.css").fresh().unwrap();
         assert_eq!(hit.body, Bytes::from("body{}"));
         assert_eq!(hit.meta.content_type.unwrap(), "text/css");
         assert_eq!(hit.meta.status, StatusCode::OK);
@@ -636,7 +674,7 @@ mod tests {
     #[test]
     fn get_miss_returns_none() {
         let cache = StaticCache::new();
-        assert!(cache.get("/nonexistent").is_none());
+        assert!(cache.get("/nonexistent").fresh().is_none());
     }
 
     #[test]
@@ -651,19 +689,68 @@ mod tests {
             last_modified: None,
         };
         cache.insert("/a.js", Bytes::from("v2"), meta2, 3600, 0, 100);
-        let hit = cache.get("/a.js").unwrap();
+        let hit = cache.get("/a.js").fresh().unwrap();
         assert_eq!(hit.body, Bytes::from("v2"));
         assert_eq!(hit.meta.content_type.unwrap(), "application/javascript");
         assert_eq!(cache.len(), 1);
     }
 
     #[test]
-    fn ttl_expiration() {
+    fn ttl_expiration_returns_stale_kept_in_place() {
         let cache = StaticCache::new();
         cache.insert("/expired.js", Bytes::from("old"), default_meta(), 0, 0, 100);
         std::thread::sleep(std::time::Duration::from_millis(10));
-        assert!(cache.get("/expired.js").is_none());
-        assert_eq!(cache.len(), 0);
+        // #266: an expired entry is not served fresh …
+        assert!(cache.get("/expired.js").fresh().is_none());
+        // … but it is kept for revalidation (Stale), not evicted.
+        assert!(matches!(
+            cache.get("/expired.js"),
+            CacheLookup::Stale(hit) if hit.body.as_ref() == b"old"
+        ));
+        assert_eq!(
+            cache.len(),
+            1,
+            "stale entries stay stored until refreshed/evicted"
+        );
+    }
+
+    #[test]
+    fn refresh_revives_a_stale_entry_to_fresh_reusing_the_body() {
+        let cache = StaticCache::new();
+        // freshness 0 ⇒ immediately stale.
+        cache.insert("/r.js", Bytes::from("v1"), default_meta(), 0, 0, 100);
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        let stale = match cache.get("/r.js") {
+            CacheLookup::Stale(hit) => hit,
+            other => panic!("expected Stale, got {}", disp(&other)),
+        };
+        // #266: a 304 revives it with a fresh lifetime, reusing the stored body.
+        cache.refresh(
+            "/r.js",
+            stale.body.clone(),
+            stale.meta.clone(),
+            3600,
+            0,
+            100,
+        );
+        let hit = cache
+            .get("/r.js")
+            .fresh()
+            .expect("entry must be fresh after refresh");
+        assert_eq!(
+            hit.body,
+            Bytes::from("v1"),
+            "refresh reuses the stored body"
+        );
+        assert_eq!(cache.len(), 1);
+    }
+
+    fn disp(l: &CacheLookup) -> &'static str {
+        match l {
+            CacheLookup::Fresh(_) => "Fresh",
+            CacheLookup::Stale(_) => "Stale",
+            CacheLookup::Miss => "Miss",
+        }
     }
 
     #[test]
@@ -676,7 +763,7 @@ mod tests {
 
         cache.insert("/d", Bytes::from("d"), default_meta(), 3600, 0, 3);
         assert_eq!(cache.len(), 3);
-        assert!(cache.get("/d").is_some());
+        assert!(cache.get("/d").fresh().is_some());
     }
 
     #[test]
@@ -692,7 +779,7 @@ mod tests {
     fn empty_body_cacheable() {
         let cache = StaticCache::new();
         cache.insert("/empty", Bytes::new(), default_meta(), 3600, 0, 100);
-        assert!(cache.get("/empty").is_some());
+        assert!(cache.get("/empty").fresh().is_some());
     }
 
     #[test]
@@ -700,7 +787,7 @@ mod tests {
         let cache = StaticCache::new();
         let big = Bytes::from(vec![0xFFu8; 1024 * 1024]);
         cache.insert("/big.bin", big.clone(), default_meta(), 3600, 0, 100);
-        let hit = cache.get("/big.bin").unwrap();
+        let hit = cache.get("/big.bin").fresh().unwrap();
         assert_eq!(hit.body, big);
     }
 
@@ -710,11 +797,11 @@ mod tests {
         cache.insert("/hot.js", Bytes::from("hot"), default_meta(), 3600, 0, 100);
 
         // First get: L2 hit + L1 promote
-        assert!(cache.get("/hot.js").is_some());
+        assert!(cache.get("/hot.js").fresh().is_some());
 
         // Second get: should be L1 hit (no way to verify directly,
         // but we can verify correctness)
-        let hit = cache.get("/hot.js").unwrap();
+        let hit = cache.get("/hot.js").fresh().unwrap();
         assert_eq!(hit.body, Bytes::from("hot"));
     }
 
@@ -763,7 +850,7 @@ mod tests {
             last_modified: None,
         };
         cache.insert("/no-ct", Bytes::from("data"), meta, 3600, 0, 100);
-        let hit = cache.get("/no-ct").unwrap();
+        let hit = cache.get("/no-ct").fresh().unwrap();
         assert!(hit.meta.content_type.is_none());
     }
 
@@ -778,7 +865,7 @@ mod tests {
             last_modified: None,
         };
         cache.insert("/304", Bytes::new(), meta, 3600, 0, 100);
-        let hit = cache.get("/304").unwrap();
+        let hit = cache.get("/304").fresh().unwrap();
         assert_eq!(hit.meta.status, StatusCode::NOT_MODIFIED);
     }
 
@@ -786,7 +873,7 @@ mod tests {
     fn hit_reports_freshness_as_max_age() {
         let cache = StaticCache::new();
         cache.insert("/a.css", Bytes::from("x"), default_meta(), 600, 0, 100);
-        let hit = cache.get("/a.css").unwrap();
+        let hit = cache.get("/a.css").fresh().unwrap();
         assert_eq!(hit.max_age_secs, 600);
     }
 
@@ -794,7 +881,7 @@ mod tests {
     fn fresh_entry_has_zero_age() {
         let cache = StaticCache::new();
         cache.insert("/a.css", Bytes::from("x"), default_meta(), 600, 0, 100);
-        let hit = cache.get("/a.css").unwrap();
+        let hit = cache.get("/a.css").fresh().unwrap();
         // Just inserted with no upstream age — Age must be ~0, never the lifetime.
         assert_eq!(hit.age_secs, 0);
     }
@@ -804,7 +891,7 @@ mod tests {
         // Object arrived from the shield already 120s old (upstream Age: 120).
         let cache = StaticCache::new();
         cache.insert("/a.css", Bytes::from("x"), default_meta(), 600, 120, 100);
-        let hit = cache.get("/a.css").unwrap();
+        let hit = cache.get("/a.css").fresh().unwrap();
         assert!(
             hit.age_secs >= 120,
             "Age must include the upstream age, got {}",
@@ -817,13 +904,13 @@ mod tests {
         let cache = StaticCache::new();
         cache.insert("/a.css", Bytes::from("a"), default_meta(), 3600, 0, 100);
         cache.insert("/b.css", Bytes::from("b"), default_meta(), 3600, 0, 100);
-        assert!(cache.get("/a.css").is_some()); // promote into L1
+        assert!(cache.get("/a.css").fresh().is_some()); // promote into L1
         let n = cache.purge_all();
         assert_eq!(n, 2);
         assert_eq!(cache.len(), 0);
         // L1 entry must be treated as stale after the generation bump
-        assert!(cache.get("/a.css").is_none());
-        assert!(cache.get("/b.css").is_none());
+        assert!(cache.get("/a.css").fresh().is_none());
+        assert!(cache.get("/b.css").fresh().is_none());
     }
 
     #[test]
@@ -855,9 +942,9 @@ mod tests {
         );
         let n = cache.purge_prefix("/assets/");
         assert_eq!(n, 2);
-        assert!(cache.get("/assets/x.js").is_none());
+        assert!(cache.get("/assets/x.js").fresh().is_none());
         assert!(
-            cache.get("/index.html").is_some(),
+            cache.get("/index.html").fresh().is_some(),
             "non-matching key survives"
         );
     }
@@ -868,7 +955,7 @@ mod tests {
         let cache = StaticCache::new();
         cache.insert("/stale", Bytes::from("x"), default_meta(), 100, 100, 100);
         assert!(
-            cache.get("/stale").is_none(),
+            cache.get("/stale").fresh().is_none(),
             "an object that arrives already past its lifetime must not be served"
         );
     }

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -1498,11 +1498,15 @@ fn upstream_age(headers: &hyper::HeaderMap) -> u64 {
 /// Content-Encoding, a `Cache-Control` whose `max-age` matches the entry's
 /// freshness lifetime, and the `Age` header so downstream caches subtract
 /// elapsed time instead of resetting their freshness clock on every hit.
-fn cache_hit_response(hit: cache::CacheHit) -> Response<ZionBody> {
+/// Serve a stored body with the given `X-Zion-Cache` disposition. `HIT` = a
+/// fresh hit; `REVALIDATED` = a stale entry the origin confirmed with a 304
+/// (RFC 9111 §4.3), served without re-downloading; `STALE` = stale served on an
+/// origin error (§4.2.4 stale-if-error).
+fn cache_response(hit: cache::CacheHit, disposition: &'static str) -> Response<ZionBody> {
     let mut builder = Response::builder()
         .status(hit.meta.status)
         .header("Cache-Control", profile_cache_control(hit.max_age_secs))
-        .header("X-Zion-Cache", "HIT")
+        .header("X-Zion-Cache", disposition)
         .header(hyper::header::AGE, hit.age_secs);
     if let Some(ct) = &hit.meta.content_type {
         builder = builder.header(hyper::header::CONTENT_TYPE, ct.clone());
@@ -1513,6 +1517,24 @@ fn cache_hit_response(hit: cache::CacheHit) -> Response<ZionBody> {
     builder
         .body(Full::new(hit.body).map_err(|never| match never {}).boxed())
         .unwrap()
+}
+
+#[inline]
+fn cache_hit_response(hit: cache::CacheHit) -> Response<ZionBody> {
+    cache_response(hit, "HIT")
+}
+
+/// Seed a conditional GET for origin revalidation (RFC 9111 §4.3.1) from a
+/// stale entry's stored validators. `insert` overwrites any client-supplied
+/// conditional header so we revalidate against *our* copy; the origin prefers
+/// `If-None-Match` when both are present (RFC 9110 §13.1.3).
+fn add_conditional_headers(headers: &mut hyper::HeaderMap, meta: &cache::CachedMeta) {
+    if let Some(etag) = &meta.etag {
+        headers.insert(hyper::header::IF_NONE_MATCH, etag.clone());
+    }
+    if let Some(lm) = &meta.last_modified {
+        headers.insert(hyper::header::IF_MODIFIED_SINCE, lm.clone());
+    }
 }
 
 /// Parse the REQUEST's `Cache-Control` for the directives a shared cache honors
@@ -1615,7 +1637,7 @@ fn not_modified_response(hit: &cache::CacheHit) -> Response<ZionBody> {
 }
 
 async fn handle_static_cache(
-    req: Request<ZionBody>,
+    mut req: Request<ZionBody>,
     state: Arc<AppState>,
     rule: &ResolvedRoute,
     remote_addr: SocketAddr,
@@ -1676,22 +1698,38 @@ async fn handle_static_cache(
     // only-if-cached (§5.2.1.7): serve from cache or 504 — never fetch.
     if rcc_only_if_cached {
         return Ok(match state.static_cache.get(&cache_key) {
-            Some(hit) => cache_hit_response(hit),
-            None => cache_only_if_cached_miss(),
+            // only-if-cached (§5.2.1.7) must not contact the origin, so a stale
+            // stored response can't be revalidated → 504, same as a miss.
+            cache::CacheLookup::Fresh(hit) => cache_hit_response(hit),
+            _ => cache_only_if_cached_miss(),
         });
     }
 
-    // RAM hit — zero-copy serve with preserved Content-Type and Content-Encoding,
-    // unless the client demanded a fresh response (`no-cache` / `no-store`).
+    // RAM lookup. `Fresh` → zero-copy serve. `Stale` → keep the body and
+    // revalidate with the origin below (RFC 9111 §4.3) instead of refetching.
+    // `Miss` → fall through to a full fetch. Skipped when the client demanded a
+    // fresh response (`no-cache` / `no-store`).
+    let mut revalidate: Option<cache::CacheHit> = None;
     if !rcc_no_cache && !rcc_no_store {
-        if let Some(hit) = state.static_cache.get(&cache_key) {
-            // Client conditional request (RFC 9110 §13): a matching
-            // If-None-Match / If-Modified-Since → 304 Not Modified, skipping the
-            // body entirely.
-            if client_conditional_hit(req.headers(), &hit.meta) {
-                return Ok(not_modified_response(&hit));
+        match state.static_cache.get(&cache_key) {
+            cache::CacheLookup::Fresh(hit) => {
+                // Client conditional request (RFC 9110 §13): a matching
+                // If-None-Match / If-Modified-Since → 304 Not Modified, skipping
+                // the body entirely.
+                if client_conditional_hit(req.headers(), &hit.meta) {
+                    return Ok(not_modified_response(&hit));
+                }
+                return Ok(cache_hit_response(hit));
             }
-            return Ok(cache_hit_response(hit));
+            cache::CacheLookup::Stale(hit) => {
+                // Only revalidate when we hold a validator; without one a
+                // conditional GET is pointless, so fall through to a full fetch.
+                if hit.meta.etag.is_some() || hit.meta.last_modified.is_some() {
+                    add_conditional_headers(req.headers_mut(), &hit.meta);
+                    revalidate = Some(hit);
+                }
+            }
+            cache::CacheLookup::Miss => {}
         }
     }
 
@@ -1714,11 +1752,13 @@ async fn handle_static_cache(
         // In both Ok and Err cases we re-check the cache; on miss we fall
         // through to fetch ourselves.
         let _ = rx.wait_for(|v| *v).await;
-        if let Some(hit) = state.static_cache.get(path_owned.as_ref()) {
+        if let Some(hit) = state.static_cache.get(path_owned.as_ref()).fresh() {
             // get() already counted this hit — don't double-count it here.
             return Ok(cache_hit_response(hit));
         }
-        // Cache miss even after wait — fall through to fetch from upstream
+        // Cache miss (or stale) even after wait — fall through to fetch from
+        // upstream, which re-populates (a stale re-check here is rare: the
+        // fetcher we waited on just stored a fresh entry).
     }
 
     // Register as the inflight fetcher for this key.
@@ -1745,10 +1785,45 @@ async fn handle_static_cache(
         Ok(r) => r,
         Err(e) => {
             state.inflight.remove(&path_owned);
+            // stale-if-error (RFC 9111 §4.2.4): if we were revalidating a stale
+            // entry and the origin is unreachable, serve the stale body rather
+            // than fail — a flapping origin doesn't take cached content down.
+            if let Some(hit) = revalidate {
+                return Ok(cache_response(hit, "STALE"));
+            }
             // tx drops at end of scope → channel closed → waiters get Err
             return Err(e);
         }
     };
+
+    // Revalidation outcome (RFC 9111 §4.3): a 304 confirms the stored entry is
+    // still good — revive its freshness and serve the stored body without the
+    // re-download. A 200 (or anything else) falls through to the normal
+    // store-and-serve path, replacing the stale entry with the new content.
+    if let Some(hit) = revalidate {
+        if resp.status() == StatusCode::NOT_MODIFIED {
+            let initial_age = upstream_age(resp.headers());
+            let effective_ttl = origin_freshness(resp.headers())
+                .map(|o| o.min(cache_ttl))
+                .unwrap_or(cache_ttl);
+            state.static_cache.refresh(
+                &path_owned,
+                hit.body.clone(),
+                hit.meta.clone(),
+                effective_ttl,
+                initial_age,
+                cache_max,
+            );
+            state.inflight.remove(&path_owned);
+            let _ = tx.send(true); // waiters observe the revived (fresh) entry
+            crate::metrics::METRICS
+                .cache_revalidations
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            return Ok(cache_response(hit, "REVALIDATED"));
+        }
+        // else: origin returned new content (200) or a non-304 status — drop the
+        // stale hit and let the normal path below store/serve the fresh response.
+    }
 
     // Only cache 200 OK responses
     if resp.status() == StatusCode::OK {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -399,6 +399,9 @@ pub struct Metrics {
     pub rate_limited: ShardedCounter,
     pub cache_hits: ShardedCounter,
     pub cache_misses: ShardedCounter,
+    /// Stale entries revalidated to a 304 (RFC 9111 §4.3) — served from cache
+    /// without re-downloading the body. A subset of "would-have-been misses".
+    pub cache_revalidations: ShardedCounter,
 
     // Global Counters (Cold Path or connection-level)
     pub websocket_upgrades: AtomicU64,
@@ -499,6 +502,7 @@ impl Metrics {
             rate_limited: ShardedCounter::new(),
             cache_hits: ShardedCounter::new(),
             cache_misses: ShardedCounter::new(),
+            cache_revalidations: ShardedCounter::new(),
             websocket_upgrades: AtomicU64::new(0),
             connections_total: AtomicU64::new(0),
             tls_handshake_errors: AtomicU64::new(0),
@@ -719,6 +723,18 @@ impl Metrics {
                                 zion_cache_misses ",
         );
         out.extend_from_slice(itoa_buf.format(self.cache_misses.load(Relaxed)).as_bytes());
+        out.extend_from_slice(b"\n");
+
+        out.extend_from_slice(
+            b"# HELP zion_cache_revalidations Stale entries revalidated to a 304 (served from cache, body not re-downloaded).\n\
+                                # TYPE zion_cache_revalidations counter\n\
+                                zion_cache_revalidations ",
+        );
+        out.extend_from_slice(
+            itoa_buf
+                .format(self.cache_revalidations.load(Relaxed))
+                .as_bytes(),
+        );
         out.extend_from_slice(b"\n");
 
         out.extend_from_slice(


### PR DESCRIPTION
Closes #266 — **the riskiest cache change** (perf-critical hot path). RFC 9111 §4.3: a stale entry is now **revalidated**, not evicted-and-re-downloaded.

## Core
- `StaticCache::get()` → `CacheLookup{Fresh|Stale|Miss}` (was `Option<CacheHit>`). An expired entry is **`Stale` and kept in place**, not evicted. **L2 is the freshness authority**; L1 stays a fresh-only zero-contention fast path and falls through to L2. `refresh()` revives a stale entry by re-inserting the stored body with a new lifetime (reuses the tested `insert` — L2 write + generation bump ⇒ L1 re-promotes).
- `handle_static_cache`: on **Stale + validator**, send a conditional GET (`If-None-Match`/`If-Modified-Since`) through the existing singleflight fetch:
  - **304** → `refresh` + serve stored body as `X-Zion-Cache: REVALIDATED` (+ `zion_cache_revalidations`) — no re-download.
  - **200** → replace with new content.
  - **origin error** → **stale-if-error** (§4.2.4): serve stale as `X-Zion-Cache: STALE`.
  - **no validator** → full fetch. `only-if-cached` still serves *fresh* only.

## Proven LIVE
Against a conditional-aware mock origin (`ETag`, `max-age=1`, 304 on `If-None-Match`):
```
1. GET → MISS   2. GET → HIT (fresh)
3. (stale) GET → REVALIDATED  (origin 304, body from cache, ORIGINAL-BODY intact)
4. GET → HIT (the 304 refreshed it)
zion_cache_revalidations 1
```

Cache tier logic unit-tested (`ttl_expiration_returns_stale_kept_in_place`, `refresh_revives_a_stale_entry_to_fresh_reusing_the_body`). Full suite green; clippy `--all-targets` clean. Docs: [caching §4.3](docs/config/caching.md) flipped to ✅ + [ADR-0018](docs/adr/0018-cache-origin-revalidation.md).

Follow-ups (noted in ADR-0018): full HTTP-date `If-Modified-Since`, and passing a client's conditional through to answer 304.

🤖 Generated with [Claude Code](https://claude.com/claude-code)