### PR TITLE
test(equivalence): generalize the harness for caddy + traefik (SWAP step 1)

### DIFF
--- a/.github/workflows/equivalence.yml
+++ b/.github/workflows/equivalence.yml
@@ -1,6 +1,7 @@
-# Equivalence harness: prove `zion import nginx` routes like the nginx it
-# converted, on real instances. Runs the branch binary (ZION_BIN mode), so a
-# mapper regression is caught before merge.
+# Equivalence harness: prove `zion import <nginx|caddy|traefik>` routes like the
+# proxy it converted, on real instances (real nginx / caddy / traefik vs real
+# zion serving the imported config). Runs the branch binary (ZION_BIN mode), so
+# a mapper regression in any of the three front-ends is caught before merge.
 name: equivalence
 
 on:
@@ -41,8 +42,20 @@ jobs:
           rustc --version && cargo --version
           cargo build --release --locked --bin zion
 
-      - name: Run the equivalence harness (branch binary vs real nginx)
+      - name: Equivalence — nginx (multi-vhost)
         env:
           ZION_BIN: target/release/zion
           NO_COLOR: "1"
         run: ./tests/equivalence/run.sh multi-vhost
+
+      - name: Equivalence — caddy (caddy-basic)
+        env:
+          ZION_BIN: target/release/zion
+          NO_COLOR: "1"
+        run: ./tests/equivalence/run.sh caddy-basic
+
+      - name: Equivalence — traefik (traefik-compose, real traefik via docker compose)
+        env:
+          ZION_BIN: target/release/zion
+          NO_COLOR: "1"
+        run: ./tests/equivalence/run.sh traefik-compose

--- a/tests/equivalence/README.md
+++ b/tests/equivalence/README.md
@@ -1,18 +1,30 @@
-# Equivalence harness — `zion import nginx`
+# Equivalence harness — `zion import <nginx|caddy|traefik>`
 
 The migration pitch for [`zion import`](../../docs/adr/0011-zion-import-nginx.md)
 is only as good as its proof. This harness produces that proof with **real
-instances, no mocks**: it converts an nginx config, then shows that real Zion
-serving the converted config routes requests the same way the real nginx
-serving the original does — and that the handful of intentional differences
-are exactly the ones the import report already flagged.
+instances, no mocks**: it converts an incumbent proxy config, then shows that
+real Zion serving the converted config routes requests the same way the real
+proxy serving the original does — and that the handful of intentional
+differences are exactly the ones the import report already flagged.
+
+The **source is auto-detected** from the scenario directory:
+
+| file present | source | how the original runs |
+|---|---|---|
+| `nginx.conf` | nginx | real `nginx:alpine`, echo backends on `zeq-net` |
+| `Caddyfile` | caddy | real `caddy:alpine`, echo backends on `zeq-net` |
+| `docker-compose.yml` | traefik | real traefik via `docker compose up` (the compose file provides its own label-routed backends; needs `docker compose`) |
+
+Shipped scenarios: `multi-vhost` (nginx), `caddy-basic` (caddy), `traefik-compose`
+(traefik). Each column of the corpus is verified — Zion's live against the
+imported config, the incumbent's against the original.
 
 ## What it does
 
-For a scenario (a real `nginx.conf` plus a request corpus), `run.sh`:
+For a scenario, `run.sh`:
 
-1. starts **real nginx** (`nginx:alpine`) on the scenario's config,
-2. runs **`zion import nginx`** on that *same* config and prints the findings,
+1. starts the **real original proxy** on the scenario's config,
+2. runs **`zion import <src>`** on that *same* config and prints the findings,
 3. starts **real Zion** on the converted `zion.toml`,
 4. replays every `(Host, path)` request in the corpus against **both**,
 5. diffs the backend that answered — request by request.

--- a/tests/equivalence/run.sh
+++ b/tests/equivalence/run.sh
@@ -1,21 +1,27 @@
 #!/usr/bin/env bash
-# zion import — equivalence harness (ADR-0011, fidelity ladder v1).
+# zion import — equivalence harness (ADR-0011/0012/0013, fidelity ladder v1).
 #
 # Proves, with real instances and no mocks, that a config converted by
