### PR TITLE
feat(static): stream large files, lifting the 64 MiB cap for mode=static

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Client -> TLS 1.3 -> Security Gates -> Radix Router -> WAF Pipeline (5 gates) ->
 ```
 
 <!-- zion-stats:modules-lines (kept in sync by scripts/update-readme-stats.sh) -->
-48 modules, ~41,700 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
+48 modules, ~41,800 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
 
 ## Features
 
@@ -286,7 +286,7 @@ MODE=full bash benchmarks/baseline/run-baseline.sh   # → benchmarks/baseline/z
 ## Testing
 
 <!-- zion-stats:test-count (kept in sync by scripts/update-readme-stats.sh) -->
-**880 unit tests** run on every change; **23 integration tests** need a running Zion + a backend.
+**882 unit tests** run on every change; **23 integration tests** need a running Zion + a backend.
 
 ```bash
 cargo test                          # unit tests

--- a/docs/adr/0021-static-file-streaming.md
+++ b/docs/adr/0021-static-file-streaming.md
@@ -1,0 +1,83 @@
+# ADR-0021: Streaming large static files (lift the 64 MiB read cap)
+
+- **Status**: accepted
+- **Date**: 2026-08-02
+- **Deciders**: fabriziosalmi
+- **Tags**: static, streaming, memory, performance
+
+## Context
+
+The third and last of the ADR-0015 runtime follow-ups (after ADR-0019
+conditional GET and ADR-0020 range requests). `mode = "static"` read the whole
+representation — a full file, or a range slice — into one `Bytes` before
+responding, guarded by a hard `MAX_FILE_BYTES = 64 MiB` cap: past it the server
+returned `413 Payload Too Large`. So a legitimate large asset (a video, an
+install image, a dataset) was simply un-servable, and a 60 MiB file still sat in
+memory whole under every concurrent request.
+
+## Decision
+
+### Buffer below the threshold, stream above it
+
+The 64 MiB constant is repurposed from a *hard limit* into a *buffer-vs-stream
+threshold*. At or below it, the body is read into one `Bytes` and served as a
+`Full` body — the low-latency common case (CSS, JS, images), byte-for-byte the
+prior behavior. Above it, the body is **streamed** frame-by-frame, so an
+arbitrarily large file is served with bounded memory instead of a 413. This
+keeps the small-file fast path untouched while the change is confined to what was
+previously the error path.
+
+### The stream is a read task feeding a bounded channel
+
+`stream_file(file, limit)` spawns a task that reads the file in `STREAM_CHUNK`
+(64 KiB) reads and sends each as a `Frame` over an mpsc channel of depth
+`STREAM_CHANNEL_CAP` (8); the response body drains the channel. In-flight memory
+is therefore bounded to ≈ `64 KiB × 9 ≈ 576 KiB` per request regardless of file
+size, and channel backpressure keeps the reader only slightly ahead of the
+socket. This reuses the exact `StreamBody` + `ReceiverStream` idiom already in
+the HTTP/3 bridge — no new dependency (`tokio-stream` is already direct).
+
+The same helper serves ranged reads: after `seek(start)` the range path streams
+`Some(len)` bytes, so a single range **larger** than the cap now streams too
+(the range PR ADR-0020 previously 413'd it).
+
+### `Content-Length` is preserved; a read fault truncates
+
+The size is known from `stat`, so streamed responses still send an exact
+`Content-Length` (not chunked-unknown) and emit precisely that many bytes. A
+mid-stream read error drops the channel sender, ending the body early — the same
+**truncate-on-error** contract the proxy path already has. The file was just
+`stat`ed and opened, so a fault here is a rare disk error rather than a routine
+branch; the client observes a short read (its own `Content-Length` check catches
+it), not a hang.
+
+## Consequences
+
+- **Positive**: large static assets are servable; memory per request is bounded
+  and constant instead of O(file size); the 413 wall is gone for full *and*
+  ranged reads. Small files keep the one-shot low-latency path.
+- **Neutral / risks**: streaming spawns a task + channel per large response —
+  negligible next to the I/O, and only on the large-file path. Truncate-on-error
+  means a disk fault yields a short 200/206 rather than an error status (the body
+  is already committed by the time bytes flow); this matches the proxy and is
+  caught by the client's `Content-Length`. A same-size-preserving mid-flight
+  overwrite could interleave old/new bytes (a pre-existing static-serving TOCTOU,
+  not introduced here).
+
+## Alternatives considered
+
+- **Always stream** — rejected: a task + channel on every tiny CSS/JS response is
+  needless overhead where a one-shot read wins on latency. The threshold gives
+  each regime its best path.
+- **`tokio_util::io::ReaderStream`** — rejected: `tokio-util` is not a direct
+  dependency, while `tokio-stream` (used by the H3 bridge) is. The channel form
+  reuses an idiom already in the tree and keeps the dependency set flat.
+- **Raise the cap instead of streaming** — rejected: it just moves the wall and
+  makes the per-request memory blow-up larger, the opposite of the goal.
+
+## References
+
+- ADR-0015 (`mode = "static"` and its 64 MiB cap), ADR-0020 (range reads that
+  now stream above the cap too)
+- `src/static_files.rs` (`stream_file`, `full_body`, `read_file`, `read_range`),
+  `src/quic.rs` (the `StreamBody` + `ReceiverStream` idiom reused)

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -31,6 +31,7 @@ defined in [0000-template.md](0000-template.md).
 | 0018  | [Cache origin-side revalidation (RFC 9111 §4.3)](0018-cache-origin-revalidation.md) | accepted |
 | 0019  | [Static file conditional GET (ETag / Last-Modified → 304)](0019-static-conditional-get.md) | accepted |
 | 0020  | [Static file range requests (206 Partial Content)](0020-static-range-requests.md) | accepted |
+| 0021  | [Streaming large static files (lift the 64 MiB read cap)](0021-static-file-streaming.md) | accepted |
 
 ## When to write a new ADR
 

--- a/docs/config/routing.md
+++ b/docs/config/routing.md
@@ -92,7 +92,7 @@ Host routing is **opt-in and zero-cost when unused**: with no `hosts` anywhere, 
 | `standard` | Standard reverse proxy with connection pooling |
 | `sse_stream` | Adds `Cache-Control: no-cache` and `X-Accel-Buffering: no` to response |
 | `static_cache` | Serves from in-memory cache on hit; fetches and caches on miss |
-| `static` | Serves files from disk under `serve_dir` (no upstream) behind a hardened path-safety core; GET/HEAD only. Emits a weak `ETag` + `Last-Modified` and answers `If-None-Match` / `If-Modified-Since` with **304 Not Modified**; supports byte-range requests (`206 Partial Content` + `Accept-Ranges: bytes`, `416` when unsatisfiable). `spa_fallback = true` serves `index.html` for an unmatched path. See [ADR-0015](/adr/0015-route-mode-static) / [ADR-0019](/adr/0019-static-conditional-get) / [ADR-0020](/adr/0020-static-range-requests). |
+| `static` | Serves files from disk under `serve_dir` (no upstream) behind a hardened path-safety core; GET/HEAD only. Emits a weak `ETag` + `Last-Modified` and answers `If-None-Match` / `If-Modified-Since` with **304 Not Modified**; supports byte-range requests (`206 Partial Content` + `Accept-Ranges: bytes`, `416` when unsatisfiable); files above 64 MiB stream frame-by-frame with bounded memory (no size limit). `spa_fallback = true` serves `index.html` for an unmatched path. See [ADR-0015](/adr/0015-route-mode-static) / [ADR-0019](/adr/0019-static-conditional-get) / [ADR-0020](/adr/0020-static-range-requests) / [ADR-0021](/adr/0021-static-file-streaming). |
 | `websocket` | Explicit WebSocket mode (also auto-detected via `Upgrade: websocket` header on any route) |
 
 ## Upstream resolution

--- a/docs/guide/migrate.md
+++ b/docs/guide/migrate.md
@@ -153,9 +153,10 @@ gets a bodiless **304 Not Modified** when the file is unchanged — the same
 browser-caching behavior nginx gives you out of the box, so a cut-over doesn't
 regress asset revalidation. Byte-range requests are honored too (`206` +
 `Accept-Ranges: bytes`, `416` when unsatisfiable), so media seeking and resumable
-downloads work — and a ranged read can pull a slice out of a file larger than the
-64 MiB whole-file cap. (Multi-range responses and streaming of very large single
-reads are tracked follow-ups.)
+downloads work. Large files (above 64 MiB) stream frame-by-frame with bounded
+memory rather than being buffered whole, so there is **no file-size limit** on a
+static route — a video or install image serves fine. (Multi-range responses are a
+tracked follow-up; single ranges and full downloads are complete.)
 
 ## Verify before you cut over
 

--- a/src/static_files.rs
+++ b/src/static_files.rs
@@ -16,18 +16,27 @@ use std::io::SeekFrom;
 use std::path::{Path, PathBuf};
 
 use bytes::Bytes;
-use http_body_util::{BodyExt, Full};
+use http_body_util::{BodyExt, Full, StreamBody};
 use hyper::header::HeaderValue;
 use hyper::{HeaderMap, Method, Response, StatusCode};
 use tokio::io::{AsyncReadExt, AsyncSeekExt};
+use tokio_stream::wrappers::ReceiverStream;
 
 use crate::proxy::ZionBody;
 
-/// Whole-file / whole-slice in-memory read cap. Streaming is a deferred follow-up
-/// (ADR-0015); until then a response body — a full file OR a single range slice —
-/// is refused past this size rather than buffered whole, which under concurrency
-/// would be a memory-amplification DoS.
+/// Buffer-whole-into-memory threshold. At or below this a body — a full file or a
+/// single range slice — is read into one `Bytes` and served as a `Full` body (the
+/// low-latency common case). Above it the body is streamed frame-by-frame instead
+/// (see [`stream_file`]), so an arbitrarily large file never sits in memory whole
+/// — the memory-amplification concern the ADR-0015 v1 guarded with a hard 413.
 const MAX_FILE_BYTES: u64 = 64 * 1024 * 1024;
+
+/// Per-read chunk size for a streamed file body.
+const STREAM_CHUNK: usize = 64 * 1024;
+/// Frames buffered between the file reader and the socket. Bounds in-flight memory
+/// to about `STREAM_CHUNK × (STREAM_CHANNEL_CAP + 1)` while keeping the reader
+/// slightly ahead of the network.
+const STREAM_CHANNEL_CAP: usize = 8;
 
 /// Turn a request-path tail (already stripped of the route prefix) into a safe
 /// RELATIVE path under the serve root, or `None` if it must be refused. Pure —
@@ -104,8 +113,53 @@ fn hex(c: u8) -> Option<u8> {
 fn resp(status: StatusCode) -> Response<ZionBody> {
     Response::builder()
         .status(status)
-        .body(Full::new(Bytes::new()).map_err(|n| match n {}).boxed())
+        .body(full_body(Bytes::new()))
         .unwrap()
+}
+
+/// Wrap already-materialized bytes as a one-shot [`ZionBody`].
+fn full_body(bytes: Bytes) -> ZionBody {
+    Full::new(bytes).map_err(|never| match never {}).boxed()
+}
+
+/// Stream `limit` bytes (or to EOF when `None`) from an already-positioned `file`
+/// as a framed [`ZionBody`], never holding more than [`STREAM_CHUNK`] × a small
+/// channel in memory. A read task feeds a bounded channel; the body drains it.
+///
+/// A mid-stream read error drops the sender, ending the body early — the same
+/// truncate-on-error behavior as the proxy path. The file was just `stat`ed and
+/// opened, so a fault here is a rare disk error, not a routine path, and the
+/// client sees a short read rather than a hang. The channel item type is
+/// `Result<_, hyper::Error>` to match [`ZionBody`]; only `Ok` frames are ever sent.
+fn stream_file(mut file: tokio::fs::File, limit: Option<u64>) -> ZionBody {
+    let (tx, rx) = tokio::sync::mpsc::channel::<Result<hyper::body::Frame<Bytes>, hyper::Error>>(
+        STREAM_CHANNEL_CAP,
+    );
+    tokio::spawn(async move {
+        let mut remaining = limit;
+        let mut buf = vec![0u8; STREAM_CHUNK];
+        loop {
+            let want = match remaining {
+                Some(0) => break,                                 // served the whole slice
+                Some(n) => (n.min(STREAM_CHUNK as u64)) as usize, // don't overshoot the range
+                None => STREAM_CHUNK,
+            };
+            match file.read(&mut buf[..want]).await {
+                Ok(0) => break, // EOF
+                Ok(n) => {
+                    let frame = hyper::body::Frame::data(Bytes::copy_from_slice(&buf[..n]));
+                    if tx.send(Ok(frame)).await.is_err() {
+                        break; // the client (receiver) went away
+                    }
+                    if let Some(r) = remaining.as_mut() {
+                        *r -= n as u64;
+                    }
+                }
+                Err(_) => break, // truncate on a read fault (see doc comment)
+            }
+        }
+    });
+    StreamBody::new(ReceiverStream::new(rx)).boxed()
 }
 
 /// Serve `tail` from `root`. `method` gates to GET/HEAD; `spa_fallback` serves
@@ -199,7 +253,7 @@ async fn read_file(path: &Path, method: &Method, req_headers: &HeaderMap) -> Res
                         total,
                         etag,
                         last_modified,
-                        Bytes::new(),
+                        full_body(Bytes::new()),
                     );
                 }
                 return read_range(path, mime, start, end, total, etag, last_modified).await;
