### PR TITLE
test(integration): e2e rule-matrix — auth, CORS & rule composition

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -51,8 +51,11 @@ jobs:
       - name: Generate self-signed cert
         run: bash benchmarks/certs/generate.sh
 
-      - name: Build zion (release)
-        run: cargo build --release --bin zion
+      - name: Build zion (release, --features auth)
+        # `auth` is enabled so the e2e rule-matrix (auth + kitchen-sink combo
+        # routes in zion-test.toml) is actually enforced, not warned-off. This
+        # job runs on stable Rust — unrelated to the 1.82 MSRV core job.
+        run: cargo build --release --features auth --bin zion
 
       - name: Build test backend (release)
         run: cargo build --release --manifest-path benchmarks/backend/Cargo.toml

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,21 +1,37 @@
 # gitleaks configuration for Zion.
 #
-# Extends the upstream default ruleset and allowlists exactly one thing: the
-# benchmark self-signed TLS material. Those are throwaway `CN=bench.local` keys
-# generated on demand by `benchmarks/certs/generate.sh` (SAN bench.local /
-# localhost / 127.0.0.1) — never production secrets. One such key was committed
-# once (commit ad2c337, 2026-04-12) before `benchmarks/certs/*.key` was
-# gitignored; it is self-signed, superseded (a different key from the current
-# local one), and worthless to anyone, but it remains in git history, so we
-# allowlist the path to keep the full-history scan green rather than rewrite
-# history for a test key.
+# Extends the upstream default ruleset. Two allowlisted findings, both test
+# fixtures — never production secrets:
+#
+#  1. Benchmark self-signed TLS material — throwaway `CN=bench.local` keys
+#     generated on demand by `benchmarks/certs/generate.sh` (SAN bench.local /
+#     localhost / 127.0.0.1). One such key was committed once (commit ad2c337,
+#     2026-04-12) before `benchmarks/certs/*.key` was gitignored; it is
+#     self-signed, superseded (a different key from the current local one), and
+#     worthless to anyone, but it remains in git history, so we allowlist the
+#     path to keep the full-history scan green rather than rewrite history for a
+#     test key.
+#
+#  2. The e2e integration auth fixture — `E2E_JWT` in tests/integration.rs, a
+#     self-contained HS256 token whose signing secret is published in plain
+#     sight in tests/zion-test.toml (`e2e-jwt-secret-...`). It exists only to
+#     drive the auth gate in the #[ignore]d integration tests; its `exp` is year
+#     2100 so it never ages out, and it signs nothing real. Allowlisted by its
+#     exact value (not by path) so the scanner keeps watching the rest of that
+#     file for genuine leaks.
 title = "Zion"
 
 [extend]
 useDefault = true
 
-[allowlist]
+[[allowlists]]
 description = "Benchmark self-signed test certs (CN=bench.local) — not production secrets"
 paths = [
   '''benchmarks/certs/.*''',
+]
+
+[[allowlists]]
+description = "e2e integration auth fixture (HS256 test JWT; secret published in tests/zion-test.toml)"
+regexes = [
+  '''eyJhbGciOiAiSFMyNTYiLCAidHlwIjogIkpXVCJ9\.eyJzdWIiOiAiZTJlLXVzZXIiLCAiZW1haWwiOiAiZTJlQHppb24udGVzdCIsICJleHAiOiA0MTAyNDQ0ODAwfQ\.i2pofCwQa8-IJSCFrmqGu2kcWwH-fdsSZ_ootnYQblc''',
 ]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -9,9 +9,10 @@
 //! - Cache (hit vs miss, Content-Type preservation)
 //! - SSE streaming
 //! - Large responses
-//! - Internal-only routes
 //! - Error code forwarding
-//! - Host header validation
+//! - Auth (JWT/HS256): missing/invalid → denied, valid → passes
+//! - CORS: preflight + allowed/disallowed origin handling
+//! - Rule composition: a route stacking WAF + auth + CORS enforces all three
 //!
 //! Prerequisites: running Zion on :4433 + test backend on :9090
 //! Setup: ZION_CONFIG=tests/zion-test.toml ./target/release/zion
