### PR TITLE
feat(static): conditional GET (ETag + Last-Modified → 304) for mode=static

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Client -> TLS 1.3 -> Security Gates -> Radix Router -> WAF Pipeline (5 gates) ->
 ```
 
 <!-- zion-stats:modules-lines (kept in sync by scripts/update-readme-stats.sh) -->
-47 modules, ~40,800 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
+48 modules, ~41,200 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
 
 ## Features
 
@@ -286,7 +286,7 @@ MODE=full bash benchmarks/baseline/run-baseline.sh   # → benchmarks/baseline/z
 ## Testing
 
 <!-- zion-stats:test-count (kept in sync by scripts/update-readme-stats.sh) -->
-**855 unit tests** run on every change; **23 integration tests** need a running Zion + a backend.
+**870 unit tests** run on every change; **23 integration tests** need a running Zion + a backend.
 
 ```bash
 cargo test                          # unit tests

--- a/docs/adr/0019-static-conditional-get.md
+++ b/docs/adr/0019-static-conditional-get.md
@@ -1,0 +1,99 @@
+# ADR-0019: Static file conditional GET (ETag / Last-Modified → 304)
+
+- **Status**: accepted
+- **Date**: 2026-08-02
+- **Deciders**: fabriziosalmi
+- **Tags**: static, caching, rfc-9110, standards
+
+## Context
+
+ADR-0015 shipped `mode = "static"` and explicitly deferred conditional GET
+(ETag / `If-Modified-Since`) as a follow-up: v1 served every request with the
+full body and no validators. That is a real regression for anyone migrating off
+nginx, which revalidates static assets out of the box — a browser that already
+has a file re-downloads it on every navigation instead of getting a cheap
+`304 Not Modified`. This ADR closes that gap. It is the first of the ADR-0015
+runtime follow-ups (range requests and streaming remain deferred).
+
+The cache path already had the RFC 9110 §13 conditional-request logic (ADR-0018,
+`dispatch::client_conditional_hit`) — but sourced from a cached representation's
+stored validators. The static path needs the same decision with validators
+derived from filesystem metadata instead.
+
+## Decision
+
+### Validators are derived from `(len, mtime)`, and the ETag is weak
+
+On a static GET/HEAD, zion derives:
+
+- `ETag: W/"{len:x}-{secs:x}.{nanos:x}"` — a **weak** validator. `len`+`mtime` is
+  a cheap change fingerprint, not a byte-for-byte content hash, so RFC 9110
+  §8.8.1 forbids treating it as strong. Weak is the honest label, and it is why
+  the future `If-Range` byte-range optimization cannot reuse this tag (a
+  deliberate constraint on the range follow-up, not an oversight).
+- `Last-Modified:` the file mtime formatted as an RFC 9110 §5.6.7 `IMF-fixdate`.
+
+Either validator is omitted (not fabricated) when the platform cannot supply an
+mtime; the file still serves, just without revalidation.
+
+### The 304 decision is shared, not duplicated
+
+The `If-None-Match` (weak comparison, `*`, comma list) / `If-Modified-Since`
+(exact echo) logic is factored into `http_conditional::is_not_modified`, which
+takes the validators as plain `Option<&HeaderValue>`. Both callers use it:
+
+- the cache path — `client_conditional_hit` became a thin adapter, its behavior
+  pinned by the existing 10-assertion test;
+- the static path — passing validators built from file metadata.
+
+One decision function means the 304 semantics can never drift between the cache
+and the file server. A matching validator returns a bodiless 304 for **both**
+GET and HEAD (RFC 9110 §15.4.5); a stale or absent validator serves 200 as
+before.
+
+### The HTTP-date formatter is dependency-free
+
+`Last-Modified` needs to *format* an mtime, which the codebase could not do —
+the cache path only ever echoed the origin's date string. Rather than pull a
+date crate into the core graph (the `time` crate is an optional feature, and
+`mode=static` lives in the lean default build — adding a mandatory date
+dependency would drag the ADR-0007 MSRV wall), `fmt_imf_fixdate` implements
+Howard Hinnant's `civil_from_days` algorithm in ~25 lines, unit-tested against
+canonical vectors (`Sun, 06 Nov 1994 08:49:37 GMT`, the epoch, a leap day, a
+year-end rollover).
+
+## Consequences
+
+- **Positive**: static-asset revalidation reaches parity with nginx/Caddy, so a
+  swap does not regress browser caching. Bandwidth and latency drop for the
+  common "unchanged asset" case. No new dependency; core MSRV untouched.
+- **Positive**: the shared `is_not_modified` removes a copy of the conditional
+  logic that would otherwise drift from the cache path.
+- **Neutral / risks**: the weak ETag means a same-second, same-size overwrite is
+  not distinguished — acceptable for a weak validator, and the mtime nanos
+  component narrows the window further on filesystems that report them. Full
+  `If-Modified-Since` HTTP-date *range* comparison (vs the current exact echo)
+  and `If-Range` remain follow-ups.
+
+## Alternatives considered
+
+- **Strong ETag (nginx-style `"{mtime}-{len}"`)** — rejected: without a content
+  hash it is not truly strong, and mislabeling it would invite an incorrect
+  `If-Range` byte-range reuse later. Weak states exactly what we can guarantee.
+- **Add the `time` (or `httpdate`) crate** — rejected: a mandatory date
+  dependency in the default build for ~25 lines of well-known calendar math, at
+  the cost of the core MSRV posture (ADR-0007).
+- **Duplicate the conditional logic in `static_files`** — rejected: two copies of
+  a standards-sensitive decision drift. One shared function, two validator
+  sources.
+
+## References
+
+- ADR-0015 (`mode = "static"`, which deferred this), ADR-0018 (the cache-path
+  conditional logic this shares), ADR-0007 (the MSRV wall the no-dep formatter
+  respects)
+- RFC 9110 §8.8 (validators), §13 (conditional requests), §15.4.5 (304),
+  §5.6.7 (`IMF-fixdate`)
+- `src/http_conditional.rs` (`is_not_modified`, `fmt_imf_fixdate`),
+  `src/static_files.rs` (`validators`, `read_file`), `src/dispatch.rs`
+  (`client_conditional_hit` adapter)

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -29,6 +29,7 @@ defined in [0000-template.md](0000-template.md).
 | 0016  | [nginx `root`/`try_files`/`index` → `mode = "static"`](0016-importer-nginx-static-mapping.md) | accepted |
 | 0017  | [Audit-log rotation with per-segment chain re-anchoring](0017-audit-log-rotation.md) | accepted |
 | 0018  | [Cache origin-side revalidation (RFC 9111 §4.3)](0018-cache-origin-revalidation.md) | accepted |
