### PR TITLE
chore(release): v0.7.2

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,7 +21,7 @@ A clear and concise description of what you expected to happen.
 **Environment (please complete the following information):**
  - OS: [e.g. Linux, macOS]
  - Architecture: [e.g. arm64, amd64]
- - Zion Version: [e.g. 0.7.1]
+ - Zion Version: [e.g. 0.7.2]
 
 **Additional context**
 Add any other context about the problem here (e.g. logs with `RUST_LOG=trace`, upstream backend type like Go/Node).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,39 @@ All notable changes to Zion Edge Gateway are documented here.
 
 ## [Unreleased]
 
+## [0.7.2] - 2026-07-31
+
+### Added
+- **Cache origin-side revalidation** (RFC 9111 §4.3, ADR-0018). A stale cache
+  entry is now revalidated with the origin via a conditional GET instead of
+  evicted and fully re-downloaded. On a `304 Not Modified` the stored body is
+  reused and served as `X-Zion-Cache: REVALIDATED` (counted by
+  `zion_cache_revalidations`); an origin error during revalidation serves the
+  stale body (`X-Zion-Cache: STALE`, stale-if-error §4.2.4). `StaticCache::get()`
+  now returns a three-valued `CacheLookup { Fresh | Stale | Miss }`.
+- **Audit-log rotation** (ADR-0017). The HMAC-chained audit log gained
+  size-based rotation with retention — `[audit].max_size_mb` (default 100) +
+  `max_files` (default 10) — so an enabled log is bounded on disk (~1.1 GB by
+  default). Each rotated segment re-anchors the chain at genesis with a
+  `chain_rotate` marker, so segments verify independently.
+- **ACME soak fault-injection legs.** `zion acme-soak` gained `key-rollover`
+  (discard the account, re-issue, assert a fresh account) and `ttl-edge` (assert
+  the renewal trigger fires at the `renew_before_days` edge) modes, run as a
+  matrix against Pebble in CI (issue #134). `nonce-collision` remains deferred
+  (needs per-request `badNonce` retry, not exposed by instant-acme 0.8.x).
+
+### Changed
+- **The AIMP mesh reputation table is now bounded** (issue #287): a 24-hour TTL
+  plus a 100k-entry cap with amortized eviction, so a long-lived mesh cannot grow
+  it without limit. Behind the `sovereign-aimp` feature (off by default).
+
+### Fixed
+- **`cargo-audit` CI (and master) went red** after v0.7.1 removed
+  `RUSTSEC-2026-0002`/`-0186` from the ignore lists on the strength of
+  cargo-deny's report — but cargo-audit scans the flat lockfile and still flags
+  them under `--deny unsound`. Re-ignored for cargo-audit only (not `deny.toml`,
+  where a not-detected id trips cargo-deny).
+
 ## [0.7.1] - 2026-07-31
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5477,7 +5477,7 @@ dependencies = [
 
 [[package]]
 name = "zion"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "aho-corasick",
  "aimp_node",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zion"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 # MSRV is the *core* default-features build (TLS proxy + WAF + cache + metrics).
 # Opt-in features (acme, auth, init, http3) pull crypto/i18n crates that have

--- a/README.md
+++ b/README.md
@@ -315,12 +315,12 @@ Every release is signed and carries SLSA v1.0 build provenance — see
 
 ```bash
 # Binary release (Sigstore-backed provenance via gh CLI)
-gh release download v0.7.1 -R fabriziosalmi/zion -p '*x86_64-unknown-linux-musl*' -p 'SHA256SUMS'
+gh release download v0.7.2 -R fabriziosalmi/zion -p '*x86_64-unknown-linux-musl*' -p 'SHA256SUMS'
 sha256sum --check --ignore-missing SHA256SUMS
-gh attestation verify zion-v0.7.1-x86_64-unknown-linux-musl.tar.gz --owner fabriziosalmi
+gh attestation verify zion-v0.7.2-x86_64-unknown-linux-musl.tar.gz --owner fabriziosalmi
 
 # Container image (cosign keyless)
-cosign verify ghcr.io/fabriziosalmi/zion:v0.7.1 \
+cosign verify ghcr.io/fabriziosalmi/zion:v0.7.2 \
     --certificate-identity-regexp "^https://github.com/fabriziosalmi/zion/\\.github/workflows/release\\.yml@refs/tags/v" \
     --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ from their containing minor — i.e. the latest `0.4.x` is always patched.
 | Version | Supported |
 | ------- | --------- |
 | 0.4.x (latest minor) | Yes |
-| < 0.7.1 | No |
+| < 0.7.2 | No |
 
 ## Reporting a Vulnerability
 

--- a/deploy/helm/zion/Chart.yaml
+++ b/deploy/helm/zion/Chart.yaml
@@ -3,7 +3,7 @@ name: zion
 description: Zion Edge Gateway — high-performance Rust TLS reverse proxy with WAF
 type: application
 version: 0.2.2
-appVersion: "0.7.1"
+appVersion: "0.7.2"
 home: https://fabriziosalmi.github.io/zion
 sources:
   - https://github.com/fabriziosalmi/zion

--- a/docs/deploy/hot-reload.md
+++ b/docs/deploy/hot-reload.md
@@ -130,7 +130,7 @@ Two surfaces report the reload state:
 
   ```json
   {
-    "version": "0.7.1",
+    "version": "0.7.2",
     "timestamp_ms": 1714425600000,
     "uptime_secs": 3712,
     "config_generation": 5,

--- a/docs/security/supply-chain.md
+++ b/docs/security/supply-chain.md
@@ -46,8 +46,8 @@ You need the GitHub CLI (`gh >= 2.49`) and `cosign >= 2.2`.
 
 ```bash
 # 1. Download the artifact + SHA256SUMS from the release page.
-gh release download v0.7.1 -R fabriziosalmi/zion \
-    -p 'zion-v0.7.1-x86_64-unknown-linux-musl.tar.gz' \
+gh release download v0.7.2 -R fabriziosalmi/zion \
+    -p 'zion-v0.7.2-x86_64-unknown-linux-musl.tar.gz' \
     -p 'SHA256SUMS' \
     -p 'zion-sbom.cdx.json'
 
@@ -55,7 +55,7 @@ gh release download v0.7.1 -R fabriziosalmi/zion \
 sha256sum --check --ignore-missing SHA256SUMS
 
 # 3. Verify the SLSA build provenance bound to the artifact's hash.
-gh attestation verify zion-v0.7.1-x86_64-unknown-linux-musl.tar.gz \
+gh attestation verify zion-v0.7.2-x86_64-unknown-linux-musl.tar.gz \
     --owner fabriziosalmi
 
 # Step 3 fails if:
@@ -78,7 +78,7 @@ grype zion-sbom.cdx.json
 ## Verifying a container image
 
 ```bash
-IMAGE=ghcr.io/fabriziosalmi/zion:v0.7.1
+IMAGE=ghcr.io/fabriziosalmi/zion:v0.7.2
 
 # 1. Pin to the digest immediately — tags are mutable, digests are not.
 DIGEST=$(crane digest "$IMAGE")
@@ -120,7 +120,7 @@ deterministically, and pins the Rust toolchain via
 [`rust-toolchain.toml`](../../rust-toolchain.toml). To reproduce locally:
 
 ```bash
-git checkout v0.7.1
+git checkout v0.7.2
 export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)
 # Linux musl example — matches the release artifact byte-for-byte
 # (modulo strip's stable behavior on your distro).


### PR DESCRIPTION
Releases the **4 adoption-track features** merged since v0.7.1:

- **Cache origin-side revalidation** (RFC 9111 §4.3) — #337, ADR-0018
- **Audit-log rotation** with retention — #334, ADR-0017
- **ACME soak** key-rollover + ttl-edge legs — #336
- **Bounded AIMP reputation table** — #335

Plus the cargo-audit red fix. `bump-version.sh 0.7.2` + CHANGELOG. On merge: tag `v0.7.2` → `release.yml` (platform tarballs + PGO + multi-arch cosign-signed container + SBOM).

🤖 Generated with [Claude Code](https://claude.com/claude-code)