### PR TITLE
ci(dependabot): freeze version updates for the v0.7.4 validation window

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,7 +19,13 @@ updates:
       interval: "daily"
       time: "06:00"
       timezone: "Europe/Rome"
-    open-pull-requests-limit: 10
+    # FROZEN for the v0.7.4 field-validation window. `0` disables version
+    # updates for this ecosystem while leaving every `ignore` rule below
+    # intact — those encode hard-won walls (toml_parser/edition2024 at
+    # 0.9.0, tract-onnx vs the 1.88 anchor, aws-lc-rs vs the unvalidated
+    # FIPS 4.x module) and must survive the freeze. Restore the previous
+    # limits, noted inline, when validation ends.
+    open-pull-requests-limit: 0  # was 10
     labels: ["dependencies", "rust"]
     commit-message:
       prefix: "deps"
@@ -117,7 +123,13 @@ updates:
     commit-message:
       prefix: "deps(bench)"
       include: "scope"
-    open-pull-requests-limit: 5
+    # FROZEN for the v0.7.4 field-validation window. `0` disables version
+    # updates for this ecosystem while leaving every `ignore` rule below
+    # intact — those encode hard-won walls (toml_parser/edition2024 at
+    # 0.9.0, tract-onnx vs the 1.88 anchor, aws-lc-rs vs the unvalidated
+    # FIPS 4.x module) and must survive the freeze. Restore the previous
+    # limits, noted inline, when validation ends.
+    open-pull-requests-limit: 0  # was 5
 
   # ── GitHub Actions ────────────────────────────────────────────────────────
   - package-ecosystem: "github-actions"
@@ -129,7 +141,13 @@ updates:
     commit-message:
       prefix: "ci"
       include: "scope"
-    open-pull-requests-limit: 5
+    # FROZEN for the v0.7.4 field-validation window. `0` disables version
+    # updates for this ecosystem while leaving every `ignore` rule below
+    # intact — those encode hard-won walls (toml_parser/edition2024 at
+    # 0.9.0, tract-onnx vs the 1.88 anchor, aws-lc-rs vs the unvalidated
+    # FIPS 4.x module) and must survive the freeze. Restore the previous
+    # limits, noted inline, when validation ends.
+    open-pull-requests-limit: 0  # was 5
     groups:
       actions:
         applies-to: "version-updates"
@@ -145,7 +163,13 @@ updates:
     commit-message:
       prefix: "docker"
       include: "scope"
-    open-pull-requests-limit: 5
+    # FROZEN for the v0.7.4 field-validation window. `0` disables version
+    # updates for this ecosystem while leaving every `ignore` rule below
+    # intact — those encode hard-won walls (toml_parser/edition2024 at
+    # 0.9.0, tract-onnx vs the 1.88 anchor, aws-lc-rs vs the unvalidated
+    # FIPS 4.x module) and must survive the freeze. Restore the previous
+    # limits, noted inline, when validation ends.
+    open-pull-requests-limit: 0  # was 5
 
   # ── VitePress docs site ───────────────────────────────────────────────────
   - package-ecosystem: "npm"
@@ -157,5 +181,11 @@ updates:
     commit-message:
       prefix: "docs"
       include: "scope"
-    open-pull-requests-limit: 3
+    # FROZEN for the v0.7.4 field-validation window. `0` disables version
+    # updates for this ecosystem while leaving every `ignore` rule below
+    # intact — those encode hard-won walls (toml_parser/edition2024 at
+    # 0.9.0, tract-onnx vs the 1.88 anchor, aws-lc-rs vs the unvalidated
+    # FIPS 4.x module) and must survive the freeze. Restore the previous
+    # limits, noted inline, when validation ends.
+    open-pull-requests-limit: 0  # was 3
     versioning-strategy: "increase-if-necessary"


### PR DESCRIPTION
v0.7.4 was cut to be held still: the next step is validating Zion against real sites, and a measurement is only meaningful if the thing being measured stops moving. Dependency bumps landing mid-window would put an uncontrolled variable under every observation — and one already arrived (#379) while the release was being prepared.

## What this does

`open-pull-requests-limit: 0` on all five ecosystems — GitHub's documented way to disable version updates.

Chosen over deleting or commenting out the config for one reason: **it leaves the 11 `ignore` rules untouched.** Those are the most expensive knowledge in this file, and each was paid for by a failure:

| rule | why it exists |
|---|---|
| `toml >= 0.9.0` | the `toml_parser`/edition2024 wall — mis-set at 1.0.0 until 0.9.12 slipped under it and failed identically (#368) |
| `tract-onnx >= 0.23.0` | rustc 1.91, past the FULL-feature 1.88 anchor |
| `aws-lc-rs >= 1.18.0` | moves the FIPS module off the NIST-validated 3.x branch onto 4.x, still pending certification (#378) |
| `simd-json`, `dashmap`, `criterion`, `hyper-rustls` | MSRV walls |
| `rustls` / `tokio` / `hyper` / `aws-lc-rs` majors | manual crypto review |

Deleting the config to pause updates would have thrown all of that away and invited rediscovering it the hard way, twice.

## Restoring

Each limit is annotated with its previous value (`# was 10`, `# was 5`, …), so undoing the freeze is mechanical rather than archaeological.

**Security updates are unaffected** — this disables *version* updates only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)