@@ -212,17 +266,23 @@ async fn read_file(path: &Path, method: &Method, req_headers: &HeaderMap) -> Res
     // memory (a HEAD to a huge file would otherwise be a cheap
     // memory-amplification DoS).
     if method == Method::HEAD {
-        return file_response(mime, total, etag, last_modified, Bytes::new());
+        return file_response(mime, total, etag, last_modified, full_body(Bytes::new()));
     }
+    // A large file streams frame-by-frame instead of buffering whole; a small one
+    // takes the low-latency one-shot read.
     if total > MAX_FILE_BYTES {
-        return resp(StatusCode::PAYLOAD_TOO_LARGE);
+        let file = match tokio::fs::File::open(path).await {
+            Ok(f) => f,
+            Err(_) => return resp(StatusCode::NOT_FOUND),
+        };
+        return file_response(mime, total, etag, last_modified, stream_file(file, None));
     }
     let data = match tokio::fs::read(path).await {
         Ok(d) => d,
         Err(_) => return resp(StatusCode::NOT_FOUND),
     };
     let len = data.len() as u64;
-    file_response(mime, len, etag, last_modified, Bytes::from(data))
+    file_response(mime, len, etag, last_modified, full_body(Bytes::from(data)))
 }
 
 /// Derive the `(ETag, Last-Modified)` validators from file metadata. The ETag is