+| 0019  | [Static file conditional GET (ETag / Last-Modified → 304)](0019-static-conditional-get.md) | accepted |
 
 ## When to write a new ADR
 

--- a/docs/config/routing.md
+++ b/docs/config/routing.md
@@ -92,6 +92,7 @@ Host routing is **opt-in and zero-cost when unused**: with no `hosts` anywhere, 
 | `standard` | Standard reverse proxy with connection pooling |
 | `sse_stream` | Adds `Cache-Control: no-cache` and `X-Accel-Buffering: no` to response |
 | `static_cache` | Serves from in-memory cache on hit; fetches and caches on miss |
+| `static` | Serves files from disk under `serve_dir` (no upstream) behind a hardened path-safety core; GET/HEAD only. Emits a weak `ETag` + `Last-Modified` and answers `If-None-Match` / `If-Modified-Since` with **304 Not Modified**. `spa_fallback = true` serves `index.html` for an unmatched path. See [ADR-0015](/adr/0015-route-mode-static) / [ADR-0019](/adr/0019-static-conditional-get). |
 | `websocket` | Explicit WebSocket mode (also auto-detected via `Upgrade: websocket` header on any route) |
 
 ## Upstream resolution

--- a/docs/guide/migrate.md
+++ b/docs/guide/migrate.md
@@ -147,6 +147,13 @@ upstream = "backend"
 request URI while Zion strips the route prefix, so the two cancel out to the same
 on-disk path.
 
+Served files carry a weak `ETag` and a `Last-Modified` derived from the file's
+size and mtime, and a revalidating client (`If-None-Match` / `If-Modified-Since`)
+gets a bodiless **304 Not Modified** when the file is unchanged — the same
+browser-caching behavior nginx gives you out of the box, so a cut-over doesn't
+regress asset revalidation. (Range requests and streaming of very large files are
+tracked follow-ups; today a file is served whole, capped at 64 MiB.)
+
 ## Verify before you cut over
 
 Treat the import as a proposal, not a fait accompli:

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -1206,7 +1206,14 @@ async fn process_request_inner(
                         .strip_prefix(rule.static_prefix.as_str())
                         .unwrap_or(path)
                         .trim_start_matches('/');
-                    crate::static_files::serve(dir, tail, rule.spa_fallback, req.method()).await
+                    crate::static_files::serve(
+                        dir,
+                        tail,
+                        rule.spa_fallback,
+                        req.method(),
+                        req.headers(),
+                    )
+                    .await
                 }
                 // Unreachable (resolve_route requires serve_dir) — fail CLOSED
                 // rather than serve the process CWD if a future refactor slips.