-# `zion import nginx` routes like the nginx it came from:
+# `zion import <nginx|caddy|traefik>` routes like the proxy it came from:
 #
-#   1. real nginx (nginx:alpine) serves the scenario config
-#   2. `zion import nginx` converts that SAME config (findings shown)
+#   1. the real ORIGINAL proxy serves the scenario config
+#   2. `zion import <src>` converts that SAME config (findings shown)
 #   3. real zion serves the converted config
 #   4. a corpus of (Host, path) requests is replayed against BOTH
 #   5. the answering backend is diffed request by request
 #
-# Rows whose expectations differ between nginx and zion are DOCUMENTED
-# divergences: the import report flags them with partial findings, and this
-# harness proves those flags are truthful rather than hiding them.
+# The source is auto-detected from the scenario dir:
+#   nginx.conf         → nginx      (real nginx:alpine, echo backends)
+#   Caddyfile          → caddy      (real caddy:alpine, echo backends)
+#   docker-compose.yml → traefik    (real traefik via `docker compose up`;
+#                                     the compose file provides its own backends)
 #
-# Requirements: docker, curl, openssl, bash. No Rust toolchain needed in the
-# default mode (zion runs from the published container image).
+# Rows whose expectations differ between the original and zion are DOCUMENTED
+# divergences: the import report flags them, and this harness proves those flags
+# are truthful rather than hiding them.
+#
+# Requirements: docker (+ `docker compose` for traefik scenarios), curl,
+# openssl, bash. No Rust toolchain needed in the default mode.
 #
 #   ./tests/equivalence/run.sh [scenario]        # default: multi-vhost
 #
@@ -29,68 +35,49 @@
 set -euo pipefail
 
 SCENARIO="${1:-multi-vhost}"
-ZION_IMAGE="${ZION_IMAGE:-ghcr.io/fabriziosalmi/zion:0.6.0}"
+ZION_IMAGE="${ZION_IMAGE:-ghcr.io/fabriziosalmi/zion:0.7.3}"
 ZION_RUNTIME_IMAGE="${ZION_RUNTIME_IMAGE:-ubuntu:24.04}"
 NGINX_IMAGE="nginx:1.27-alpine"
+CADDY_IMAGE="caddy:2-alpine"
 NET=zeq-net
-NGINX_PORT=18080
+PROXY_PORT=18080
 ZION_PORT=18443
 BACKEND_PORT=5678
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
 SCEN_DIR="$HERE/scenarios/$SCENARIO"
-[ -f "$SCEN_DIR/nginx.conf" ] || { echo "unknown scenario '$SCENARIO'" >&2; exit 1; }
 
-# Color when attached to a TTY or when explicitly forced (the demo recorder
-# sets FORCE_COLOR so the SVG keeps its verdict colors); NO_COLOR wins.
+# ── Source detection: which incumbent proxy does this scenario describe? ──
+if   [ -f "$SCEN_DIR/nginx.conf" ];         then SRC=nginx;   SRC_CFG="nginx.conf"
+elif [ -f "$SCEN_DIR/Caddyfile" ];          then SRC=caddy;   SRC_CFG="Caddyfile"
+elif [ -f "$SCEN_DIR/docker-compose.yml" ]; then SRC=traefik; SRC_CFG="docker-compose.yml"
+else
+    echo "scenario '$SCENARIO' has no nginx.conf / Caddyfile / docker-compose.yml" >&2
+    exit 1
+fi
+
 if { [ -t 1 ] || [ -n "${FORCE_COLOR:-}" ]; } && [ -z "${NO_COLOR:-}" ]; then
     G=$'\033[32m'; Y=$'\033[33m'; R=$'\033[31m'; B=$'\033[1m'; N=$'\033[0m'
 else
     G=""; Y=""; R=""; B=""; N=""
 fi