@@ -264,8 +324,7 @@ fn not_modified(
     if let Some(lm) = last_modified {
         b = b.header(hyper::header::LAST_MODIFIED, lm);
     }
-    b.body(Full::new(Bytes::new()).map_err(|n| match n {}).boxed())
-        .unwrap()
+    b.body(full_body(Bytes::new())).unwrap()
 }
 
 /// A `200 OK` file response (or its HEAD twin, with an empty `body`): content
@@ -276,7 +335,7 @@ fn file_response(
     content_length: u64,
     etag: Option<HeaderValue>,
     last_modified: Option<HeaderValue>,
-    body: Bytes,
+    body: ZionBody,
 ) -> Response<ZionBody> {
     let mut b = Response::builder()
         .status(StatusCode::OK)
@@ -289,8 +348,7 @@ fn file_response(
     if let Some(lm) = last_modified {
         b = b.header(hyper::header::LAST_MODIFIED, lm);
     }
-    b.body(Full::new(body).map_err(|n| match n {}).boxed())
-        .unwrap()
+    b.body(body).unwrap()
 }
 
 /// The outcome of evaluating a `Range` header against a file of `total` bytes.
@@ -391,15 +449,24 @@ async fn read_range(
     last_modified: Option<HeaderValue>,
 ) -> Response<ZionBody> {
     let len = end - start + 1;
-    if len > MAX_FILE_BYTES {
-        return resp(StatusCode::PAYLOAD_TOO_LARGE);
-    }
     let mut f = match tokio::fs::File::open(path).await {
         Ok(f) => f,
         Err(_) => return resp(StatusCode::NOT_FOUND),
     };
     if f.seek(SeekFrom::Start(start)).await.is_err() {
         return resp(StatusCode::INTERNAL_SERVER_ERROR);
+    }
+    // A large slice streams from the seek position; a small one is read whole.
+    if len > MAX_FILE_BYTES {
+        return partial_response(
+            mime,
+            start,
+            end,
+            total,
+            etag,
+            last_modified,
+            stream_file(f, Some(len)),
+        );
     }
     let mut buf = vec![0u8; len as usize];
     if f.read_exact(&mut buf).await.is_err() {
@@ -414,7 +481,7 @@ async fn read_range(
         total,
         etag,
         last_modified,
-        Bytes::from(buf),
+        full_body(Bytes::from(buf)),
     )
 }
 
@@ -427,7 +494,7 @@ fn partial_response(
     total: u64,
     etag: Option<HeaderValue>,
     last_modified: Option<HeaderValue>,
-    body: Bytes,
+    body: ZionBody,
 ) -> Response<ZionBody> {
     let mut b = Response::builder()
         .status(StatusCode::PARTIAL_CONTENT)
@@ -444,8 +511,7 @@ fn partial_response(
     if let Some(lm) = last_modified {
         b = b.header(hyper::header::LAST_MODIFIED, lm);
     }
-    b.body(Full::new(body).map_err(|n| match n {}).boxed())
-        .unwrap()
+    b.body(body).unwrap()
 }
 
 /// A `416 Range Not Satisfiable` carrying the authoritative total via
@@ -464,8 +530,7 @@ fn range_not_satisfiable(
     if let Some(lm) = last_modified {
         b = b.header(hyper::header::LAST_MODIFIED, lm);
     }
-    b.body(Full::new(Bytes::new()).map_err(|n| match n {}).boxed())
-        .unwrap()
+    b.body(full_body(Bytes::new())).unwrap()
 }
 
 /// MIME type by extension — a small, closed table (no `mime_guess` dependency).
@@ -1018,5 +1083,55 @@ mod serve_tests {
         let r = get_h(&root.0, "css/main.css", h).await;
         assert_eq!(r.status(), StatusCode::OK, "weak If-Range → full 200");
         assert_eq!(&body_bytes(r).await, b"body{}");
+    }
+
+    // ── Streaming bodies (stream_file) ────────────────────────────────────────
+    // The >MAX_FILE_BYTES serve path just opens the file and hands it to
+    // stream_file; these prove that machinery byte-for-byte without writing a
+    // 64 MiB fixture into the unit suite. The threshold path itself is exercised
+    // live (a >64 MiB file over a real socket).
+
+    async fn collect(body: ZionBody) -> Vec<u8> {
+        body.collect().await.unwrap().to_bytes().to_vec()
+    }
+
+    #[tokio::test]
+    async fn stream_file_whole_seek_and_limit() {
+        let root = root("stream-small"); // css/main.css = "body{}"
+        let path = root.0.join("css/main.css");
+
+        let whole = tokio::fs::File::open(&path).await.unwrap();
+        assert_eq!(&collect(stream_file(whole, None)).await, b"body{}");
+
+        let capped = tokio::fs::File::open(&path).await.unwrap();
+        assert_eq!(&collect(stream_file(capped, Some(3))).await, b"bod");
+
+        // A seek before streaming (how the range path drives it): last 4 bytes.
+        let mut seeked = tokio::fs::File::open(&path).await.unwrap();
+        seeked.seek(SeekFrom::Start(2)).await.unwrap();
+        assert_eq!(&collect(stream_file(seeked, Some(4))).await, b"dy{}");
+    }
+
+    #[tokio::test]
+    async fn stream_file_spans_multiple_chunks() {
+        // A file several STREAM_CHUNKs long exercises the read/send loop across
+        // many frames; the reassembled body must be byte-exact, and a non-chunk-
+        // aligned limit must stop on the exact byte.
+        let root = root("stream-big");
+        let n = STREAM_CHUNK * 3 + 12_345; // spans 4 frames, unaligned tail
+        let data: Vec<u8> = (0..n).map(|i| (i % 251) as u8).collect();
+        let path = root.0.join("big.bin");
+        std::fs::write(&path, &data).unwrap();
+
+        let whole = tokio::fs::File::open(&path).await.unwrap();
+        let got = collect(stream_file(whole, None)).await;
+        assert_eq!(got.len(), n);
+        assert_eq!(got, data, "whole streamed body must be byte-exact");
+
+        let limit = STREAM_CHUNK + 7; // stop mid-second-chunk
+        let capped = tokio::fs::File::open(&path).await.unwrap();
+        let got = collect(stream_file(capped, Some(limit as u64))).await;
+        assert_eq!(got.len(), limit);
+        assert_eq!(got, data[..limit], "limited stream stops on the exact byte");
     }
 }


### PR DESCRIPTION
## Why

Third and last of the [ADR-0015](docs/adr/0015-route-mode-static.md) runtime follow-ups (after [#340](https://github.com/fabriziosalmi/zion/pull/340) conditional GET, [#341](https://github.com/fabriziosalmi/zion/pull/341) range). `mode = "static"` read the whole representation — a full file or a range slice — into one `Bytes`, guarded by a hard `MAX_FILE_BYTES = 64 MiB` cap that returned **`413`** past it. So a legitimate large asset (video, install image, dataset) was **un-servable**, and a 60 MiB file still sat in memory whole under every concurrent request.

## What

- The 64 MiB constant becomes a **buffer-vs-stream threshold**, not a hard wall:
  - **≤ 64 MiB** → one-shot read + `Full` body (byte-for-byte the prior fast path);
  - **> 64 MiB** → **stream** frame-by-frame. Applies to full reads **and** range slices — a single range larger than the cap (which #341 still `413`'d) now streams too.
- `stream_file(file, limit)` spawns a reader that sends 64 KiB frames over a depth-8 mpsc channel; the body drains it. **In-flight memory is bounded to ~576 KiB/request regardless of file size**, with channel backpressure keeping the reader just ahead of the socket. Reuses the exact `StreamBody` + `ReceiverStream` idiom already in the H3 bridge — **no new dependency** (`tokio-stream` is already direct).
- `Content-Length` is **preserved** (size known from `stat`; the stream emits exactly that many bytes). A mid-stream read fault drops the sender, truncating — the same contract as the proxy path (rare disk error on a just-opened file, caught by the client's `Content-Length`, not a hang).

## Proof

- **2** new unit tests exercising `stream_file` directly: whole / seek-positioned / limited, and a **multi-chunk** file (`STREAM_CHUNK*3 + 12345` → 4 frames) reassembled **byte-exact** including a non-chunk-aligned limit. (No 64 MiB fixture in the unit suite — the threshold path is proven live.)
- **LIVE** over a real TLS socket: a **65 MiB** (68 157 440-byte) file → **`200` streamed** (was `413`), `Content-Length` exact, and **SHA-256 of the downloaded bytes matches the source** across ~1040 chunks; a range on the big file → `206`.
- `fmt` + `clippy --all-targets` clean on **default** / **--no-default-features** / **--all-features**; full unit suite green (**685**).

## Docs

New [ADR-0021](docs/adr/0021-static-file-streaming.md) + index row; `routing.md` `static` row and `migrate.md` note that a static route now has **no file-size limit**. No version bump (feature PR).

With this, the `mode=static` runtime follow-ups from ADR-0015 (conditional GET → range → streaming) are complete; only precompressed `.br`/`.gz` sidecars remain as an optional nicety.

🤖 Generated with [Claude Code](https://claude.com/claude-code)