### PR TITLE
fix(ci): repair the sovereign-data refresh — four layers deep

### DIFF
--- a/.github/workflows/sovereign-data.yml
+++ b/.github/workflows/sovereign-data.yml
@@ -76,9 +76,22 @@ jobs:
       if: steps.diff.outputs.changed == 'true'
       run: |
         BRANCH="sovereign-data-${{ matrix.region }}-$(date +%Y%m%d)"
+
+        # The runner has no git identity, so `git commit` aborted with
+        #   fatal: empty ident name (for <runner@...>) not allowed
+        # every scheduled run since 2026-07-06 — the fetch worked, the commit
+        # never happened, and the datasets silently stopped being refreshed.
+        # `-s` below derives the Signed-off-by trailer from these values, so the
+        # identity and the DCO sign-off cannot drift apart.
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
         git checkout -b "$BRANCH"
         git add ${{ matrix.output }}
-        git commit -m "data(sovereign): weekly ${{ matrix.adjective }} CIDR refresh
+        # -s is required: dco.yml gates every pull_request to master on a
+        # Signed-off-by trailer, so an unsigned commit here would open a PR that
+        # can never merge.
+        git commit -s -m "data(sovereign): weekly ${{ matrix.adjective }} CIDR refresh
 
         Source: RIPE NCC delegated + IPtoASN ($(date +%Y-%m-%d))
         Changes: +${{ steps.diff.outputs.added }} -${{ steps.diff.outputs.removed }} lines"

--- a/.github/workflows/sovereign-data.yml
+++ b/.github/workflows/sovereign-data.yml
@@ -58,8 +58,9 @@ jobs:
           exit 1
         fi
 
-    # The PAT is passed to checkout so the credential git persists for `git push`
-    # is the PAT, not the read-only GITHUB_TOKEN.
+    # checkout stores whichever token it is given, and `git push` later reuses
+    # that stored credential. Passing the PAT here is therefore what makes the
+    # push work — the default GITHUB_TOKEN is read-only in this job.
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         token: ${{ secrets.SOVEREIGN_DATA_PAT }}

--- a/.github/workflows/sovereign-data.yml
+++ b/.github/workflows/sovereign-data.yml
@@ -21,8 +21,11 @@ jobs:
     name: refresh ${{ matrix.region }}
     runs-on: ubuntu-latest
     permissions:
-      contents: write       # push the auto-generated branch
-      pull-requests: write  # open the refresh PR
+      # Read-only on purpose. Both writes this job performs — pushing the branch
+      # and opening the PR — are carried by SOVEREIGN_DATA_PAT, so GITHUB_TOKEN
+      # needs nothing beyond read. Leaving `contents: write` here would grant a
+      # capability nothing uses, against this file's own stated posture.
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -34,7 +37,32 @@ jobs:
             output: src/sovereign/data_eu.rs
             adjective: EU-27
     steps:
+    # Fail with a sentence a human can act on. Without this, a missing secret
+    # surfaces 40 lines later as an opaque auth error on `git push`, which is
+    # how the previous three failures in this workflow stayed unread.
+    - name: Preflight — the refresh PAT must be present
+      env:
+        PAT: ${{ secrets.SOVEREIGN_DATA_PAT }}
+      run: |
+        if [ -z "$PAT" ]; then
+          echo "::error::secret SOVEREIGN_DATA_PAT is not set."
+          echo "This workflow opens its refresh PR with a dedicated fine-grained PAT"
+          echo "rather than GITHUB_TOKEN, because 'Allow GitHub Actions to create and"
+          echo "approve pull requests' is disabled repo-wide — deliberately, since"
+          echo "enabling it would grant that power to every workflow here."
+          echo ""
+          echo "Create a fine-grained PAT scoped to this repository only, with:"
+          echo "  Contents:      Read and write   (push the refresh branch)"
+          echo "  Pull requests: Read and write   (open the refresh PR)"
+          echo "Nothing else. Then add it as the SOVEREIGN_DATA_PAT repository secret."
+          exit 1
+        fi
+
+    # The PAT is passed to checkout so the credential git persists for `git push`
+    # is the PAT, not the read-only GITHUB_TOKEN.
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        token: ${{ secrets.SOVEREIGN_DATA_PAT }}
 
     - name: Download RIPE NCC delegated stats + IPtoASN
       run: |