@@ -485,4 +486,130 @@ integration_test!(t31_static_route_serves_files_not_503, {
     // the on-disk file server refuses traversal on the live server too.
     let (st, _, _) = get("/assets/..%2f..%2f..%2fetc/passwd");
     assert!(st == 403 || st == 404, "traversal must not leak (got {st})");
+});
+
+// ── Rule matrix: auth / CORS / and the two composed on one route ────────────
+// Proves the middlewares work AND compose. Auth is enforced only under the
+// `--features auth` build the integration workflow uses; host-based routing is
+// covered by the equivalence harness (tests/equivalence/multi-vhost).
+
+/// A JWT signed HS256 with the `[auth_profile.e2e].secret` in zion-test.toml,
+/// `exp` in the year 2100. Regenerate with the same secret if the profile
+/// changes: base64url(header).base64url(payload).HMAC-SHA256.
+const E2E_JWT: &str = "eyJhbGciOiAiSFMyNTYiLCAidHlwIjogIkpXVCJ9.eyJzdWIiOiAiZTJlLXVzZXIiLCAiZW1haWwiOiAiZTJlQHppb24udGVzdCIsICJleHAiOiA0MTAyNDQ0ODAwfQ.i2pofCwQa8-IJSCFrmqGu2kcWwH-fdsSZ_ootnYQblc";
+
+/// GET with Host + arbitrary extra headers/flags.
+fn get_with(path: &str, extra: &[&str]) -> (u16, String, String) {
+    let url = format!("https://127.0.0.1:4433{path}");
+    let mut args: Vec<&str> = vec!["-H", "Host: bench.local"];
+    args.extend_from_slice(extra);
+    args.push(&url);
+    curl(&args)
+}
+
+integration_test!(t40_auth_missing_token_is_401, {
+    let (status, _, _) = get("/auth/x");
+    assert_eq!(status, 401, "an auth route with no token must be 401");
+});
+
+integration_test!(t41_auth_invalid_token_denied, {
+    let (status, _, _) = get_with("/auth/x", &["-H", "Authorization: Bearer not-a-jwt"]);
+    assert!(
+        status == 401 || status == 403,
+        "an invalid token must be denied (401/403), got {status}"
+    );
+});
+
+integration_test!(t42_auth_valid_jwt_reaches_backend, {
+    let auth = format!("Authorization: Bearer {E2E_JWT}");
+    let (status, _, _) = get_with("/auth/x", &["-H", &auth]);
+    assert_eq!(status, 200, "a valid JWT must reach the backend (200)");
+});
+
+integration_test!(t43_cors_preflight_returns_acao, {
+    let (status, _, headers) = get_with(
+        "/cors/x",
+        &[
+            "-X",
+            "OPTIONS",
+            "-H",
+            "Origin: https://trusted.example",
+            "-H",
+            "Access-Control-Request-Method: POST",
+        ],
+    );
+    assert!(
+        headers
+            .to_lowercase()
+            .contains("access-control-allow-origin"),
+        "preflight must return Access-Control-Allow-Origin; headers:\n{headers}"
+    );
+    assert!(status == 200 || status == 204, "preflight status {status}");
+});
+
+integration_test!(t44_cors_allowed_origin_reflected, {
+    let (_, _, headers) = get_with("/cors/x", &["-H", "Origin: https://trusted.example"]);
+    assert!(
+        headers
+            .to_lowercase()
+            .contains("access-control-allow-origin"),
+        "a request with an allowed Origin must get Access-Control-Allow-Origin"
+    );
+});
+
+integration_test!(t45_cors_disallowed_origin_not_reflected, {
+    let (_, _, headers) = get_with("/cors/x", &["-H", "Origin: https://evil.example"]);
+    let reflected = headers
+        .lines()
+        .find(|l| l.to_lowercase().starts_with("access-control-allow-origin"))
+        .map(|l| l.contains("evil.example"))
+        .unwrap_or(false);
+    assert!(!reflected, "a disallowed origin must never be reflected");
+});
+
+integration_test!(t46_combo_unauthenticated_is_401, {
+    // Clean GET, no token — auth gates before the request reaches the backend.
+    let (status, _, _) = get("/combo/x");
+    assert_eq!(
+        status, 401,
+        "the combo route (waf+auth+cors) must require auth"
+    );
+});
+
+integration_test!(t47_combo_authed_clean_passes_with_cors, {
+    let auth = format!("Authorization: Bearer {E2E_JWT}");
+    let (status, _, headers) = get_with(
+        "/combo/x",
+        &["-H", &auth, "-H", "Origin: https://trusted.example"],
+    );
+    assert_eq!(status, 200, "authed + clean must pass the combo route");
+    assert!(
+        headers
+            .to_lowercase()
+            .contains("access-control-allow-origin"),
+        "CORS must still apply on the combo route"
+    );
+});
+
+integration_test!(t48_combo_authed_malformed_body_still_waf_blocked, {
+    // Authed, but a malformed JSON body: auth passes, WAF must still block —
+    // proving the middlewares stack rather than one bypassing the other.
+    let auth = format!("Authorization: Bearer {E2E_JWT}");
+    let (status, _, _) = curl(&[
+        "-X",
+        "POST",
+        "-H",
+        "Host: bench.local",
+        "-H",
+        &auth,
+        "-H",
+        "Content-Type: application/json",
+        "-d",
+        "{ this is not valid json",
+        "https://127.0.0.1:4433/combo/x",
+    ]);
+    assert!(
+        status == 400 || status == 403,
+        "WAF must block a malformed body even on an authed request, got {status}"
+    );
 });