@@ -1576,41 +1583,17 @@ fn cache_only_if_cached_miss() -> Response<ZionBody> {
         .unwrap()
 }
 
-/// Strip a weak-ETag `W/` prefix for the weak comparison `If-None-Match` uses
-/// (RFC 9110 §8.8.3.2).
-fn strip_weak(etag: &str) -> &str {
-    etag.strip_prefix("W/").unwrap_or(etag)
-}
-
 /// Does a client conditional request match this cached entry — i.e. can we
-/// answer 304 Not Modified? RFC 9110 §13.1: `If-None-Match` takes precedence
-/// (weak comparison; `*` matches any stored entry); otherwise `If-Modified-Since`
-/// is honored as an exact echo of the stored `Last-Modified` (the dominant
-/// browser revalidation pattern — full HTTP-date comparison is a follow-up).
+/// answer 304 Not Modified? Thin adapter over the shared
+/// [`crate::http_conditional::is_not_modified`] decision (RFC 9110 §13.1),
+/// sourcing the validators from the cached representation's metadata so the 304
+/// semantics stay identical to the static file server's.
 fn client_conditional_hit(req_headers: &hyper::HeaderMap, meta: &cache::CachedMeta) -> bool {
-    if let Some(inm) = req_headers
-        .get(hyper::header::IF_NONE_MATCH)
-        .and_then(|v| v.to_str().ok())
-    {
-        let inm = inm.trim();
-        if inm == "*" {
-            return true;
-        }
-        let stored = match meta.etag.as_ref().and_then(|e| e.to_str().ok()) {
-            Some(e) => strip_weak(e.trim()),
-            None => return false,
-        };
-        return inm.split(',').any(|t| strip_weak(t.trim()) == stored);
-    }
-    if let (Some(ims), Some(lm)) = (
-        req_headers
-            .get(hyper::header::IF_MODIFIED_SINCE)
-            .and_then(|v| v.to_str().ok()),
-        meta.last_modified.as_ref().and_then(|v| v.to_str().ok()),
-    ) {
-        return ims.trim() == lm.trim();
-    }
-    false
+    crate::http_conditional::is_not_modified(
+        req_headers,
+        meta.etag.as_ref(),
+        meta.last_modified.as_ref(),
+    )
 }
 
 /// 304 Not Modified from a cache hit — preserved validators + freshness, no body

