### PR TITLE
chore(release): v0.7.4

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,7 +21,7 @@ A clear and concise description of what you expected to happen.
 **Environment (please complete the following information):**
  - OS: [e.g. Linux, macOS]
  - Architecture: [e.g. arm64, amd64]
- - Zion Version: [e.g. 0.7.3]
+ - Zion Version: [e.g. 0.7.4]
 
 **Additional context**
 Add any other context about the problem here (e.g. logs with `RUST_LOG=trace`, upstream backend type like Go/Node).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,29 @@ All notable changes to Zion Edge Gateway are documented here.
 
 ## [Unreleased]
 
-Nothing here changes runtime behaviour for an operator: no new features, no bug
-fixes on the request path, no config surface. It is dependency hygiene, test
-infrastructure, and one experimental scaffold that ships inert. **This section
-is deliberately not a release** — recorded so that "nothing worth releasing" is
-distinguishable from "someone forgot to write it down".
+## [0.7.4] - 2026-08-13
+
+**A stability release, cut to be held still.** Nothing here changes runtime
+behaviour for an operator: no new features on the request path, no bug fixes
+there, no config surface. It is dependency hygiene, supply-chain corrections,
+CI that now checks what it claims to, and one experimental scaffold that ships
+inert.
+
+The reason to tag it anyway is that the next step is field validation against
+real sites — and that is only meaningful against a fixed point. Everything
+below is what the frozen baseline contains.
+
+### Data
+
+- **Sovereign ASN/CIDR datasets refreshed** (#375, #376) after the weekly job
+  had been silently failing for six weeks (see *Fixed*). EU-27 coverage is
+  essentially unchanged (+0.01%); the Italian set loses 0.86%, which was
+  verified against the sources rather than assumed: three Telecom Italia /15
+  blocks currently return `AS0 — Not routed` in IPtoASN, and one /24 has moved
+  to `AS32787` (Prolexic, US DDoS scrubbing). Excluding both is correct —
+  classifying unrouted space, or a US scrubbing centre, as Italian residential
+  would be wrong. Note this tracks BGP, so the classification will oscillate if
+  those prefixes are announced again.
 
 ### Added
 - **ML-WAF training pipeline** (#345, ADR-0023) — a reproducible in-repo `ml/`
@@ -38,6 +56,21 @@ distinguishable from "someone forgot to write it down".
   Actions updates.
 
 ### Fixed
+- **The weekly sovereign-data refresh runs again** (#374), after failing every
+  scheduled run from 2026-07-06 to 2026-08-12. Four layers, each hidden by the
+  one before it: the runner had no git identity, so `git commit` aborted; the
+  commit carried no `Signed-off-by`, so its PR could never have passed
+  `dco.yml`; the `sovereign-data` and `automated` labels did not exist, so
+  `gh pr create` died after pushing the branch; and repo policy forbids Actions
+  from opening pull requests, so it now uses a fine-grained PAT scoped to this
+  repository rather than lifting that policy for every workflow.
+- **`aws-lc-rs` held below 1.18.0** (#378). That release switches
+  `aws-lc-fips-sys` from the AWS-LC-FIPS **3.x** module — FIPS 140-3 validated,
+  NIST certificates #5314 and #5298 — to **4.x**, which has completed lab
+  testing but is still on the CMVP Modules In Process list. `--features fips`
+  exists to give operators a validated module, and the repo says "validated" in
+  five places; taking the bump would have made all five false behind a
+  `rust-minor` label. The existing pin only covered semver-major.
 - **Three advisory ignores retired**, not silenced (#371) — each because the
   advisory stopped applying, verified crate-by-crate:
   `RUSTSEC-2024-0436` (`paste`, both sources gone), `RUSTSEC-2024-0320`
@@ -53,6 +86,15 @@ distinguishable from "someone forgot to write it down".
   respective walls.
 
 ### Testing
+- **A watchdog over the scheduled workflows** (#372). Every cron in this repo
+  reported into the void — a failing one blocks no merge and notifies nobody,
+  which is how the sovereign-data breakage above survived six weeks. A daily job
+  now asserts that each scheduled workflow has had a *successful scheduled* run
+  inside its window, and opens an issue when one has not. It derives the
+  workflow list from the cron lines rather than hardcoding it, so a new
+  scheduled workflow is covered automatically; it also catches a cron that
+  stopped existing, since GitHub disables schedules after 60 days of repository
+  inactivity and a disabled cron never fails.
 - **Equivalence harness generalized to Caddy and Traefik** (#347), previously
   nginx-only.
 - **ML-WAF review findings fixed** — header lookups made case-insensitive on

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5150,7 +5150,7 @@ dependencies = [
 
 [[package]]
 name = "zion"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "aho-corasick",
  "aimp_node",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zion"
-version = "0.7.3"
+version = "0.7.4"
 edition = "2021"
 # MSRV is the *core* default-features build (TLS proxy + WAF + cache + metrics).
 # Opt-in features (acme, auth, init, http3) pull crypto/i18n crates that have

--- a/README.md
+++ b/README.md
@@ -315,12 +315,12 @@ Every release is signed and carries SLSA v1.0 build provenance — see
 
 ```bash
 # Binary release (Sigstore-backed provenance via gh CLI)
-gh release download v0.7.3 -R fabriziosalmi/zion -p '*x86_64-unknown-linux-musl*' -p 'SHA256SUMS'
+gh release download v0.7.4 -R fabriziosalmi/zion -p '*x86_64-unknown-linux-musl*' -p 'SHA256SUMS'
 sha256sum --check --ignore-missing SHA256SUMS
-gh attestation verify zion-v0.7.3-x86_64-unknown-linux-musl.tar.gz --owner fabriziosalmi
+gh attestation verify zion-v0.7.4-x86_64-unknown-linux-musl.tar.gz --owner fabriziosalmi
 
 # Container image (cosign keyless)
-cosign verify ghcr.io/fabriziosalmi/zion:v0.7.3 \
+cosign verify ghcr.io/fabriziosalmi/zion:v0.7.4 \
     --certificate-identity-regexp "^https://github.com/fabriziosalmi/zion/\\.github/workflows/release\\.yml@refs/tags/v" \
     --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,13 +2,19 @@
 
 ## Supported Versions
 
-Security fixes ship in the latest minor release. Point releases inherit fixes
-from their containing minor — i.e. the latest `0.4.x` is always patched.
+Security fixes ship in the latest release only. There is no long-term support
+branch: older minors receive nothing, and the way to stay patched is to move to
+the current version.
 
 | Version | Supported |
 | ------- | --------- |
-| 0.4.x (latest minor) | Yes |
 | < 0.7.4 | No |
+
+Everything at or above that line is the current release. Stated as a single
+threshold on purpose — the previous wording carried a second, hardcoded row
+(`0.4.x`) that `bump-version.sh` never rewrote, so it kept claiming support for
+0.4.x while the threshold marched on to 0.7.x. A policy that contradicts itself
+is worse than a terse one, and on a security policy it is worse still.
 
 ## Reporting a Vulnerability
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ from their containing minor — i.e. the latest `0.4.x` is always patched.
 | Version | Supported |
 | ------- | --------- |
 | 0.4.x (latest minor) | Yes |
-| < 0.7.3 | No |
+| < 0.7.4 | No |
 
 ## Reporting a Vulnerability
 

--- a/deploy/helm/zion/Chart.yaml
+++ b/deploy/helm/zion/Chart.yaml
@@ -3,7 +3,7 @@ name: zion
 description: Zion Edge Gateway — high-performance Rust TLS reverse proxy with WAF
 type: application
 version: 0.2.2
-appVersion: "0.7.3"
+appVersion: "0.7.4"
 home: https://fabriziosalmi.github.io/zion
 sources:
   - https://github.com/fabriziosalmi/zion

--- a/deploy/helm/zion/Chart.yaml
+++ b/deploy/helm/zion/Chart.yaml
@@ -19,7 +19,7 @@ annotations:
   artifacthub.io/license: Apache-2.0
   artifacthub.io/changes: |
     - kind: changed
-      description: Bump appVersion to 0.1.11 (process hardening — version SSOT, draconian DCO, boot-panic refactor)
+      description: Bump appVersion to 0.7.4
     - kind: added
       description: ZION_AUDIT_HMAC_KEY wired from a Kubernetes Secret when [audit] is enabled
     - kind: added

--- a/docs/deploy/hot-reload.md
+++ b/docs/deploy/hot-reload.md
@@ -130,7 +130,7 @@ Two surfaces report the reload state:
 
   ```json
   {
-    "version": "0.7.3",
+    "version": "0.7.4",
     "timestamp_ms": 1714425600000,
     "uptime_secs": 3712,
     "config_generation": 5,

--- a/docs/security/supply-chain.md
+++ b/docs/security/supply-chain.md
@@ -46,8 +46,8 @@ You need the GitHub CLI (`gh >= 2.49`) and `cosign >= 2.2`.
 
 ```bash
 # 1. Download the artifact + SHA256SUMS from the release page.
-gh release download v0.7.3 -R fabriziosalmi/zion \
-    -p 'zion-v0.7.3-x86_64-unknown-linux-musl.tar.gz' \
+gh release download v0.7.4 -R fabriziosalmi/zion \
+    -p 'zion-v0.7.4-x86_64-unknown-linux-musl.tar.gz' \
     -p 'SHA256SUMS' \
     -p 'zion-sbom.cdx.json'
 
@@ -55,7 +55,7 @@ gh release download v0.7.3 -R fabriziosalmi/zion \
 sha256sum --check --ignore-missing SHA256SUMS
 
 # 3. Verify the SLSA build provenance bound to the artifact's hash.
-gh attestation verify zion-v0.7.3-x86_64-unknown-linux-musl.tar.gz \
+gh attestation verify zion-v0.7.4-x86_64-unknown-linux-musl.tar.gz \
     --owner fabriziosalmi
 
 # Step 3 fails if:
@@ -78,7 +78,7 @@ grype zion-sbom.cdx.json
 ## Verifying a container image
 
 ```bash
-IMAGE=ghcr.io/fabriziosalmi/zion:v0.7.3
+IMAGE=ghcr.io/fabriziosalmi/zion:v0.7.4
 
 # 1. Pin to the digest immediately — tags are mutable, digests are not.
 DIGEST=$(crane digest "$IMAGE")
@@ -120,7 +120,7 @@ deterministically, and pins the Rust toolchain via
 [`rust-toolchain.toml`](../../rust-toolchain.toml). To reproduce locally:
 
 ```bash
-git checkout v0.7.3
+git checkout v0.7.4
 export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)
 # Linux musl example — matches the release artifact byte-for-byte
 # (modulo strip's stable behavior on your distro).

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -72,6 +72,12 @@ sedi "/^\[package\]/,/^\[/ s/^version[[:space:]]*=[[:space:]]*\"$OLD\"/version =
 # 2. Helm chart appVersion (chart `version:` is independent and not touched)
 if [[ -f deploy/helm/zion/Chart.yaml ]]; then
   sedi "s/^appVersion:[[:space:]]*\"$OLD\"/appVersion: \"$NEW\"/" deploy/helm/zion/Chart.yaml
+  # The Artifact Hub changelog annotation names the version too, and used to be
+  # left behind: it still read "Bump appVersion to 0.1.11" at 0.7.4, publishing
+  # wrong release notes to Artifact Hub for every release in between. Rewriting
+  # appVersion while leaving its own description stale is the drift this script
+  # exists to prevent.
+  sedi "s/(description: Bump appVersion to )$OLD.*/\1$NEW/" deploy/helm/zion/Chart.yaml
 fi
 
 # 3. README + docs — rewrite vX.Y.Z occurrences of the OLD version only.

--- a/scripts/check-version-sync.sh
+++ b/scripts/check-version-sync.sh
@@ -91,6 +91,7 @@ PATTERN_CHECKS=(
   "SECURITY supported-versions|SECURITY.md|s/^\| < ([0-9]+\.[0-9]+\.[0-9]+) \| No \|.*/\1/p"
   "hot-reload.md snapshot example|docs/deploy/hot-reload.md|s/.*\"version\":[[:space:]]*\"([0-9]+\.[0-9]+\.[0-9]+)\".*/\1/p"
   "bug_report.md template default|.github/ISSUE_TEMPLATE/bug_report.md|s/.*Zion Version: \[e\.g\. ([0-9]+\.[0-9]+\.[0-9]+)\].*/\1/p"
+  "Helm chart Artifact Hub changelog|deploy/helm/zion/Chart.yaml|s/.*description: Bump appVersion to ([0-9]+\.[0-9]+\.[0-9]+).*/\1/p"
 )
 for entry in "${PATTERN_CHECKS[@]}"; do
   IFS='|' read -r label file extractor <<< "$entry"


### PR DESCRIPTION
**A stability release, cut to be held still.**

Nothing here changes runtime behaviour for an operator: no new features on the request path, no bug fixes there, no config surface. Dependency hygiene, supply-chain corrections, CI that now checks what it claims to, and one experimental scaffold that ships inert.

The reason to tag it anyway is that the next step is field validation against real sites, and that is only meaningful against a fixed point.

## What the frozen baseline contains

**Data.** Sovereign ASN/CIDR datasets refreshed (#375, #376) after the weekly job had been silently failing for six weeks. EU-27 essentially unchanged (+0.01%); the Italian set loses 0.86%, verified against IPtoASN rather than assumed — three Telecom Italia `/15` blocks currently return `AS0 — Not routed`, and one `/24` moved to `AS32787` (Prolexic, US DDoS scrubbing). Excluding both is correct: classifying unrouted space, or a US scrubbing centre, as Italian residential would be wrong. This tracks BGP, so the classification will oscillate if those prefixes are announced again.

**That weekly job repaired** (#374), four layers deep — no git identity, no DCO sign-off, missing labels, and a repo policy forbidding Actions from opening PRs (now a fine-grained PAT rather than lifting the policy for every workflow).

**A watchdog over every scheduled workflow** (#372), because the six-week failure above was invisible by construction: a failing cron blocks no merge and notifies nobody.

**`aws-lc-rs` held below 1.18.0** (#378) — that release moves the FIPS module from the validated 3.x branch (NIST #5314, #5298) to 4.x, still pending certification, while five places in this repo claim "validated".

**Supply chain**: three advisory ignores retired because they stopped applying, `cargo-vet` exemptions 422 → 395, `sovereign-aimp` down from +123 to +56 crates (#371).

## Verification

`check-version-sync.sh` OK at 0.7.4 · README stats current · full CI below.

## After merge

Tag `v0.7.4`, then hold. Worth suspending Dependabot for the validation window — if bumps keep landing while real traffic is being measured, the thing under test changes underneath the measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)