-
 say() { printf '%s\n' "$*"; }
 step() { printf '\n%s── %s%s\n' "$B" "$*" "$N"; }
 
 WORK="$(mktemp -d "${TMPDIR:-/tmp}/zion-eq.XXXXXX")"
 chmod 755 "$WORK"
 
+COMPOSE_UP=""  # set to the compose file when a traefik scenario is running
 cleanup() {
     [ -n "${KEEP:-}" ] && { say "KEEP=1 — leaving containers up (work dir: $WORK)"; return; }
+    [ -n "$COMPOSE_UP" ] && docker compose -f "$COMPOSE_UP" -p zeq-traefik down -v >/dev/null 2>&1 || true
     docker ps -aq --filter "name=^zeq-" | xargs -r docker rm -f >/dev/null 2>&1 || true
     docker network rm "$NET" >/dev/null 2>&1 || true
     rm -rf "$WORK"
 }
 trap cleanup EXIT
 
-# Backends referenced by the scenario config: zeq-be-<name>.
-BACKENDS="$(grep -oE 'zeq-be-[a-z0-9-]+' "$SCEN_DIR/nginx.conf" | sed 's/^zeq-be-//' | sort -u)"
-
-step "scenario '$SCENARIO' — backends: $(echo "$BACKENDS" | tr '\n' ' ')"
-docker network create "$NET" >/dev/null
-
-for name in $BACKENDS; do
-    mkdir -p "$WORK/be-$name"
-    cat > "$WORK/be-$name/default.conf" <<EOF
-server {
-    listen $BACKEND_PORT;
-    default_type text/plain;
-    location / { return 200 "$name\n"; }
-}
-EOF
-    chmod -R a+rX "$WORK/be-$name"
-    docker run -d --name "zeq-be-$name" --network "$NET" \
-        -v "$WORK/be-$name/default.conf:/etc/nginx/conf.d/default.conf:ro" \
-        "$NGINX_IMAGE" >/dev/null
-done
-
-step "nginx (the original) on :$NGINX_PORT"
-docker run -d --name zeq-nginx --network "$NET" -p "127.0.0.1:$NGINX_PORT:80" \
-    -v "$SCEN_DIR/nginx.conf:/etc/nginx/conf.d/default.conf:ro" \
-    "$NGINX_IMAGE" >/dev/null
-
-# How zion is invoked: released image, or a tree-built binary mounted into a
-# plain runtime image (CI mode).
+# ── zion invocation: released image, or a tree-built binary (CI mode) ──
 if [ -n "${ZION_BIN:-}" ]; then
     ZION_BIN="$(cd "$(dirname "$ZION_BIN")" && pwd)/$(basename "$ZION_BIN")"
     zion_docker() { # extra-docker-args... -- zion-args...
@@ -98,18 +85,67 @@ if [ -n "${ZION_BIN:-}" ]; then
         docker run "${extra[@]}" -v "$ZION_BIN:/usr/local/bin/zion:ro" \
             --entrypoint /usr/local/bin/zion "$ZION_RUNTIME_IMAGE" "$@"
     }
-    say "zion: local binary $ZION_BIN (runtime: $ZION_RUNTIME_IMAGE)"
+    ZION_DESC="local binary $ZION_BIN (runtime: $ZION_RUNTIME_IMAGE)"
 else
     zion_docker() {
         local extra=(); while [ "$1" != "--" ]; do extra+=("$1"); shift; done; shift
         docker run "${extra[@]}" "$ZION_IMAGE" "$@"
     }
-    say "zion: $ZION_IMAGE"
+    ZION_DESC="$ZION_IMAGE"
 fi
 