--- a/src/http_conditional.rs
+++ b/src/http_conditional.rs
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Shared HTTP conditional-request helpers (RFC 9110 §13): weak-ETag comparison,
+//! the `If-None-Match` / `If-Modified-Since` → 304 decision, and RFC 9110 §5.6.7
+//! `IMF-fixdate` formatting.
+//!
+//! Two callers with different validator *sources* share one comparison:
+//!  - the cache revalidation path (dispatch) echoes the origin's `ETag` /
+//!    `Last-Modified`;
+//!  - the static file server derives them from filesystem metadata.
+//!
+//! Keeping the decision in one place means the 304 semantics can never drift
+//! between the two.
+
+use hyper::header::{HeaderMap, HeaderValue, IF_MODIFIED_SINCE, IF_NONE_MATCH};
+
+/// Strip a weak-ETag `W/` prefix for the weak comparison `If-None-Match` uses
+/// (RFC 9110 §8.8.3.2).
+pub fn strip_weak(etag: &str) -> &str {
+    etag.strip_prefix("W/").unwrap_or(etag)
+}
+
+/// Can this conditional request be answered `304 Not Modified`? RFC 9110 §13.1:
+/// `If-None-Match` takes precedence (weak comparison; `*` matches any current
+/// representation); otherwise `If-Modified-Since` is honored as an exact echo of
+/// the current `Last-Modified` (the dominant browser revalidation pattern — full
+/// HTTP-date range comparison is a deliberate follow-up).
+pub fn is_not_modified(
+    req_headers: &HeaderMap,
+    etag: Option<&HeaderValue>,
+    last_modified: Option<&HeaderValue>,
+) -> bool {
+    if let Some(inm) = req_headers.get(IF_NONE_MATCH).and_then(|v| v.to_str().ok()) {
+        let inm = inm.trim();
+        if inm == "*" {
+            return true;
+        }
+        let stored = match etag.and_then(|e| e.to_str().ok()) {
+            Some(e) => strip_weak(e.trim()),
+            None => return false,
+        };
+        return inm.split(',').any(|t| strip_weak(t.trim()) == stored);
+    }
+    if let (Some(ims), Some(lm)) = (
+        req_headers
+            .get(IF_MODIFIED_SINCE)
+            .and_then(|v| v.to_str().ok()),
+        last_modified.and_then(|v| v.to_str().ok()),
+    ) {
+        return ims.trim() == lm.trim();
+    }
+    false
+}
+
+/// Format a UNIX timestamp (seconds since the epoch, UTC) as an RFC 9110 §5.6.7
+/// `IMF-fixdate` — e.g. `Sun, 06 Nov 1994 08:49:37 GMT`.
+///
+/// Dependency-free on purpose: the `time` crate is an optional feature and
+/// `mode=static` lives in the lean default build, so this uses Howard Hinnant's
+/// `civil_from_days` algorithm rather than pulling a date crate into core.
+pub fn fmt_imf_fixdate(unix_secs: u64) -> String {
+    let days = (unix_secs / 86_400) as i64;
+    let sod = unix_secs % 86_400;
+    let (hh, mm, ss) = (sod / 3600, (sod % 3600) / 60, sod % 60);
+
+    // Epoch day 0 (1970-01-01) was a Thursday; index the table from there.
+    const WKD: [&str; 7] = ["Thu", "Fri", "Sat", "Sun", "Mon", "Tue", "Wed"];
+    let wkd = WKD[days.rem_euclid(7) as usize];
+
+    // civil_from_days: days since 1970-01-01 → (year, month, day). See
+    // https://howardhinnant.github.io/date_algorithms.html
+    let z = days + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = z - era * 146_097; // day-of-era  [0, 146096]
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365; // [0, 399]
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100); // day-of-year [0, 365]
+    let mp = (5 * doy + 2) / 153; // month, shifted so March = 0  [0, 11]
+    let d = doy - (153 * mp + 2) / 5 + 1; // day-of-month [1, 31]
+    let m = if mp < 10 { mp + 3 } else { mp - 9 }; // real month [1, 12]
+    let y = yoe + era * 400 + if m <= 2 { 1 } else { 0 };
+
+    const MON: [&str; 12] = [
+        "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+    ];
+    format!(
+        "{wkd}, {d:02} {mon} {y:04} {hh:02}:{mm:02}:{ss:02} GMT",
+        mon = MON[(m - 1) as usize],
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hv(s: &str) -> HeaderValue {
+        HeaderValue::from_str(s).unwrap()
+    }
+    fn headers(pairs: &[(hyper::header::HeaderName, &str)]) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        for (k, v) in pairs {
+            h.insert(k.clone(), hv(v));
+        }
+        h
+    }
+
+    // ── fmt_imf_fixdate ──────────────────────────────────────────────────────
+
+    #[test]
+    fn imf_fixdate_canonical_vectors() {
+        // The classic RFC example.
+        assert_eq!(
+            fmt_imf_fixdate(784_111_777),
+            "Sun, 06 Nov 1994 08:49:37 GMT"
+        );
+        // The epoch itself (a Thursday).
+        assert_eq!(fmt_imf_fixdate(0), "Thu, 01 Jan 1970 00:00:00 GMT");
+        // A leap-day (2000-02-29 was a Tuesday) — exercises the century rule.
+        assert_eq!(
+            fmt_imf_fixdate(951_782_400),
+            "Tue, 29 Feb 2000 00:00:00 GMT"
+        );
+        // End-of-year rollover, zero-padded day.
+        assert_eq!(
+            fmt_imf_fixdate(978_307_199),
+            "Sun, 31 Dec 2000 23:59:59 GMT"
+        );
+    }
+
+    #[test]
+    fn imf_fixdate_is_stable_and_round_trippable_as_a_header() {
+        // Whatever it emits must be a valid header value (no panics downstream).
+        let s = fmt_imf_fixdate(1_700_000_000);
+        assert!(HeaderValue::from_str(&s).is_ok());
+        assert!(s.ends_with(" GMT"));
+    }
+
+    // ── is_not_modified ──────────────────────────────────────────────────────
+
+    #[test]
+    fn inm_exact_and_weak_match_is_304() {
+        let et = hv("W/\"abc\"");
+        let h = headers(&[(IF_NONE_MATCH, "W/\"abc\"")]);
+        assert!(is_not_modified(&h, Some(&et), None));
+        // Weak/strong prefixes are compared weakly: a strong INM still matches a
+        // weak stored tag on the same opaque value.
+        let h2 = headers(&[(IF_NONE_MATCH, "\"abc\"")]);
+        assert!(is_not_modified(&h2, Some(&et), None));
+    }
+
+    #[test]
+    fn inm_mismatch_is_not_304() {
+        let et = hv("W/\"abc\"");
+        let h = headers(&[(IF_NONE_MATCH, "W/\"xyz\"")]);
+        assert!(!is_not_modified(&h, Some(&et), None));
+    }
+
+    #[test]
+    fn inm_star_matches_any_representation() {
+        let et = hv("W/\"whatever\"");
+        let h = headers(&[(IF_NONE_MATCH, "*")]);
+        assert!(is_not_modified(&h, Some(&et), None));
+        // `*` matches even when we somehow have no stored ETag.
+        assert!(is_not_modified(&h, None, None));
+    }
+
+    #[test]
+    fn inm_list_matches_any_member() {
+        let et = hv("W/\"abc\"");
+        let h = headers(&[(IF_NONE_MATCH, "\"p\", W/\"abc\" , \"q\"")]);
+        assert!(is_not_modified(&h, Some(&et), None));
+    }
+
+    #[test]
+    fn inm_without_stored_etag_is_not_304() {
+        let h = headers(&[(IF_NONE_MATCH, "\"abc\"")]);
+        assert!(!is_not_modified(&h, None, None));
+    }
+
+    #[test]
+    fn ims_exact_echo_is_304_and_ims_takes_a_back_seat_to_inm() {
+        let lm = hv("Sun, 06 Nov 1994 08:49:37 GMT");
+        let h = headers(&[(IF_MODIFIED_SINCE, "Sun, 06 Nov 1994 08:49:37 GMT")]);
+        assert!(is_not_modified(&h, None, Some(&lm)));
+        // A non-echo IMS does not (yet) 304 — full date comparison is a follow-up.
+        let h2 = headers(&[(IF_MODIFIED_SINCE, "Mon, 07 Nov 1994 00:00:00 GMT")]);
+        assert!(!is_not_modified(&h2, None, Some(&lm)));
+
+        // When both are present, INM wins: a matching INM 304s regardless of IMS,
+        // and a mismatching INM blocks the 304 even if IMS would have echoed.
+        let et = hv("W/\"abc\"");
+        let both_inm_hit = headers(&[
+            (IF_NONE_MATCH, "W/\"abc\""),
+            (IF_MODIFIED_SINCE, "Mon, 07 Nov 1994 00:00:00 GMT"),
+        ]);
+        assert!(is_not_modified(&both_inm_hit, Some(&et), Some(&lm)));
+        let both_inm_miss = headers(&[
+            (IF_NONE_MATCH, "W/\"nope\""),
+            (IF_MODIFIED_SINCE, "Sun, 06 Nov 1994 08:49:37 GMT"),
+        ]);
+        assert!(!is_not_modified(&both_inm_miss, Some(&et), Some(&lm)));
+    }
+
+    #[test]
+    fn no_conditional_headers_is_not_304() {
+        assert!(!is_not_modified(
+            &HeaderMap::new(),
+            Some(&hv("W/\"a\"")),
+            None
+        ));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,6 +53,7 @@ mod connlimit;
 mod doctor;
 mod error;
 mod health;
+mod http_conditional;
 mod import;
 mod init;
 mod listener;

--- a/src/static_files.rs
+++ b/src/static_files.rs
@@ -16,7 +16,8 @@ use std::path::{Path, PathBuf};
 
 use bytes::Bytes;
 use http_body_util::{BodyExt, Full};
-use hyper::{Method, Response, StatusCode};
+use hyper::header::HeaderValue;
+use hyper::{HeaderMap, Method, Response, StatusCode};
 
 use crate::proxy::ZionBody;
 
@@ -106,6 +107,7 @@ pub async fn serve(
     tail: &str,
     spa_fallback: bool,
     method: &Method,
+    req_headers: &HeaderMap,
 ) -> Response<ZionBody> {
     if method != Method::GET && method != Method::HEAD {
         return resp(StatusCode::METHOD_NOT_ALLOWED);
@@ -120,11 +122,11 @@ pub async fn serve(
     };
 
     if let Some(path) = resolve_file(&canon_root, &rel).await {
-        return read_file(&path, method).await;
+        return read_file(&path, method, req_headers).await;
     }
     if spa_fallback {
         if let Some(index) = resolve_file(&canon_root, Path::new("index.html")).await {
-            return read_file(&index, method).await;
+            return read_file(&index, method, req_headers).await;
         }
     }
     resp(StatusCode::NOT_FOUND)
@@ -155,40 +157,111 @@ async fn resolve_file(canon_root: &Path, rel: &Path) -> Option<PathBuf> {
     }
 }
 
-async fn read_file(path: &Path, method: &Method) -> Response<ZionBody> {
+async fn read_file(path: &Path, method: &Method, req_headers: &HeaderMap) -> Response<ZionBody> {
+    let meta = match tokio::fs::metadata(path).await {
+        Ok(m) => m,
+        Err(_) => return resp(StatusCode::NOT_FOUND),
+    };
+    let (etag, last_modified) = validators(&meta);
+
+    // Conditional request: a fresh validator answers 304 (no body) for GET *and*
+    // HEAD (RFC 9110 §15.4.5). This is the whole point of the feature — a
+    // revalidating client gets bytes back only when the file actually changed.
+    if crate::http_conditional::is_not_modified(req_headers, etag.as_ref(), last_modified.as_ref())
+    {
+        return not_modified(etag, last_modified);
+    }
+
     // HEAD needs only the length — never read the bytes into memory (a HEAD to a
     // huge file would otherwise be a cheap memory-amplification DoS).
     if method == Method::HEAD {
-        let len = match tokio::fs::metadata(path).await {
-            Ok(m) => m.len(),
-            Err(_) => return resp(StatusCode::NOT_FOUND),
-        };
-        return Response::builder()
-            .status(StatusCode::OK)
-            .header(hyper::header::CONTENT_TYPE, mime_for(path))
-            .header(hyper::header::CONTENT_LENGTH, len)
-            .body(Full::new(Bytes::new()).map_err(|n| match n {}).boxed())
-            .unwrap();
+        return file_response(
+            mime_for(path),
+            meta.len(),
+            etag,
+            last_modified,
+            Bytes::new(),
+        );
     }
+
     // Cap the whole-file in-memory read (streaming is a deferred follow-up,
     // ADR-0015): refuse an oversized file rather than buffering it whole, which
     // would be a memory-amplification DoS under concurrency.
     const MAX_FILE_BYTES: u64 = 64 * 1024 * 1024;
-    match tokio::fs::metadata(path).await {
-        Ok(m) if m.len() > MAX_FILE_BYTES => return resp(StatusCode::PAYLOAD_TOO_LARGE),
-        Ok(_) => {}
-        Err(_) => return resp(StatusCode::NOT_FOUND),
+    if meta.len() > MAX_FILE_BYTES {
+        return resp(StatusCode::PAYLOAD_TOO_LARGE);
     }
     let data = match tokio::fs::read(path).await {
         Ok(d) => d,
         Err(_) => return resp(StatusCode::NOT_FOUND),
     };
-    let len = data.len();
-    Response::builder()
+    let len = data.len() as u64;
+    file_response(mime_for(path), len, etag, last_modified, Bytes::from(data))
+}
+
+/// Derive the `(ETag, Last-Modified)` validators from file metadata. The ETag is
+/// *weak* (`W/"len-secs.nanos"`): `len`+`mtime` is a cheap change fingerprint,
+/// not a byte-for-byte content hash, so it must never be used for a strong
+/// comparison (RFC 9110 §8.8.1) — which is exactly why `If-Range` byte-range
+/// reuse is deferred to the range follow-up. Either validator is `None` when the
+/// platform can't supply an mtime; the file still serves, just without
+/// revalidation.
+fn validators(meta: &std::fs::Metadata) -> (Option<HeaderValue>, Option<HeaderValue>) {
+    let dur = meta
+        .modified()
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok());
+    let etag = dur.and_then(|d| {
+        HeaderValue::from_str(&format!(
+            "W/\"{:x}-{:x}.{:x}\"",
+            meta.len(),
+            d.as_secs(),
+            d.subsec_nanos()
+        ))
+        .ok()
+    });
+    let last_modified = dur.and_then(|d| {
+        HeaderValue::from_str(&crate::http_conditional::fmt_imf_fixdate(d.as_secs())).ok()
+    });
+    (etag, last_modified)
+}
+
+/// A `304 Not Modified` — validators preserved, no body (RFC 9110 §15.4.5).
+fn not_modified(
+    etag: Option<HeaderValue>,
+    last_modified: Option<HeaderValue>,
+) -> Response<ZionBody> {
+    let mut b = Response::builder().status(StatusCode::NOT_MODIFIED);
+    if let Some(e) = etag {
+        b = b.header(hyper::header::ETAG, e);
+    }
+    if let Some(lm) = last_modified {
+        b = b.header(hyper::header::LAST_MODIFIED, lm);
+    }
+    b.body(Full::new(Bytes::new()).map_err(|n| match n {}).boxed())
+        .unwrap()
+}
+
+/// A `200 OK` file response (or its HEAD twin, with an empty `body`): content
+/// headers plus the revalidation validators the client echoes back next time.
+fn file_response(
+    mime: &'static str,
+    content_length: u64,
+    etag: Option<HeaderValue>,
+    last_modified: Option<HeaderValue>,
+    body: Bytes,
+) -> Response<ZionBody> {
+    let mut b = Response::builder()
         .status(StatusCode::OK)
-        .header(hyper::header::CONTENT_TYPE, mime_for(path))
-        .header(hyper::header::CONTENT_LENGTH, len)
-        .body(Full::new(Bytes::from(data)).map_err(|n| match n {}).boxed())
+        .header(hyper::header::CONTENT_TYPE, mime)
+        .header(hyper::header::CONTENT_LENGTH, content_length);
+    if let Some(e) = etag {
+        b = b.header(hyper::header::ETAG, e);
+    }
+    if let Some(lm) = last_modified {
+        b = b.header(hyper::header::LAST_MODIFIED, lm);
+    }
+    b.body(Full::new(body).map_err(|n| match n {}).boxed())
         .unwrap()
 }
 
@@ -322,10 +395,22 @@ mod serve_tests {
     }
 
     async fn get(root: &Path, tail: &str, spa: bool) -> (StatusCode, String) {
-        let r = serve(root, tail, spa, &Method::GET).await;
+        let r = serve(root, tail, spa, &Method::GET, &HeaderMap::new()).await;
         let status = r.status();
         let body = r.into_body().collect().await.unwrap().to_bytes();
         (status, String::from_utf8_lossy(&body).into_owned())
+    }
+
+    /// GET with a set of request headers; returns the full response so tests can
+    /// inspect status + response headers (validators, 304, …).
+    async fn get_h(root: &Path, tail: &str, req: HeaderMap) -> Response<ZionBody> {
+        serve(root, tail, false, &Method::GET, &req).await
+    }
+
+    fn one(k: hyper::header::HeaderName, v: &str) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        h.insert(k, HeaderValue::from_str(v).unwrap());
+        h
     }
 
     #[tokio::test]
@@ -379,7 +464,14 @@ mod serve_tests {
     async fn head_returns_length_without_reading_the_body() {
         // F2: HEAD must report Content-Length without buffering the file.
         let root = root("head");
-        let r = serve(&root.0, "css/main.css", false, &Method::HEAD).await;
+        let r = serve(
+            &root.0,
+            "css/main.css",
+            false,
+            &Method::HEAD,
+            &HeaderMap::new(),
+        )
+        .await;
         assert_eq!(r.status(), StatusCode::OK);
         assert_eq!(
             r.headers().get(hyper::header::CONTENT_LENGTH).unwrap(),
@@ -387,5 +479,116 @@ mod serve_tests {
         );
         let body = r.into_body().collect().await.unwrap().to_bytes();
         assert!(body.is_empty());
+    }
+
+    // ── Conditional GET (ETag / Last-Modified → 304) ──────────────────────────
+
+    #[tokio::test]
+    async fn a_200_carries_both_validators() {
+        let root = root("cond-200");
+        let r = get_h(&root.0, "css/main.css", HeaderMap::new()).await;
+        assert_eq!(r.status(), StatusCode::OK);
+        let et = r.headers().get(hyper::header::ETAG).expect("ETag present");
+        assert!(
+            et.to_str().unwrap().starts_with("W/\""),
+            "ETag should be weak, got {et:?}"
+        );
+        assert!(
+            r.headers().get(hyper::header::LAST_MODIFIED).is_some(),
+            "Last-Modified present"
+        );
+    }
+
+    #[tokio::test]
+    async fn matching_if_none_match_is_304_with_no_body() {
+        let root = root("cond-inm");
+        // First fetch to learn the ETag the server minted for this file.
+        let first = get_h(&root.0, "css/main.css", HeaderMap::new()).await;
+        let etag = first
+            .headers()
+            .get(hyper::header::ETAG)
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_owned();
+        // Re-request with it: must be a bodiless 304 that still echoes the ETag.
+        let second = get_h(
+            &root.0,
+            "css/main.css",
+            one(hyper::header::IF_NONE_MATCH, &etag),
+        )
+        .await;
+        assert_eq!(second.status(), StatusCode::NOT_MODIFIED);
+        assert_eq!(
+            second.headers().get(hyper::header::ETAG).unwrap(),
+            etag.as_str()
+        );
+        let body = second.into_body().collect().await.unwrap().to_bytes();
+        assert!(body.is_empty(), "304 must carry no body");
+    }
+
+    #[tokio::test]
+    async fn matching_if_modified_since_is_304() {
+        let root = root("cond-ims");
+        let first = get_h(&root.0, "css/main.css", HeaderMap::new()).await;
+        let lm = first
+            .headers()
+            .get(hyper::header::LAST_MODIFIED)
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_owned();
+        let second = get_h(
+            &root.0,
+            "css/main.css",
+            one(hyper::header::IF_MODIFIED_SINCE, &lm),
+        )
+        .await;
+        assert_eq!(second.status(), StatusCode::NOT_MODIFIED);
+    }
+
+    #[tokio::test]
+    async fn stale_if_none_match_still_serves_200() {
+        let root = root("cond-stale");
+        let r = get_h(
+            &root.0,
+            "css/main.css",
+            one(hyper::header::IF_NONE_MATCH, "W/\"deadbeef-0.0\""),
+        )
+        .await;
+        assert_eq!(r.status(), StatusCode::OK);
+        let body = r.into_body().collect().await.unwrap().to_bytes();
+        assert_eq!(&body[..], b"body{}");
+    }
+
+    #[tokio::test]
+    async fn if_none_match_star_is_304() {
+        let root = root("cond-star");
+        let r = get_h(
+            &root.0,
+            "css/main.css",
+            one(hyper::header::IF_NONE_MATCH, "*"),
+        )
+        .await;
+        assert_eq!(r.status(), StatusCode::NOT_MODIFIED);
+    }
+
+    #[tokio::test]
+    async fn conditional_head_also_304s() {
+        // A HEAD that carries a matching validator must 304 too, not 200.
+        let root = root("cond-head");
+        let first = serve(
+            &root.0,
+            "css/main.css",
+            false,
+            &Method::HEAD,
+            &HeaderMap::new(),
+        )
+        .await;
+        let etag = first.headers().get(hyper::header::ETAG).unwrap().clone();
+        let mut h = HeaderMap::new();
+        h.insert(hyper::header::IF_NONE_MATCH, etag);
+        let second = serve(&root.0, "css/main.css", false, &Method::HEAD, &h).await;
+        assert_eq!(second.status(), StatusCode::NOT_MODIFIED);
     }
 }


### PR DESCRIPTION
## Why

[ADR-0015](docs/adr/0015-route-mode-static.md) shipped `mode = "static"` but **deferred conditional GET**: every request returned the full body with no validators. A browser that already has an asset re-downloads it on every navigation — a real regression for anyone migrating off nginx, which revalidates static assets out of the box.

This closes that gap. It's the **first of the ADR-0015 runtime follow-ups**; range requests and streaming remain deferred (tracked separately).

## What

| Area | Change |
|------|--------|
| **`static_files`** | Derive a **weak** `ETag: W/"len-secs.nanos"` + `Last-Modified` from the file's size + mtime. A matching `If-None-Match` / `If-Modified-Since` returns a **bodiless 304** for GET *and* HEAD (RFC 9110 §15.4.5); validators are added to 200/HEAD. Weak because len+mtime is a change fingerprint, not a content hash (RFC 9110 §8.8.1). |
| **`http_conditional`** (new) | Shared 304 decision — `is_not_modified()` (INM weak compare with `*`/list, else IMS exact echo) + a **dependency-free** `fmt_imf_fixdate()` (Hinnant civil-from-days; the `time` crate is optional and `mode=static` is in the lean default build, so no date dep enters the core MSRV graph). |
| **`dispatch`** | `client_conditional_hit()` becomes a **thin adapter** over the shared helper — behavior pinned by its existing 10-assertion test — so the cache and static paths can never drift on 304 semantics. `serve()` now takes request headers; the `Static` arm passes `req.headers()`. |

## Proof

- **9** `http_conditional` unit tests: canonical `IMF-fixdate` vectors (`Sun, 06 Nov 1994 08:49:37 GMT`, the epoch, a leap day, year-end) + the full `is_not_modified` truth table.
- **6** new `static_files` serve tests: 200 carries both validators; matching INM/IMS → 304 no body; stale INM → 200; `*` → 304; conditional HEAD → 304.
- **LIVE** against a real TLS socket:
  - `GET /assets/hello.txt` → `200` + `etag: W/"a-6a6c94cc.23c0152a"` + `last-modified: Fri, 31 Jul 2026 12:27:56 GMT`
  - same ETag via `If-None-Match` → **304**, empty body · `If-Modified-Since` → **304** · stale INM → `200` · `*` → **304** · conditional HEAD → **304**
- `fmt` + `clippy --all-targets` clean on **default**, **--no-default-features** (MSRV core graph) and **--all-features**; full unit suite green.

## Docs

- New [ADR-0019](docs/adr/0019-static-conditional-get.md) (records the weak-ETag and no-date-dependency decisions) + index row.
- `routing.md` gains the previously-**missing** `static` route-mode row.
- `migrate.md` notes the nginx-parity asset revalidation.

No version bump (feature PR). All new tests are unit/serve tests in the default build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)