@@ -109,4 +137,7 @@ jobs:
         The \`ranges_are_sorted\` and \`ranges_dont_overlap\` tests will run in CI." \
           --label "sovereign-data,automated"
       env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # Dedicated PAT, not GITHUB_TOKEN: repo-wide policy blocks Actions from
+        # creating pull requests, and the narrow fix is a token scoped to this
+        # repo rather than lifting that policy for every workflow.
+        GH_TOKEN: ${{ secrets.SOVEREIGN_DATA_PAT }}


### PR DESCRIPTION
The weekly Sovereign Data Refresh failed **every scheduled run from 2026-07-06 to 2026-08-12** — six consecutive weeks, both matrix legs. The fetch half always worked. The datasets behind sovereign geo-routing simply stopped being refreshed, quietly, because a cron that fails blocks no merge and notifies no one.

Found during a read-only audit. The failure turned out to be four layers deep, each one hidden by the one before it.

## Layer 1 — no git identity

```
fatal: empty ident name (for <runner@runnervm...>) not allowed
```

The runner cannot synthesise an identity: the `runner` account's gecos field is empty, so git aborts rather than guessing. Fixed by configuring `github-actions[bot]`.

## Layer 2 — no DCO sign-off

Anticipated by reading `dco.yml` before shipping, not by hitting it. It gates every `pull_request` to master on a `Signed-off-by` trailer, and this workflow's commit had none — so fixing only layer 1 would have opened a PR that could never merge. `git commit -s` derives the trailer from the identity configured above, so the two cannot drift apart.

## Layer 3 — the labels did not exist

```
could not add label: 'sovereign-data' not found
```

Only visible once layers 1 and 2 fell. `gh pr create` died *after* pushing the branch. Both `sovereign-data` and `automated` have been created.

## Layer 4 — Actions cannot open PRs here

```
GitHub Actions is not permitted to create or approve pull requests
```

A repository setting (`can_approve_pull_request_reviews: false`), not a bug. Lifting it would grant PR-creation to **every** workflow in this repo — a poor trade for one weekly refresh. Instead this uses a fine-grained PAT scoped to this repository alone.

## What this PR needs before it works

A repository secret `SOVEREIGN_DATA_PAT`, holding a fine-grained PAT scoped to this repo with exactly:

| permission | why |
|---|---|
| Contents: Read and write | push the refresh branch |
| Pull requests: Read and write | open the refresh PR |

Nothing else. The secret is deliberately **not** created here — that is a credential and belongs to the account owner.

A preflight step fails with those instructions if the secret is missing, rather than surfacing an opaque auth error forty lines later. That mattered: opaque failures are exactly how this workflow went unread for six weeks.

## Also

The job drops to `contents: read`. With both writes carried by the PAT, `contents: write` and `pull-requests: write` governed a `GITHUB_TOKEN` nothing uses — a permission block describing something no longer true.

## Verification

Layers 1 and 2 are **proven on the real runner**, not locally: the `fatal: empty ident name` does not reproduce on macOS, where git synthesises an identity from the OS user. Dispatching this branch produced a commit whose orphaned branch showed:

```
author:  github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
trailer: Signed-off-by: github-actions[bot] <...>
```

The commit that had been impossible for six weeks, made and correctly signed. Layers 3 and 4 were then diagnosed from that same runner. Test branches were cleaned up.

Layer 4 cannot be verified until the secret exists — first scheduled run, or a manual dispatch, is the proof.

Related: #372 adds the watchdog that would have surfaced this on day one instead of week six.

🤖 Generated with [Claude Code](https://claude.com/claude-code)