### PR TITLE
ci(dependabot): hold aws-lc-rs below 1.18 — FIPS module 3.x is validated, 4.x is not

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -90,6 +90,22 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "aws-lc-rs"
         update-types: ["version-update:semver-major"]
+      # aws-lc-rs 1.18.0 switches `aws-lc-fips-sys` from the AWS-LC-FIPS 3.x
+      # branch to 4.x. 3.x is FIPS 140-3 VALIDATED (NIST certificates #5314
+      # static, #5298 dynamic); 4.x has completed lab testing and is submitted,
+      # but sits on the CMVP Modules In Process list — not yet certified.
+      #
+      # `--features fips` exists precisely to give operators a validated module,
+      # and README, docs/guide/architecture.md and docs/security/fips.md all say
+      # "validated" in so many words. Taking 1.18 would make those claims false
+      # while the PR title read like routine maintenance ("rust-minor group").
+      # Upstream's own guidance: pin to <1.18.0 to stay on the 3.x module.
+      #
+      # Note this is a SEPARATE condition from the semver-major pin above, which
+      # exists for a different reason (manual security review of crypto majors).
+      # When NIST certifies 4.0, delete this entry only — the other still stands.
+      - dependency-name: "aws-lc-rs"
+        versions: [">=1.18.0"]
 
   # Benchmarks workspace has its own Cargo.toml — keep it on the same cadence.
   - package-ecosystem: "cargo"


### PR DESCRIPTION
Closes the recurrence path for #370, which is being closed unmerged.

## What #370 actually did

Title: *"bump aws-lc-rs from 1.17.3 to 1.18.0 in the rust-minor group"*. Underneath, `aws-lc-fips-sys` went 0.13.16 → 0.14.1, switching the cryptographic module branch:

| AWS-LC-FIPS module | in | status |
|---|---|---|
| **3.x** | `aws-lc-rs` <1.18.0 (current) | **FIPS 140-3 validated** — NIST certificates [#5314](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/5314) static, [#5298](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/5298) dynamic |
| **4.x** | `aws-lc-rs` ≥1.18.0 | lab testing complete, submitted — on the [CMVP Modules In Process](https://csrc.nist.gov/Projects/cryptographic-module-validation-program/modules-in-process/Modules-In-Process-List) list, **not yet certified** |

## Why that matters here specifically

`--features fips` exists to give operators a validated module, and this repo says "validated" in five places: the `Cargo.toml` feature comment, README twice, `docs/guide/architecture.md`, and `docs/security/fips.md` — which explains that the build verifies the module's integrity hash at link time precisely because CMVP requires the validated binary's hash to match the certificate.

Merging #370 would have made all five false, silently, behind a `rust-minor` label. For someone building with `--features fips` to satisfy a compliance requirement, validated versus pending-certification is the entire reason the flag exists.

Upstream says the same: pin to `<1.18.0` to stay on the 3.x module.

## Why the existing rule missed it

```yaml
- dependency-name: "aws-lc-rs"
  update-types: ["version-update:semver-major"]
```

1.18.0 is a **minor**. Same shape as the `toml` floor corrected in #368 — a rule tuned to a version number rather than to where the consequence actually begins.

Added as a **separate** condition rather than folded into the existing entry: that one exists for an unrelated reason (manual security review of crypto majors, alongside rustls/tokio/hyper). When NIST certifies 4.0, delete this entry only and the other still stands.

## Not assessed here

Whether anyone is currently operating Zion in FIPS mode against those certificate numbers. That is not a technical call — and `docs/security/fips.md` makes the point itself: a FIPS binary is not a FIPS deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)