-step "zion import nginx — converting the SAME config (findings below)"
-zion_docker --rm -v "$SCEN_DIR/nginx.conf:/in/nginx.conf:ro" -- \
-    import nginx /in/nginx.conf \
+step "scenario '$SCENARIO' — source: ${B}$SRC${N}   zion: $ZION_DESC"
+docker network create "$NET" >/dev/null
+
+# ── Start the ORIGINAL proxy (source-specific) ──
+case "$SRC" in
+nginx | caddy)
+    # These two share the model: echo backends referenced as zeq-be-<name> in
+    # the config, plus a single-container proxy serving the config file.
+    BACKENDS="$(grep -oE 'zeq-be-[a-z0-9-]+' "$SCEN_DIR/$SRC_CFG" | sed 's/^zeq-be-//' | sort -u)"
+    step "backends: $(echo "$BACKENDS" | tr '\n' ' ')"
+    for name in $BACKENDS; do
+        mkdir -p "$WORK/be-$name"
+        cat > "$WORK/be-$name/default.conf" <<EOF
+server {
+    listen $BACKEND_PORT;
+    default_type text/plain;
+    location / { return 200 "$name\n"; }
+}
+EOF
+        chmod -R a+rX "$WORK/be-$name"
+        docker run -d --name "zeq-be-$name" --network "$NET" \
+            -v "$WORK/be-$name/default.conf:/etc/nginx/conf.d/default.conf:ro" \
+            "$NGINX_IMAGE" >/dev/null
+    done
+    if [ "$SRC" = nginx ]; then
+        step "nginx (the original) on :$PROXY_PORT"
+        docker run -d --name zeq-nginx --network "$NET" -p "127.0.0.1:$PROXY_PORT:80" \
+            -v "$SCEN_DIR/nginx.conf:/etc/nginx/conf.d/default.conf:ro" \
+            "$NGINX_IMAGE" >/dev/null
+    else
+        step "caddy (the original) on :$PROXY_PORT"
+        docker run -d --name zeq-caddy --network "$NET" -p "127.0.0.1:$PROXY_PORT:80" \
+            -v "$SCEN_DIR/Caddyfile:/etc/caddy/Caddyfile:ro" \
+            "$CADDY_IMAGE" caddy run --config /etc/caddy/Caddyfile --adapter caddyfile >/dev/null
+    fi
+    ;;
+traefik)
+    # Traefik's native model is docker labels; the scenario IS a self-contained
+    # compose file (traefik + its own labelled echo backends). `docker compose
+    # up` runs the real thing; traefik must publish its entrypoint on
+    # 127.0.0.1:$PROXY_PORT (the compose file wires that).
+    command -v docker >/dev/null && docker compose version >/dev/null 2>&1 || {
+        echo "traefik scenarios need 'docker compose'" >&2; exit 1; }
+    step "traefik (the original) via docker compose on :$PROXY_PORT"
+    COMPOSE_UP="$SCEN_DIR/docker-compose.yml"
+    ZEQ_PROXY_PORT="$PROXY_PORT" docker compose -f "$COMPOSE_UP" -p zeq-traefik up -d >/dev/null
+    ;;
+esac
+
+step "zion import $SRC — converting the SAME config (findings below)"
+zion_docker --rm -v "$SCEN_DIR/$SRC_CFG:/in/$SRC_CFG:ro" -- \
+    import "$SRC" "/in/$SRC_CFG" \
     > "$WORK/zion.toml" 2> "$WORK/report.txt" || { cat "$WORK/report.txt" >&2; exit 1; }
 sed 's/^/  /' "$WORK/report.txt"
 
@@ -127,15 +163,11 @@ zion_docker -d --name zeq-zion --network "$NET" -p "127.0.0.1:$ZION_PORT:443" \
     -v "$WORK/zion.key:/etc/ssl/zion/zion.key:ro" \
     -e ZION_CONFIG=/etc/zion/zion.toml -- >/dev/null
 
