### PR TITLE
chore(release): v0.7.3

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,7 +21,7 @@ A clear and concise description of what you expected to happen.
 **Environment (please complete the following information):**
  - OS: [e.g. Linux, macOS]
  - Architecture: [e.g. arm64, amd64]
- - Zion Version: [e.g. 0.7.2]
+ - Zion Version: [e.g. 0.7.3]
 
 **Additional context**
 Add any other context about the problem here (e.g. logs with `RUST_LOG=trace`, upstream backend type like Go/Node).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,42 @@ All notable changes to Zion Edge Gateway are documented here.
 
 ## [Unreleased]
 
+## [0.7.3] - 2026-08-03
+
+### Added
+- **`mode = "static"` runtime maturity — full nginx/Caddy asset parity.** The
+  disk file server (ADR-0015) gained the four HTTP behaviors real static hosting
+  needs, each proven live over a real socket:
+  - **Conditional GET** (ADR-0019, #340): a weak `ETag` (`W/"len-secs.nanos"`) +
+    `Last-Modified` derived from file metadata; `If-None-Match` /
+    `If-Modified-Since` are answered with a bodiless **304 Not Modified** (GET and
+    HEAD). The 304 decision is shared with the cache path via a new
+    `http_conditional` module; the required HTTP-date formatter is dependency-free
+    (no date crate in the core MSRV graph).
+  - **Range requests** (ADR-0020, #341): single-range `Range: bytes=…` →
+    **206 Partial Content** with `Content-Range` (served via seek), `416` when
+    unsatisfiable, `Accept-Ranges: bytes` advertised; `If-Range` honored.
+  - **Streaming** (ADR-0021, #342): files above 64 MiB now stream frame-by-frame
+    with bounded (~576 KiB) memory instead of returning `413` — **no file-size
+    limit** on a static route (video / install images serve fine). Applies to
+    ranged reads too.
+  - **Precompressed sidecars** (ADR-0022, #343): opt-in `precompressed = true`
+    serves a `.br`/`.gz` sidecar (Brotli preferred) when `Accept-Encoding` allows,
+    with the original `Content-Type` + `Content-Encoding` + `Vary: Accept-Encoding`
+    (like nginx `gzip_static`). Sidecars go through the same path-safety guard;
+    Zion never compresses on the fly.
+
+### Testing
+- **End-to-end rule-matrix** (#339): the integration suite gained live auth
+  (JWT/HS256), CORS, and **rule-composition** coverage — one route stacking
+  `waf + auth + cors` proves the middlewares compose (a valid token does not let a
+  malformed body bypass the WAF). The integration workflow now builds
+  `--features auth` so the gate is enforced.
+
+### Docs
+- Slowed the README "Migrating from nginx" terminal animation to a readable pace
+  (#344).
+
 ## [0.7.2] - 2026-07-31
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5477,7 +5477,7 @@ dependencies = [
 
 [[package]]
 name = "zion"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "aho-corasick",
  "aimp_node",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zion"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 # MSRV is the *core* default-features build (TLS proxy + WAF + cache + metrics).
 # Opt-in features (acme, auth, init, http3) pull crypto/i18n crates that have

--- a/README.md
+++ b/README.md
@@ -315,12 +315,12 @@ Every release is signed and carries SLSA v1.0 build provenance — see
 
 ```bash
 # Binary release (Sigstore-backed provenance via gh CLI)
-gh release download v0.7.2 -R fabriziosalmi/zion -p '*x86_64-unknown-linux-musl*' -p 'SHA256SUMS'
+gh release download v0.7.3 -R fabriziosalmi/zion -p '*x86_64-unknown-linux-musl*' -p 'SHA256SUMS'
 sha256sum --check --ignore-missing SHA256SUMS
-gh attestation verify zion-v0.7.2-x86_64-unknown-linux-musl.tar.gz --owner fabriziosalmi
+gh attestation verify zion-v0.7.3-x86_64-unknown-linux-musl.tar.gz --owner fabriziosalmi
 
 # Container image (cosign keyless)
-cosign verify ghcr.io/fabriziosalmi/zion:v0.7.2 \
+cosign verify ghcr.io/fabriziosalmi/zion:v0.7.3 \
     --certificate-identity-regexp "^https://github.com/fabriziosalmi/zion/\\.github/workflows/release\\.yml@refs/tags/v" \
     --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ from their containing minor — i.e. the latest `0.4.x` is always patched.
 | Version | Supported |
 | ------- | --------- |
 | 0.4.x (latest minor) | Yes |
-| < 0.7.2 | No |
+| < 0.7.3 | No |
 
 ## Reporting a Vulnerability
 

--- a/deploy/helm/zion/Chart.yaml
+++ b/deploy/helm/zion/Chart.yaml
@@ -3,7 +3,7 @@ name: zion
 description: Zion Edge Gateway — high-performance Rust TLS reverse proxy with WAF
 type: application
 version: 0.2.2
-appVersion: "0.7.2"
+appVersion: "0.7.3"
 home: https://fabriziosalmi.github.io/zion
 sources:
   - https://github.com/fabriziosalmi/zion

--- a/docs/deploy/hot-reload.md
+++ b/docs/deploy/hot-reload.md
@@ -130,7 +130,7 @@ Two surfaces report the reload state:
 
   ```json
   {
-    "version": "0.7.2",
+    "version": "0.7.3",
     "timestamp_ms": 1714425600000,
     "uptime_secs": 3712,
     "config_generation": 5,

--- a/docs/security/supply-chain.md
+++ b/docs/security/supply-chain.md
@@ -46,8 +46,8 @@ You need the GitHub CLI (`gh >= 2.49`) and `cosign >= 2.2`.
 
 ```bash
 # 1. Download the artifact + SHA256SUMS from the release page.
-gh release download v0.7.2 -R fabriziosalmi/zion \
-    -p 'zion-v0.7.2-x86_64-unknown-linux-musl.tar.gz' \
+gh release download v0.7.3 -R fabriziosalmi/zion \
+    -p 'zion-v0.7.3-x86_64-unknown-linux-musl.tar.gz' \
     -p 'SHA256SUMS' \
     -p 'zion-sbom.cdx.json'
 
@@ -55,7 +55,7 @@ gh release download v0.7.2 -R fabriziosalmi/zion \
 sha256sum --check --ignore-missing SHA256SUMS
 
 # 3. Verify the SLSA build provenance bound to the artifact's hash.
-gh attestation verify zion-v0.7.2-x86_64-unknown-linux-musl.tar.gz \
+gh attestation verify zion-v0.7.3-x86_64-unknown-linux-musl.tar.gz \
     --owner fabriziosalmi
 
 # Step 3 fails if:
@@ -78,7 +78,7 @@ grype zion-sbom.cdx.json
 ## Verifying a container image
 
 ```bash
-IMAGE=ghcr.io/fabriziosalmi/zion:v0.7.2
+IMAGE=ghcr.io/fabriziosalmi/zion:v0.7.3
 
 # 1. Pin to the digest immediately — tags are mutable, digests are not.
 DIGEST=$(crane digest "$IMAGE")
@@ -120,7 +120,7 @@ deterministically, and pins the Rust toolchain via
 [`rust-toolchain.toml`](../../rust-toolchain.toml). To reproduce locally:
 
 ```bash
-git checkout v0.7.2
+git checkout v0.7.3
 export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)
 # Linux musl example — matches the release artifact byte-for-byte
 # (modulo strip's stable behavior on your distro).


### PR DESCRIPTION
Patch release folding in the 6 PRs merged to master since v0.7.2. **No API break.** The ML-WAF scaffold (#345) is deliberately **excluded** — it stays in review.

## Highlights — `mode = "static"` reaches full nginx/Caddy asset parity

The disk file server (ADR-0015) gained the four HTTP behaviors real static hosting needs, each proven live over a real socket:

- **Conditional GET → 304** (ADR-0019, #340) — weak `ETag` + `Last-Modified`; `If-None-Match`/`If-Modified-Since` answered with a bodiless 304. Shared 304 logic with the cache path; dependency-free HTTP-date formatter (no date crate in core MSRV).
- **Range requests** (ADR-0020, #341) — `206`/`Content-Range`/`Accept-Ranges`, `416` when unsatisfiable, `If-Range`.
- **Streaming >64 MiB** (ADR-0021, #342) — bounded-memory frame streaming, **no file-size limit** (proven: 65 MiB file, SHA-256 match).
- **Precompressed `.br`/`.gz` sidecars** (ADR-0022, #343) — opt-in `precompressed = true`, Brotli-preferred, `Vary: Accept-Encoding`, same path-safety guard.

## Also

- **e2e rule-matrix** (#339) — live auth/CORS/rule-composition coverage; integration builds `--features auth`.
- **README animation** slowed to a readable pace (#344).

## Release mechanics

Version bumped via `bump-version.sh 0.7.3` (SSOT = Cargo.toml; `check-version-sync.sh` green). CHANGELOG updated. After merge: annotated unsigned tag `v0.7.3` → `release.yml` (10 assets + multi-arch cosign container).

🤖 Generated with [Claude Code](https://claude.com/claude-code)