### PR TITLE
ci(dependabot): hold simd-json/toml/tract-onnx at the MSRV walls

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -54,6 +54,22 @@ updates:
       # hold at 0.5.x rather than relitigate MSRV for a benchmark harness.
       - dependency-name: "criterion"
         versions: [">=0.6.0"]
+      # simd-json 0.15+ raised its MSRV to rustc 1.85 (via value-trait 0.12,
+      # edition2024) against the 1.82 anchor — the MSRV job fails at manifest
+      # parse, before any code compiles. Hold at 0.14.x. Same posture as above.
+      - dependency-name: "simd-json"
+        versions: [">=0.15.0"]
+      # toml 1.1+ raised its MSRV to rustc 1.85 (via serde_spanned 1.1,
+      # edition2024). Note the floor is 1.1.0, not 1.0.0: toml 1.0.x still
+      # declares rustc 1.76 and remains a legitimate upgrade from 0.8.x.
+      - dependency-name: "toml"
+        versions: [">=1.1.0"]
+      # tract-onnx 0.23+ requires rustc 1.91, past the FULL-feature 1.88
+      # anchor (rust-toolchain.toml) — a different wall from the ones above,
+      # since ml-waf is excluded from the no-default-features MSRV job. 0.22.x
+      # (rustc 1.85) stays proposable. Revisit when ml-waf leaves EXPERIMENTAL.
+      - dependency-name: "tract-onnx"
+        versions: [">=0.23.0"]
       # Pin major-version bumps for the cryptographic / network core — those
       # need a manual security review (release notes, advisory diff) before merge.
       - dependency-name: "rustls"


### PR DESCRIPTION
Three open Dependabot bumps (#350, #352, #353) were red on **MSRV, not on code** — each fails at manifest parse, before anything compiles:

| PR | bump | wall |
|---|---|---|
| #350 | simd-json 0.14.3 → 0.17.3 | `value-trait 0.12` (edition2024) — rustc **1.85** > 1.82 core anchor |
| #352 | toml 0.8.23 → 1.1.3 | `serde_spanned 1.1` (edition2024) — rustc **1.85** > 1.82 core anchor |
| #353 | tract-onnx 0.21.17 → 0.23.4 | rustc **1.91** > 1.88 full anchor (`rust-toolchain.toml`) |

Same class as the `hyper-rustls` / `dashmap` / `criterion` holds already recorded in this file, so it gets the same treatment: an ignore rule with the reason written down, since the MSRV CI gate is the hard guard and this only stops the re-proposal churn.

**Floors are the first breaking release, not the whole major**, so the still-compatible upgrades stay proposable:
- `toml` 1.0.x declares rustc 1.76 — a real move off 0.8.x that this rule deliberately leaves open;
- `tract-onnx` 0.22.x declares rustc 1.85 — clears the 1.88 anchor.

Per-version MSRV verified against the crates.io index rather than assumed.

Revisit `simd-json`/`toml` when MSRV-core moves to 1.85, and `tract-onnx` when `ml-waf` leaves EXPERIMENTAL.

Closes the triage for #350, #352, #353 (closed as won't-merge, with the reason on each).