--- a/tests/zion-test.toml
+++ b/tests/zion-test.toml
@@ -71,6 +71,42 @@ path = "/"
 upstream = "backend"
 mode = "standard"
 
+# ── e2e rule-matrix (comprehensive coverage — auth/cors/combos) ──────────────
+# These prove features work end-to-end AND compose. Host-based routing is
+# covered separately by the equivalence harness (tests/equivalence/multi-vhost).
+
+# CORS per-route: zion injects Access-Control-* / answers the preflight; the
+# backend 200s any path.
+[[route]]
+path = "/cors/{*rest}"
+upstream = "backend"
+mode = "standard"
+cors = { allowed_origins = ["https://trusted.example"], allowed_headers = ["X-Custom"], max_age = 600 }
+
+# Auth (JWT HS256) — ENFORCED only when zion is built with `--features auth`
+# (the integration workflow builds with it). The lean default build parses this
+# but warns "auth feature off" and does NOT gate.
+[auth_profile.e2e]
+secret = "e2e-jwt-secret-at-least-32-bytes-long!"
+algorithm = "HS256"
+
+[[route]]
+path = "/auth/{*rest}"
+upstream = "backend"
+mode = "standard"
+auth_profile = "e2e"
+
+# Kitchen-sink combo: WAF + auth + CORS stacked on ONE route. Proves the
+# middlewares compose — auth gates an unauthenticated request; a valid token +
+# clean GET passes with the CORS header; a malformed JSON body is WAF-blocked.
+[[route]]
+path = "/combo/{*rest}"
+upstream = "backend"
+mode = "standard"
+waf = true
+auth_profile = "e2e"
+cors = { allowed_origins = ["https://trusted.example"] }
+
 # Catch-all (HTML/SSR)
 [[route]]
 path = "/{*rest}"


### PR DESCRIPTION
## Why

The integration suite covered the **core** well — proxy pass, WAF, cache, SSE, streaming, forwarding headers, redirect — but the honest answer to *"does Zion really work in every configured case?"* exposed blind spots:

- **no auth coverage** (JWT gate never exercised end-to-end),
- **no CORS coverage** (per-route `Access-Control-*` never asserted),
- **zero tests of rules _composing_** on a single route.

That last gap is the important one: nothing proved that stacking WAF + auth + CORS on one route makes *all three* fire, rather than one silently bypassing another.

## What

Three kinds of coverage, all **proven live** against a real `zion` + backend (9 passed / 0 failed), added as `t40`–`t48` in [tests/integration.rs](tests/integration.rs):

| Area | Tests | Asserts |
|------|-------|---------|
| **Auth** (JWT/HS256) | t40–t42 | missing token → `401`, invalid → `401/403`, valid signed JWT → reaches backend `200` |
| **CORS** (per-route) | t43–t45 | preflight answered with `Access-Control-Allow-Origin`; allowed `Origin` reflected; disallowed `Origin` **never** reflected |
| **Rule composition** | t46–t48 | one `/combo/*` route stacking `waf + auth + cors`: unauthenticated → `401`; authed + clean → `200` **with** the CORS header; authed + **malformed body → still WAF-blocked** (`400/403`) |

t48 is the point of the PR: auth passing does **not** let a bad body slip past the WAF — the middlewares stack.

### Config & workflow

- New routes in [tests/zion-test.toml](tests/zion-test.toml): `/cors/*`, `[auth_profile.e2e]` + `/auth/*`, and the kitchen-sink `/combo/*`. Host-based routing is covered separately by the equivalence harness, so it's intentionally out of scope here.
- The JWT's `exp` is year 2100, so the fixture never ages out.
- [.github/workflows/integration.yml](.github/workflows/integration.yml) now builds `--features auth` so the gate is actually **enforced** (the lean default build parses the profile but warns it off). This job runs on **stable** Rust — unrelated to the 1.82 MSRV core job.

## Safety

All new tests are `#[ignore]`d like the rest of the suite, so `cargo test` still runs only unit tests. Full unit suite green via pre-commit; new e2e tests verified live; existing integration tests unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)