### PR TITLE
ci: watch the watchers — alarm when a scheduled workflow stops running green

### DIFF
--- a/.github/workflows/cron-watchdog.yml
+++ b/.github/workflows/cron-watchdog.yml
@@ -1,0 +1,91 @@
+name: cron-watchdog
+
+# Watches the watchers. Every other scheduled workflow in this repo reports into
+# the void: a failing cron blocks no merge, gates no PR, and notifies nobody.
+# sovereign-data failed six consecutive weekly runs (2026-07-06 .. 2026-08-12)
+# before anyone looked, and the datasets it maintains went stale the whole time.
+#
+# This job asserts that every cron workflow has SUCCEEDED on schedule recently,
+# and — the part that matters — makes a failure impossible to miss by opening
+# an issue. A watchdog that only turns its own run red would inherit exactly the
+# problem it exists to solve.
+
+on:
+  schedule:
+    # 09:00 UTC: after the 04:00 and 06:00 crons have had time to finish.
+    - cron: '0 9 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read # list workflow runs
+  issues: write # raise the alarm where a human will see it
+
+concurrency:
+  group: cron-watchdog
+  cancel-in-progress: false
+
+jobs:
+  freshness:
+    name: Scheduled workflows are alive
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5.0.1
+
+      - name: Check cron freshness
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set +e
+          OUT=$(scripts/check-cron-freshness.sh 2>&1)
+          RC=$?
+          echo "$OUT"
+          {
+            echo 'report<<CRONEOF'
+            echo "$OUT"
+            echo 'CRONEOF'
+          } >> "$GITHUB_OUTPUT"
+          echo "rc=$RC" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Open or update the alarm issue
+        if: steps.check.outputs.rc != '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPORT: ${{ steps.check.outputs.report }}
+        run: |
+          TITLE="Scheduled workflows are not running green"
+          BODY=$(printf '%s\n\n```\n%s\n```\n\n%s\n' \
+            "One or more scheduled workflows have not succeeded on schedule within their expected window." \
+            "$REPORT" \
+            "Two things trigger this, and the second is the quiet one: the workflow is failing, or GitHub disabled it (scheduled workflows are switched off after 60 days of repository inactivity — a disabled cron never fails, it just stops).
+
+          Raised by \`.github/workflows/cron-watchdog.yml\`. This issue is reused, not duplicated: it closes on its own once every cron is green again.")
+
+          EXISTING=$(gh issue list --state open --label cron-watchdog \
+            --json number --jq '.[0].number // empty')
+
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --body "$BODY"
+            echo "updated issue #$EXISTING"
+          else
+            gh issue create --title "$TITLE" --body "$BODY" \
+              --label cron-watchdog --label automated
+          fi
+
+      - name: Close the alarm once everything is green
+        if: steps.check.outputs.rc == '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          EXISTING=$(gh issue list --state open --label cron-watchdog \
+            --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            gh issue close "$EXISTING" \
+              --comment "All scheduled workflows are succeeding on schedule again. Closed automatically."
+          fi
+
+      - name: Fail the run so the badge reflects reality
+        if: steps.check.outputs.rc != '0'
+        run: exit 1

--- a/.github/workflows/cron-watchdog.yml
+++ b/.github/workflows/cron-watchdog.yml
@@ -30,7 +30,7 @@ jobs:
     name: Scheduled workflows are alive
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Check cron freshness
         id: check

--- a/scripts/check-cron-freshness.sh
+++ b/scripts/check-cron-freshness.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Verify that every scheduled workflow has SUCCEEDED recently.
+#
+# Why this exists: sovereign-data failed every weekly run from 2026-07-06 to
+# 2026-08-12 — six consecutive weeks — and nothing said so. A cron that fails
+# blocks no merge and notifies no one, so the datasets it maintains silently
+# went stale. Red is not the problem; unwatched is.
+#
+# Two distinct failure modes are covered, and the second is the one people
+# forget: GitHub DISABLES scheduled workflows after 60 days of repository
+# inactivity. A disabled cron does not fail — it stops existing, and a check
+# that only looks at the last run's conclusion would report the last success
+# forever.
+#
+# The workflow list is DERIVED, never hardcoded: adding a cron workflow puts it
+# under this guard automatically. A hardcoded list would itself go stale, which
+# is the failure this script exists to prevent.
+#
+# Usage:  scripts/check-cron-freshness.sh [--json]
+# Needs:  gh (authenticated), and `actions: read` when run in CI.
+set -uo pipefail
+
+REPO="${GITHUB_REPOSITORY:-fabriziosalmi/zion}"
+WF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/.github/workflows"
+JSON=0
+[[ "${1:-}" == "--json" ]] && JSON=1
+
+# Slack over the nominal cadence: runners queue, GitHub spreads scheduled load,
+# and a single missed tick is noise rather than signal. Two ticks missed is not.
+DAILY_MAX_AGE_H=48
+WEEKLY_MAX_AGE_H=216 # 9 days
+
+now_epoch=$(date -u +%s)
+stale=0
+checked=0
+declare -a ROWS=()
+
+for f in "$WF_DIR"/*.yml; do
+  cron_line=$(grep -oE "cron: *['\"][^'\"]*['\"]" "$f" 2>/dev/null | head -1) || true
+  [[ -z "$cron_line" ]] && continue
+
+  name="$(basename "$f")"
+  schedule="$(sed -E "s/cron: *['\"]//; s/['\"]$//" <<<"$cron_line")"
+
+  # Day-of-week field pinned to a specific day => weekly, otherwise daily.
+  dow="$(awk '{print $5}' <<<"$schedule")"
+  if [[ "$dow" == "*" ]]; then
+    max_age_h=$DAILY_MAX_AGE_H
+    cadence="daily"
+  else
+    max_age_h=$WEEKLY_MAX_AGE_H
+    cadence="weekly"
+  fi
+
+  # The most recent SUCCESSFUL scheduled run — not merely the most recent run.
+  # Asking for the latest conclusion instead would go green again the moment a
+  # manual dispatch succeeded, while the schedule stayed broken.
+  last_ok=$(gh run list --repo "$REPO" --workflow "$name" --limit 40 \
+    --json conclusion,createdAt,event \
+    --jq '[.[] | select(.event == "schedule" and .conclusion == "success")] | .[0].createdAt // empty' 2>/dev/null) || true
+
+  checked=$((checked + 1))
+
+  if [[ -z "$last_ok" ]]; then
+    ROWS+=("STALE|${name%.yml}|$cadence|never succeeded on schedule")
+    stale=$((stale + 1))
+    continue
+  fi
+
+  last_epoch=$(date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$last_ok" +%s 2>/dev/null \
+    || date -u -d "$last_ok" +%s 2>/dev/null) || last_epoch=0
+  age_h=$(((now_epoch - last_epoch) / 3600))
+
+  if ((age_h > max_age_h)); then
+    ROWS+=("STALE|${name%.yml}|$cadence|last scheduled success ${age_h}h ago (limit ${max_age_h}h)")
+    stale=$((stale + 1))
+  else
+    ROWS+=("OK|${name%.yml}|$cadence|${age_h}h ago")
+  fi
+done
+
+if ((JSON)); then
+  printf '{"checked":%d,"stale":%d,"rows":[' "$checked" "$stale"
+  first=1
+  for r in "${ROWS[@]}"; do
+    IFS='|' read -r st wf cad detail <<<"$r"
+    ((first)) || printf ','
+    first=0
+    printf '{"status":"%s","workflow":"%s","cadence":"%s","detail":"%s"}' "$st" "$wf" "$cad" "$detail"
+  done
+  printf ']}\n'
+else
+  for r in "${ROWS[@]}"; do
+    IFS='|' read -r st wf cad detail <<<"$r"
+    printf '  %-6s %-20s %-8s %s\n' "$st" "$wf" "$cad" "$detail"
+  done
+  echo
+  echo "  checked: $checked scheduled workflow(s), stale: $stale"
+fi
+
+((stale == 0)) || exit 1

--- a/scripts/check-cron-freshness.sh
+++ b/scripts/check-cron-freshness.sh
@@ -40,6 +40,14 @@ for f in "$WF_DIR"/*.yml; do
   [[ -z "$cron_line" ]] && continue
 
   name="$(basename "$f")"
+
+  # Skip ourselves. This workflow carries a `schedule:` trigger too, so it lands
+  # in its own scan — and on the very first run it has no prior successful
+  # SCHEDULED run of itself, so it would flag itself STALE and open an alarm
+  # while every workflow it watches is healthy. A watchdog whose first act is a
+  # false positive teaches people to ignore it.
+  [[ "$name" == "cron-watchdog.yml" ]] && continue
+
   schedule="$(sed -E "s/cron: *['\"]//; s/['\"]$//" <<<"$cron_line")"
 
   # Day-of-week field pinned to a specific day => weekly, otherwise daily.
@@ -55,9 +63,16 @@ for f in "$WF_DIR"/*.yml; do
   # The most recent SUCCESSFUL scheduled run — not merely the most recent run.
   # Asking for the latest conclusion instead would go green again the moment a
   # manual dispatch succeeded, while the schedule stayed broken.
-  last_ok=$(gh run list --repo "$REPO" --workflow "$name" --limit 40 \
-    --json conclusion,createdAt,event \
-    --jq '[.[] | select(.event == "schedule" and .conclusion == "success")] | .[0].createdAt // empty' 2>/dev/null) || true
+  #
+  # Filtered server-side rather than by fetching N runs and filtering here.
+  # Several of these workflows (scorecard, supply-chain, codeql) also run on
+  # push and pull_request, so any fixed window can fill up with unrelated runs
+  # and push the last scheduled success out of view — reporting STALE for a
+  # perfectly healthy workflow. A watchdog that cries wolf gets muted, which
+  # returns us to exactly the problem it exists to solve.
+  last_ok=$(gh api \
+    "repos/$REPO/actions/workflows/$name/runs?event=schedule&status=success&per_page=1" \
+    --jq '.workflow_runs[0].created_at // empty' 2>/dev/null) || true
 
   checked=$((checked + 1))
 


### PR DESCRIPTION
`sovereign-data` failed **every weekly run from 2026-07-06 to 2026-08-12** — six consecutive weeks — and nothing said so. A cron blocks no merge, gates no PR and notifies nobody, so the ASN/CIDR datasets it maintains went stale for six weeks while every other signal in the repo stayed green.

The bugs behind that are fixed separately. This is the guard that would have surfaced them on day one instead of week six.

## What it checks

`scripts/check-cron-freshness.sh` asserts every scheduled workflow has had a **successful scheduled run** inside its window — 48h daily, 9 days weekly, slack included because runners queue and one missed tick is noise.

Three design choices, each one a way this guard could have quietly become useless:

**The workflow list is derived, not hardcoded.** Parsed from the cron lines in `.github/workflows/*.yml`, so a new scheduled workflow falls under the guard automatically. A hardcoded list would itself go stale — precisely the failure being guarded against.

**It looks for the last success on `event == schedule`**, not the last run's conclusion. The latter would go green the moment someone manually dispatched the workflow successfully, while the schedule stayed broken.

**It catches a cron that stopped existing.** GitHub disables scheduled workflows after 60 days of repo inactivity; a disabled cron never fails, it just stops. Freshness sees that; "did the last run fail" cannot.

## Making failure visible

Opens an issue labelled `cron-watchdog`, reuses rather than duplicates, closes it automatically when everything is green again. Also fails its own run.

The issue is the point. A watchdog whose only output is its own red badge inherits the exact problem it exists to solve.

## Verified

Against real data on this repo — it flags the known-bad case, which is the acceptance test:

```
OK     acme-soak            weekly   77h ago
OK     codeql               weekly   52h ago
OK     scorecard            daily    3h ago
STALE  sovereign-data       weekly   never succeeded on schedule
OK     stability-soak       daily    5h ago
OK     supply-chain         daily    3h ago
OK     tls-conformance      weekly   53h ago
OK     waf-corpus           daily    5h ago
checked: 8 scheduled workflow(s), stale: 1   (exit 1)
```

Labels `cron-watchdog` and `automated` created.

## Not verified, and worth knowing before merge

**The alarm path itself is untested.** `workflow_dispatch` only works for workflows already on the default branch, so this cannot be exercised until it merges.

That matters more than usual here: this repo has `default_workflow_permissions: read` and `can_approve_pull_request_reviews: false`, and that second setting is what currently stops `sovereign-data` from opening its PR. Issue creation is governed by a *different* toggle — declaring `permissions: issues: write` should elevate the token, and the PR restriction is specific to pull requests — but that is reasoning, not evidence.

**First dispatch after merge is the real test.** It should open an issue for `sovereign-data` immediately, since that one is genuinely stale. If no issue appears, the alarm is muted and the guard is decorative — worth checking rather than assuming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)