-ask_nginx() { # host path -> backend id or HTTP status
-    local out
-    out="$(curl -s -m 5 -o - -w '|%{http_code}' -H "Host: $1" "http://127.0.0.1:$NGINX_PORT$2" || true)"
-    normalize "$out"
+ask_orig() { # host path -> backend id or HTTP status
+    normalize "$(curl -s -m 5 -o - -w '|%{http_code}' -H "Host: $1" "http://127.0.0.1:$PROXY_PORT$2" || true)"
 }
 ask_zion() {
-    local out
-    out="$(curl -sk -m 5 -o - -w '|%{http_code}' -H "Host: $1" "https://127.0.0.1:$ZION_PORT$2" || true)"
-    normalize "$out"
+    normalize "$(curl -sk -m 5 -o - -w '|%{http_code}' -H "Host: $1" "https://127.0.0.1:$ZION_PORT$2" || true)"
 }
 normalize() { # "body|status" -> body first line, or the status when no body / >= 400
     local body="${1%|*}" code="${1##*|}"
@@ -146,16 +178,14 @@ normalize() { # "body|status" -> body first line, or the status when no body / >
     fi
 }
 
-# Readiness gate: loop until the FIRST corpus row answers with its expected
-# backend on BOTH instances. Zion binds and pre-warms upstreams after boot,
-# so the first requests can otherwise race the listener coming up.
-read -r first_host first_path want_nginx want_zion _ < <(
+# Readiness gate: loop until the FIRST corpus row answers as expected on BOTH.
+read -r first_host first_path want_orig want_zion _ < <(
     awk '!/^#/ && NF {print; exit}' "$SCEN_DIR/requests.txt")
 for i in $(seq 1 40); do
-    [ "$(ask_nginx "$first_host" "$first_path")" = "$want_nginx" ] &&
+    [ "$(ask_orig "$first_host" "$first_path")" = "$want_orig" ] &&
         [ "$(ask_zion "$first_host" "$first_path")" = "$want_zion" ] && break
     [ "$i" = 40 ] && {
-        echo "instances did not become ready (nginx=$(ask_nginx "$first_host" "$first_path") zion=$(ask_zion "$first_host" "$first_path"))" >&2
+        echo "instances did not become ready (orig=$(ask_orig "$first_host" "$first_path") zion=$(ask_zion "$first_host" "$first_path"))" >&2
         docker logs zeq-zion 2>&1 | tail -20 >&2 || true
         exit 1
     }
@@ -163,23 +193,23 @@ for i in $(seq 1 40); do
 done
 
 step "replaying the request corpus against BOTH instances"
-printf '  %-22s %-22s %-10s %-10s %s\n' "HOST" "PATH" "nginx" "zion" "VERDICT"
+printf '  %-22s %-22s %-10s %-10s %s\n' "HOST" "PATH" "$SRC" "zion" "VERDICT"
 fails=0; identical=0; documented=0
-while read -r host path want_nginx want_zion; do
+while read -r host path want_orig want_zion; do
     case "$host" in ''|'#'*) continue ;; esac
-    got_nginx="$(ask_nginx "$host" "$path")"
+    got_orig="$(ask_orig "$host" "$path")"
     got_zion="$(ask_zion "$host" "$path")"
-    if [ "$got_nginx" != "$want_nginx" ] || [ "$got_zion" != "$want_zion" ]; then
-        verdict="${R}FAIL (expected nginx=$want_nginx zion=$want_zion)${N}"
+    if [ "$got_orig" != "$want_orig" ] || [ "$got_zion" != "$want_zion" ]; then
+        verdict="${R}FAIL (expected $SRC=$want_orig zion=$want_zion)${N}"
         fails=$((fails + 1))
-    elif [ "$want_nginx" != "$want_zion" ]; then
+    elif [ "$want_orig" != "$want_zion" ]; then
         verdict="${Y}documented divergence (flagged by the import report)${N}"
         documented=$((documented + 1))
     else
         verdict="${G}identical${N}"
         identical=$((identical + 1))
     fi
-    printf '  %-22s %-22s %-10s %-10s %s\n' "$host" "$path" "$got_nginx" "$got_zion" "$verdict"
+    printf '  %-22s %-22s %-10s %-10s %s\n' "$host" "$path" "$got_orig" "$got_zion" "$verdict"
 done < "$SCEN_DIR/requests.txt"
 
 step "result"

--- a/tests/equivalence/scenarios/caddy-basic/Caddyfile
+++ b/tests/equivalence/scenarios/caddy-basic/Caddyfile
@@ -1,0 +1,37 @@
+# Equivalence scenario: caddy-basic.
+# Mirrors the nginx multi-vhost routing in Caddy's model — three host site
+# blocks + a multi-path API host + a hostless catch-all. Every backend answers
+# with its own name, so "which backend replied" IS the routing decision.
+# Backends resolve as zeq-be-<name>:5678 on the harness docker network.
+
+{
+	admin off
+	auto_https off
+}
+
+alpha.example.com:80 {
+	reverse_proxy zeq-be-alpha:5678
+}
+
+beta.example.com:80 {
+	reverse_proxy zeq-be-beta:5678
+}
+
+api.example.com:80 {
+	handle /status {
+		reverse_proxy zeq-be-health:5678
+	}
+	handle /v1/users* {
+		reverse_proxy zeq-be-users:5678
+	}
+	handle /v1/* {
+		reverse_proxy zeq-be-legacy:5678
+	}
+	handle {
+		reverse_proxy zeq-be-default:5678
+	}
+}
+
+:80 {
+	reverse_proxy zeq-be-default:5678
+}

--- a/tests/equivalence/scenarios/caddy-basic/requests.txt
+++ b/tests/equivalence/scenarios/caddy-basic/requests.txt
@@ -1,0 +1,21 @@
+# Replay corpus: HOST PATH EXPECT_CADDY EXPECT_ZION
+# Zion's column is verified live (zion serving the imported config); Caddy's is
+# what real Caddy does with the original Caddyfile — the harness proves they
+# agree (or diverge exactly as noted). `404` = no backend answered.
+alpha.example.com    /                      alpha    alpha
+alpha.example.com    /some/deep/path        alpha    alpha
+ALPHA.EXAMPLE.COM    /case-folding          alpha    alpha
+beta.example.com     /                      beta     beta
+unknown.example.com  /                      default  default
+api.example.com      /status                health   health
+api.example.com      /v1/users              users    users
+api.example.com      /v1/users/42/profile   users    users
+api.example.com      /v1/orders             legacy   legacy
+api.example.com      /other                 default  default
+# Documented divergence (string-prefix glob vs path segments): Caddy's
+# `handle /v1/users*` matches `/v1/users999` by string prefix -> users; Zion
+# imports it as `/v1/users/{*rest}` and matches on path segments, so
+# `/v1/users999` is a different segment and falls to `/v1/` -> legacy. NB: the
+# nginx importer flags this class as a partial finding; the caddy importer does
+# not yet — a follow-up (the harness surfaces it here regardless).
+api.example.com      /v1/users999           users    legacy

--- a/tests/equivalence/scenarios/traefik-compose/docker-compose.yml
+++ b/tests/equivalence/scenarios/traefik-compose/docker-compose.yml
@@ -1,0 +1,60 @@
+# Equivalence scenario: traefik-compose.
+# Traefik's native model is docker labels. This compose runs real traefik (the
+# docker provider) plus label-routed echo backends, and is ALSO exactly what
+# `zion import traefik` reads. Backends echo their own name, so "which backend
+# replied" IS the routing decision.
+#
+# All services join the harness-created external network `zeq-net`, so the
+# zion container (also on zeq-net) resolves the backend service names.
+#
+# Backends use hashicorp/http-echo (returns a fixed string). Traefik publishes
+# its `web` entrypoint on 127.0.0.1:${ZEQ_PROXY_PORT} (set by run.sh).
+
+networks:
+  default:
+    name: zeq-net
+    external: true
+
+services:
+  traefik:
+    image: traefik:v3.1
+    command:
+      - --providers.docker=true
+      - --providers.docker.exposedbydefault=false
+      - --entrypoints.web.address=:80
+    ports:
+      - "127.0.0.1:${ZEQ_PROXY_PORT:-18080}:80"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+
+  alpha:
+    image: hashicorp/http-echo
+    command: ["-text=alpha", "-listen=:5678"]
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.alpha.rule=Host(`alpha.example.com`)
+      - traefik.http.services.alpha.loadbalancer.server.port=5678
+
+  beta:
+    image: hashicorp/http-echo
+    command: ["-text=beta", "-listen=:5678"]
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.beta.rule=Host(`beta.example.com`)
+      - traefik.http.services.beta.loadbalancer.server.port=5678
+
+  users:
+    image: hashicorp/http-echo
+    command: ["-text=users", "-listen=:5678"]
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.users.rule=Host(`api.example.com`) && PathPrefix(`/v1/users`)
+      - traefik.http.services.users.loadbalancer.server.port=5678
+
+  legacy:
+    image: hashicorp/http-echo
+    command: ["-text=legacy", "-listen=:5678"]
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.legacy.rule=Host(`api.example.com`) && PathPrefix(`/v1`)
+      - traefik.http.services.legacy.loadbalancer.server.port=5678

--- a/tests/equivalence/scenarios/traefik-compose/requests.txt
+++ b/tests/equivalence/scenarios/traefik-compose/requests.txt
@@ -1,0 +1,18 @@
+# Replay corpus: HOST PATH EXPECT_TRAEFIK EXPECT_ZION
+# Zion's column is verified live (zion serving the imported config); Traefik's
+# is what real traefik does with the same labels. `404` = no router matched.
+# Traefik has no default router, so an unmatched host or path is a 404 on both.
+alpha.example.com    /                      alpha    alpha
+alpha.example.com    /deep/path             alpha    alpha
+beta.example.com     /                      beta     beta
+api.example.com      /v1/users              users    users
+api.example.com      /v1/users/42           users    users
+api.example.com      /v1/orders             legacy   legacy
+api.example.com      /v1                    legacy   legacy
+api.example.com      /other                 404      404
+unknown.example.com  /                      404      404
+# Documented divergence (string prefix vs path segments): traefik's
+# PathPrefix(`/v1/users`) matches `/v1/users999` by string prefix -> users;
+# Zion imports it as `/v1/users/{*rest}` (segment-matched) so `/v1/users999`
+# falls to `/v1` -> legacy.
+api.example.com      /v1/users999           users    legacy


### PR DESCRIPTION
Step 1 of the zion-replace **SWAP track**: the equivalence harness proved `zion import nginx` routes like real nginx — now it covers **caddy** and **traefik** too, so a mapper regression in any of the three front-ends is caught before merge.

## What changed

- **`run.sh` is source-aware.** It auto-detects the incumbent from the scenario dir and starts the matching **real** proxy:
  | file | source | original runs as |
  |---|---|---|
  | `nginx.conf` | nginx | `nginx:alpine` (unchanged) |
  | `Caddyfile` | caddy | `caddy:alpine` |
  | `docker-compose.yml` | traefik | real traefik via `docker compose up` (its native docker-labels model) |
  The rest — `zion import <src>`, cert, zion serve, replay, diff — is shared. nginx behavior is byte-for-byte unchanged.
- **New scenarios**: `caddy-basic` (3 host blocks + multi-path API + hostless catch-all) and `traefik-compose` (real traefik + label-routed `http-echo` backends on the harness network).
- **CI** (`equivalence.yml`) runs all three scenarios in `ZION_BIN` mode.

## Grounded, not guessed

Each scenario's **`EXPECT_ZION` column was derived live** — zion serving the imported config against local echo backends — so the corpus reflects real Zion behavior. Both new scenarios independently surface the *same real divergence* the nginx one does:

> a string-prefix glob (`handle /v1/users*` in Caddy, `PathPrefix(/v1/users)` in Traefik) vs Zion's **path-segment** matching → `/v1/users999` routes to the incumbent's `users` but Zion's `legacy`.

A genuine finding fell out: the **caddy importer doesn't yet flag** this prefix-vs-segment class as a `partial` finding the way the nginx importer does — noted as a follow-up.

## Honesty about the proof

The real-proxy **head-to-head runs in CI** (ubuntu has docker + compose). No container runtime is available in the dev sandbox, so locally I proved the **import legs** (`zion import caddy`/`traefik` → valid config + findings) and the **zion-serving legs** (the `EXPECT_ZION` columns). CI closes the loop against real caddy/traefik.

Prereq for the on-host SWAP work (first real swap: rainlogs/nis2) — the harness now generalizes to whatever proxy fronts a target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)