### PR TITLE
ci(dependabot): lower the toml floor to >=0.9.0 (toml_parser wall starts at 0.9)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -59,16 +59,21 @@ updates:
       # parse, before any code compiles. Hold at 0.14.x. Same posture as above.
       - dependency-name: "simd-json"
         versions: [">=0.15.0"]
-      # toml 1.1+ raised its MSRV to rustc 1.85 (edition2024). The 1.0 line is
-      # blocked too, but transitively — which is why the floor is 1.0.0 and not
-      # 1.1.0 as first written: toml 1.0.7 declares rustc 1.76 itself, yet
-      # depends on `toml_parser ^1.0.10`, and that caret resolves to 1.1.x
-      # (rustc 1.85). #362 died parsing toml_parser-1.1.2's manifest under the
-      # 1.82 MSRV job, before any code compiled. Pinning the transitive down to
-      # 1.0.x is more upkeep than a build-time config parser earns, so hold the
-      # whole 1.x line at 0.8 until MSRV-core moves to 1.85.
+      # toml is blocked transitively, by `toml_parser` — not by its own MSRV.
+      # The wall starts at 0.9.0, not 1.0.0 as first written: 0.9.0 is where
+      # the parser was split out into `toml_parser ^1.0.0` (default `parse`
+      # feature), and that caret resolves to 1.1.x, which is edition2024 /
+      # rustc 1.85 — past the 1.82 anchor. The MSRV job then fails at manifest
+      # parse, before any code compiles: #362 (toml 1.0.7) and #367 (toml
+      # 0.9.12) both died on exactly that line, and 0.9.x slipped past the
+      # old >=1.0.0 floor. Note toml_parser 1.1.x is ALREADY in the lock via
+      # proc-macro-crate -> toml_edit 0.25, but that path sits outside the
+      # no-default-features graph, so cargo never opens its manifest; toml 0.9
+      # moves it onto the direct, non-optional config path where cargo must.
+      # Pinning the transitive down to 1.0.x is more upkeep than a build-time
+      # config parser earns, so hold at 0.8.x until MSRV-core moves to 1.85.
       - dependency-name: "toml"
-        versions: [">=1.0.0"]
+        versions: [">=0.9.0"]
       # tract-onnx 0.23+ requires rustc 1.91, past the FULL-feature 1.88
       # anchor (rust-toolchain.toml) — a different wall from the ones above,
       # since ml-waf is excluded from the no-default-features MSRV job. 0.22.x


### PR DESCRIPTION
## What

One-line change to the `toml` ignore rule in `.github/dependabot.yml`: floor `>=1.0.0` → `>=0.9.0`, plus a rewritten comment.

## Why

The rule added in #365 held `toml` at `>=1.0.0`, but its own comment stated the intent was to hold *the whole line* at 0.8. The floor was tuned to the wrong number — the `toml_parser` wall starts at **0.9.0**, not 1.0.0.

`toml` 0.9.0 is where the parser was split out into `toml_parser ^1.0.0` (via the default `parse` feature). That caret resolves to 1.1.x, which is edition2024 / rustc 1.85 — past the 1.82 `no-default-features` anchor. The MSRV job then dies at manifest parse, before any code compiles.

#367 (`toml` 0.9.12) slipped under the `>=1.0.0` floor and failed exactly the way #362 (`toml` 1.0.7) did:

```
error: failed to parse manifest at `.../toml_parser-1.1.2+spec-1.1.0/Cargo.toml`
Caused by:
  feature `edition2024` is required
```

Notably, on #367 *everything else was green* — clippy across all 8 feature flavours, `test` default + all-features, all three soaks, integration, macOS, Windows, BoGo. The 0.8 → 0.9 API migration is transparent for how Zion uses `toml`. The block is purely the transitive MSRV wall.

## Why master is green today with `toml_parser` 1.1.2 already in `Cargo.lock`

Worth recording, since it looks contradictory: `toml_parser` 1.1.2 reaches the lock via `proc-macro-crate` → `toml_edit 0.25`, a path that sits **outside** the `no-default-features` graph — so cargo never opens its manifest. `toml` 0.9 moves `toml_parser` onto the direct, non-optional config path, where cargo must parse it. That is the whole difference.

## Scope

Dependabot config only, no code change. Revisit when MSRV-core moves to 1.85.

Closes the recurrence path for #367.

🤖 Generated with [Claude Code](https://claude.com/claude-code)