### PR TITLE
data(sovereign): weekly EU-27 CIDR refresh (2026-08-24)

### DIFF
--- a/src/sovereign/data_eu.rs
+++ b/src/sovereign/data_eu.rs
@@ -21,7 +21,6 @@ pub static RANGES: &[CidrEntry] = &[
     // ── EU DATACENTER / CLOUD ──
     cr(0x021A8400, 0x021A84FF, IpClass::DatacenterEu),
     cr(0x021A9900, 0x021A99FF, IpClass::DatacenterEu),
-    cr(0x021AA600, 0x021AA6FF, IpClass::DatacenterEu),
     cr(0x021B6100, 0x021B61FF, IpClass::DatacenterEu),
     cr(0x021BA400, 0x021BA4FF, IpClass::DatacenterEu),
     cr(0x021C0000, 0x021DFFFF, IpClass::DatacenterEu),
@@ -280,7 +279,7 @@ pub static RANGES: &[CidrEntry] = &[
     cr(0x053F1000, 0x053F11FF, IpClass::Eu),
     cr(0x053F1400, 0x053F16FF, IpClass::Eu),
     cr(0x053F1800, 0x053F3FFF, IpClass::Eu),
-    cr(0x053F8000, 0x053F8FFF, IpClass::Eu),
+    cr(0x053F8800, 0x053F8FFF, IpClass::Eu),
     cr(0x053FA800, 0x053FFFFF, IpClass::Eu),
     // ── EU DATACENTER / CLOUD ──
     cr(0x054B8000, 0x054BFFFF, IpClass::DatacenterEu),
@@ -1284,10 +1283,7 @@ pub static RANGES: &[CidrEntry] = &[
     // ── EU-27 BASELINE (country-level) ──
     cr(0x258B4800, 0x258B4FFF, IpClass::Eu),
     cr(0x258B5800, 0x258B5FFF, IpClass::Eu),
-    cr(0x258B7800, 0x258B81FF, IpClass::Eu),
-    // ── EU DATACENTER / CLOUD ──
-    cr(0x258B8200, 0x258B82FF, IpClass::DatacenterEu),
-    // ── EU-27 BASELINE (country-level) ──
+    cr(0x258B7800, 0x258B82FF, IpClass::Eu),
     cr(0x258B8800, 0x258BBFFF, IpClass::Eu),
     cr(0x258CC800, 0x258CCFFF, IpClass::Eu),
     cr(0x258CD900, 0x258CDCFF, IpClass::Eu),
@@ -2402,7 +2398,7 @@ pub static RANGES: &[CidrEntry] = &[
     // ── EU-27 BASELINE (country-level) ──
     cr(0x2D911100, 0x2D9113FF, IpClass::Eu),
     cr(0x2D911800, 0x2D911BFF, IpClass::Eu),
-    cr(0x2D912000, 0x2D9125FF, IpClass::Eu),
+    cr(0x2D912400, 0x2D9125FF, IpClass::Eu),
     cr(0x2D912700, 0x2D912FFF, IpClass::Eu),
     cr(0x2D915000, 0x2D9153FF, IpClass::Eu),
     cr(0x2D915C00, 0x2D9163FF, IpClass::Eu),
@@ -2536,8 +2532,10 @@ pub static RANGES: &[CidrEntry] = &[
     cr(0x2D976700, 0x2D9767FF, IpClass::DatacenterEu),
     cr(0x2D976900, 0x2D9769FF, IpClass::DatacenterEu),
     cr(0x2D976B00, 0x2D976BFF, IpClass::DatacenterEu),
+    // ── EU RESIDENTIAL ISPs ──
+    cr(0x2D977000, 0x2D9773FF, IpClass::ResidentialEu),
     // ── EU-27 BASELINE (country-level) ──
-    cr(0x2D977000, 0x2D9779FF, IpClass::Eu),
+    cr(0x2D977400, 0x2D9779FF, IpClass::Eu),
     // ── EU DATACENTER / CLOUD ──
     cr(0x2D977A00, 0x2D977BFF, IpClass::DatacenterEu),
     // ── EU-27 BASELINE (country-level) ──
@@ -2658,7 +2656,11 @@ pub static RANGES: &[CidrEntry] = &[
     cr(0x2D9CD000, 0x2D9CD3FF, IpClass::Eu),
     cr(0x2D9CE400, 0x2D9CF7FF, IpClass::Eu),
     cr(0x2D9CFC00, 0x2D9CFFFF, IpClass::Eu),
-    cr(0x2D9D0400, 0x2D9D23FF, IpClass::Eu),
+    cr(0x2D9D0400, 0x2D9D1FFF, IpClass::Eu),
+    // ── EU RESIDENTIAL ISPs ──
+    cr(0x2D9D2000, 0x2D9D21FF, IpClass::ResidentialEu),
+    // ── EU-27 BASELINE (country-level) ──
+    cr(0x2D9D2200, 0x2D9D23FF, IpClass::Eu),
     // ── EU DATACENTER / CLOUD ──
     cr(0x2D9D2400, 0x2D9D24FF, IpClass::DatacenterEu),
     cr(0x2D9D2600, 0x2D9D27FF, IpClass::DatacenterEu),
@@ -2723,7 +2725,11 @@ pub static RANGES: &[CidrEntry] = &[
     cr(0x2D9F9C00, 0x2D9F9FFF, IpClass::Eu),
     cr(0x2D9FA400, 0x2D9FB3FF, IpClass::Eu),
     cr(0x2D9FB500, 0x2D9FB5FF, IpClass::Eu),
-    cr(0x2D9FBC00, 0x2D9FC3FF, IpClass::Eu),
+    cr(0x2D9FBC00, 0x2D9FBFFF, IpClass::Eu),
+    // ── EU RESIDENTIAL ISPs ──
+    cr(0x2D9FC000, 0x2D9FC1FF, IpClass::ResidentialEu),
+    // ── EU-27 BASELINE (country-level) ──
+    cr(0x2D9FC200, 0x2D9FC3FF, IpClass::Eu),
     // ── EU DATACENTER / CLOUD ──
     cr(0x2D9FCC00, 0x2D9FCFFF, IpClass::DatacenterEu),
     // ── EU-27 BASELINE (country-level) ──
@@ -3280,6 +3286,7 @@ pub static RANGES: &[CidrEntry] = &[
     // ── EU DATACENTER / CLOUD ──
     cr(0x33F10100, 0x33F101FF, IpClass::DatacenterEu),
     // ── EU RESIDENTIAL ISPs ──
+    cr(0x33F11200, 0x33F112FF, IpClass::ResidentialEu),
     cr(0x33F15600, 0x33F156FF, IpClass::ResidentialEu),
     cr(0x33F1E400, 0x33F1E7FF, IpClass::ResidentialEu),
     // ── EU DATACENTER / CLOUD ──
@@ -4075,6 +4082,7 @@ pub static RANGES: &[CidrEntry] = &[
     cr(0x4D57B800, 0x4D57BFFF, IpClass::Eu),
     cr(0x4D57D800, 0x4D57FFFF, IpClass::Eu),
     cr(0x4D588000, 0x4D58BFFF, IpClass::Eu),
+    cr(0x4D58E000, 0x4D58EFFF, IpClass::Eu),
     cr(0x4D590000, 0x4D597FFF, IpClass::Eu),
     cr(0x4D5A0000, 0x4D5ABFFF, IpClass::Eu),
     cr(0x4D5B0000, 0x4D5B3FFF, IpClass::Eu),
@@ -4809,6 +4817,9 @@ pub static RANGES: &[CidrEntry] = &[
     cr(0x50560000, 0x50560FFF, IpClass::Eu),
     cr(0x50563000, 0x50567FFF, IpClass::Eu),
     cr(0x50569000, 0x5056BFFF, IpClass::Eu),
+    // ── EU DATACENTER / CLOUD ──
+    cr(0x5056D300, 0x5056D3FF, IpClass::DatacenterEu),
+    // ── EU-27 BASELINE (country-level) ──
     cr(0x5056F000, 0x5056FFFF, IpClass::Eu),
     cr(0x50572000, 0x50573FFF, IpClass::Eu),
     cr(0x50577000, 0x50577FFF, IpClass::Eu),
@@ -4922,7 +4933,8 @@ pub static RANGES: &[CidrEntry] = &[
     cr(0x509FE000, 0x50A7FFFF, IpClass::Eu),
     cr(0x50AA0000, 0x50AD8FFF, IpClass::Eu),
     cr(0x50AD9800, 0x50AD9FFF, IpClass::Eu),
-    cr(0x50ADAC00, 0x50ADBFFF, IpClass::Eu),
+    cr(0x50ADAC00, 0x50ADAEFF, IpClass::Eu),
+    cr(0x50ADB000, 0x50ADBFFF, IpClass::Eu),
     cr(0x50ADC800, 0x50ADCBFF, IpClass::Eu),
     cr(0x50ADD000, 0x50ADE3FF, IpClass::Eu),
     cr(0x50AE0000, 0x50AEFFFF, IpClass::Eu),
@@ -5606,9 +5618,6 @@ pub static RANGES: &[CidrEntry] = &[
     cr(0x5229F400, 0x5229F4FF, IpClass::ResidentialEu),
     cr(0x522F0E00, 0x522F10FF, IpClass::ResidentialEu),
     cr(0x522F1B00, 0x522F1BFF, IpClass::ResidentialEu),
-    // ── EU DATACENTER / CLOUD ──
-    cr(0x522F2400, 0x522F25FF, IpClass::DatacenterEu),
-    // ── EU RESIDENTIAL ISPs ──
     cr(0x522F3B00, 0x522F3BFF, IpClass::ResidentialEu),
     // ── EU DATACENTER / CLOUD ──
     cr(0x522F3F00, 0x522F3FFF, IpClass::DatacenterEu),
@@ -5672,6 +5681,7 @@ pub static RANGES: &[CidrEntry] = &[
     // ── EU RESIDENTIAL ISPs ──
     cr(0x52680000, 0x526BFFFF, IpClass::ResidentialEu),
     cr(0x526C6800, 0x526C6BFF, IpClass::ResidentialEu),
+    cr(0x526D9C00, 0x526D9CFF, IpClass::ResidentialEu),
     // ── EU-27 BASELINE (country-level) ──
     cr(0x5270A800, 0x5270AFFF, IpClass::Eu),
     cr(0x5270E000, 0x5270FFFF, IpClass::Eu),
@@ -5761,6 +5771,7 @@ pub static RANGES: &[CidrEntry] = &[
     cr(0x52986200, 0x529862FF, IpClass::DatacenterEu),
     cr(0x52986D00, 0x52986DFF, IpClass::DatacenterEu),
     cr(0x5298C500, 0x5298C5FF, IpClass::DatacenterEu),
+    cr(0x5298C800, 0x5298C8FF, IpClass::DatacenterEu),
     cr(0x5298D300, 0x5298D3FF, IpClass::DatacenterEu),
     cr(0x5298E200, 0x5298E2FF, IpClass::DatacenterEu),
     cr(0x5298F000, 0x5298F0FF, IpClass::DatacenterEu),
@@ -5873,7 +5884,8 @@ pub static RANGES: &[CidrEntry] = &[
     cr(0x5344E000, 0x5344FFFF, IpClass::Eu),
     cr(0x53452000, 0x53453FFF, IpClass::Eu),
     cr(0x53460000, 0x534BFFFF, IpClass::Eu),
-    cr(0x53500000, 0x535FFFFF, IpClass::Eu),
+    cr(0x53500000, 0x535E3FFF, IpClass::Eu),
+    cr(0x535E6000, 0x535FFFFF, IpClass::Eu),
     cr(0x53608000, 0x5360FFFF, IpClass::Eu),
     cr(0x53610800, 0x53610FFF, IpClass::Eu),
     cr(0x53611400, 0x53611FFF, IpClass::Eu),
@@ -6367,7 +6379,11 @@ pub static RANGES: &[CidrEntry] = &[
     cr(0x555C6800, 0x555C6BFF, IpClass::Eu),
     cr(0x555C7700, 0x555C77FF, IpClass::Eu),
     cr(0x555C7C00, 0x555C9FFF, IpClass::Eu),
-    cr(0x555D0000, 0x555D1FFF, IpClass::Eu),
+    cr(0x555D0000, 0x555D13FF, IpClass::Eu),
+    // ── EU DATACENTER / CLOUD ──
+    cr(0x555D1400, 0x555D14FF, IpClass::DatacenterEu),
+    // ── EU-27 BASELINE (country-level) ──
+    cr(0x555D1500, 0x555D1FFF, IpClass::Eu),
     cr(0x555D4000, 0x555D7FFF, IpClass::Eu),
     cr(0x555DA000, 0x555DDFFF, IpClass::Eu),
     cr(0x555E4000, 0x555E5FFF, IpClass::Eu),
@@ -6429,7 +6445,7 @@ pub static RANGES: &[CidrEntry] = &[
     cr(0x55891F00, 0x55891FFF, IpClass::Eu),
     cr(0x55895200, 0x558957FF, IpClass::Eu),
     cr(0x5589A400, 0x5589B5FF, IpClass::Eu),
-    cr(0x5589B700, 0x5589D5FF, IpClass::Eu),
+    cr(0x5589B700, 0x5589D3FF, IpClass::Eu),
     cr(0x5589D700, 0x5589D7FF, IpClass::Eu),
     cr(0x5589DC00, 0x5589DFFF, IpClass::Eu),
     cr(0x5589E800, 0x5589EDFF, IpClass::Eu),
@@ -6443,7 +6459,8 @@ pub static RANGES: &[CidrEntry] = &[
     cr(0x559B6800, 0x559B6BFF, IpClass::Eu),
     cr(0x559B7400, 0x559B77FF, IpClass::Eu),
     cr(0x559B9C00, 0x559BA7FF, IpClass::Eu),
-    cr(0x559BAC00, 0x559BDFFF, IpClass::Eu),
+    cr(0x559BAC00, 0x559BBFFF, IpClass::Eu),
+    cr(0x559BD000, 0x559BDFFF, IpClass::Eu),
     cr(0x559BE800, 0x559E0BFF, IpClass::Eu),
     cr(0x559E1000, 0x559E17FF, IpClass::Eu),
     cr(0x559E4800, 0x559E4FFF, IpClass::Eu),
@@ -6871,6 +6888,7 @@ pub static RANGES: &[CidrEntry] = &[
     // ── EU-27 BASELINE (country-level) ──
     cr(0x574E0000, 0x574FFFFF, IpClass::Eu),
     // ── EU RESIDENTIAL ISPs ──
+    cr(0x57537200, 0x575372FF, IpClass::ResidentialEu),
     cr(0x57560800, 0x57560BFF, IpClass::ResidentialEu),
     cr(0x57565200, 0x575655FF, IpClass::ResidentialEu),
     // ── EU DATACENTER / CLOUD ──
@@ -6930,7 +6948,7 @@ pub static RANGES: &[CidrEntry] = &[
     // ── EU RESIDENTIAL ISPs ──
     cr(0x57800000, 0x57BFFFFF, IpClass::ResidentialEu),
     // ── EU-27 BASELINE (country-level) ──
-    cr(0x57C00000, 0x57C057FF, IpClass::Eu),
+    cr(0x57C04000, 0x57C057FF, IpClass::Eu),
     cr(0x57C08000, 0x57C0CFFF, IpClass::Eu),
     cr(0x57C0D800, 0x57C0DFFF, IpClass::Eu),
     cr(0x57C10000, 0x57C1FFFF, IpClass::Eu),
@@ -7621,8 +7639,11 @@ pub static RANGES: &[CidrEntry] = &[
     cr(0x597DAC00, 0x597DACFF, IpClass::DatacenterEu),
     // ── EU-27 BASELINE (country-level) ──
     cr(0x597E0000, 0x597E7FFF, IpClass::Eu),
-    cr(0x597EC000, 0x597ECFFF, IpClass::Eu),
-    cr(0x597EE000, 0x597EF7FF, IpClass::Eu),
+    cr(0x597EE000, 0x597EE8FF, IpClass::Eu),
+    // ── EU DATACENTER / CLOUD ──
+    cr(0x597EE900, 0x597EE9FF, IpClass::DatacenterEu),
+    // ── EU-27 BASELINE (country-level) ──
+    cr(0x597EEA00, 0x597EF7FF, IpClass::Eu),
     cr(0x597F0000, 0x597F7FFF, IpClass::Eu),
     cr(0x597FC000, 0x597FDFFF, IpClass::Eu),
     cr(0x597FEC00, 0x597FEFFF, IpClass::Eu),
@@ -7687,7 +7708,8 @@ pub static RANGES: &[CidrEntry] = &[
     cr(0x59BCC000, 0x59BCDFFF, IpClass::Eu),
     cr(0x59BD2000, 0x59BD3FFF, IpClass::Eu),
     cr(0x59BDC000, 0x59BDDFFF, IpClass::Eu),
-    cr(0x59BE0000, 0x59BE83FF, IpClass::Eu),
+    cr(0x59BE0000, 0x59BE5FFF, IpClass::Eu),
+    cr(0x59BE8000, 0x59BE83FF, IpClass::Eu),
     cr(0x59BE8800, 0x59BE8FFF, IpClass::Eu),
     cr(0x59BE9400, 0x59BE9BFF, IpClass::Eu),
     cr(0x59BEA000, 0x59BEDFFF, IpClass::Eu),
@@ -7714,6 +7736,9 @@ pub static RANGES: &[CidrEntry] = &[
     cr(0x59CFF000, 0x59CFF7FF, IpClass::Eu),
     cr(0x59D20000, 0x59D2FFFF, IpClass::Eu),
     cr(0x59D40000, 0x59D4FFFF, IpClass::Eu),
+    // ── EU DATACENTER / CLOUD ──
+    cr(0x59D54300, 0x59D543FF, IpClass::DatacenterEu),
+    // ── EU-27 BASELINE (country-level) ──
     cr(0x59D60000, 0x59D7FFFF, IpClass::Eu),
     cr(0x59DB0000, 0x59DB03FF, IpClass::Eu),
     cr(0x59DB8000, 0x59DB83FF, IpClass::Eu),
@@ -7843,13 +7868,9 @@ pub static RANGES: &[CidrEntry] = &[
     // ── EU-27 BASELINE (country-level) ──
     cr(0x5A552700, 0x5A5527FF, IpClass::Eu),
     // ── EU RESIDENTIAL ISPs ──
-    cr(0x5A552800, 0x5A55FFFF, IpClass::ResidentialEu),
+    cr(0x5A552800, 0x5A58BFFF, IpClass::ResidentialEu),
     // ── EU-27 BASELINE (country-level) ──
-    cr(0x5A560000, 0x5A56FFFF, IpClass::Eu),
-    // ── EU RESIDENTIAL ISPs ──
-    cr(0x5A570000, 0x5A57FFFF, IpClass::ResidentialEu),
-    // ── EU-27 BASELINE (country-level) ──
-    cr(0x5A580000, 0x5A58FFFF, IpClass::Eu),
+    cr(0x5A58C000, 0x5A58FFFF, IpClass::Eu),
     // ── EU RESIDENTIAL ISPs ──
     cr(0x5A590000, 0x5A5DFFFF, IpClass::ResidentialEu),
     // ── EU-27 BASELINE (country-level) ──
@@ -7902,9 +7923,9 @@ pub static RANGES: &[CidrEntry] = &[
     cr(0x5B5A3000, 0x5B5A3FFF, IpClass::Eu),
     cr(0x5B5A4800, 0x5B5A57FF, IpClass::Eu),
     // ── EU DATACENTER / CLOUD ──
-    cr(0x5B5A5800, 0x5B5A5FFF, IpClass::DatacenterEu),
+    cr(0x5B5A5800, 0x5B5A5EFF, IpClass::DatacenterEu),
     // ── EU-27 BASELINE (country-level) ──
-    cr(0x5B5A6000, 0x5B5A67FF, IpClass::Eu),
+    cr(0x5B5A5F00, 0x5B5A67FF, IpClass::Eu),
     cr(0x5B5A7000, 0x5B5A7FFF, IpClass::Eu),
     cr(0x5B5A9000, 0x5B5AA1FF, IpClass::Eu),
     cr(0x5B5AA400, 0x5B5AA5FF, IpClass::Eu),
@@ -8633,6 +8654,7 @@ pub static RANGES: &[CidrEntry] = &[
     cr(0x5BD08700, 0x5BD087FF, IpClass::Eu),
     cr(0x5BD08900, 0x5BD089FF, IpClass::Eu),
     cr(0x5BD08E00, 0x5BD08FFF, IpClass::Eu),
+    cr(0x5BD09200, 0x5BD092FF, IpClass::Eu),
     cr(0x5BD09600, 0x5BD098FF, IpClass::Eu),
     cr(0x5BD09B00, 0x5BD09BFF, IpClass::Eu),
     cr(0x5BD09D00, 0x5BD0A0FF, IpClass::Eu),
@@ -10560,7 +10582,8 @@ pub static RANGES: &[CidrEntry] = &[
     cr(0x5D9EE800, 0x5D9EEBFF, IpClass::Eu),
     cr(0x5D9F0000, 0x5D9FBFFF, IpClass::Eu),
     cr(0x5D9FD000, 0x5D9FD7FF, IpClass::Eu),
-    cr(0x5D9FF800, 0x5DA7FFFF, IpClass::Eu),
+    cr(0x5D9FF800, 0x5DA53FFF, IpClass::Eu),
+    cr(0x5DA56000, 0x5DA7FFFF, IpClass::Eu),
     cr(0x5DAA0000, 0x5DABFFFF, IpClass::Eu),
     cr(0x5DAE0000, 0x5DAE07FF, IpClass::Eu),
     cr(0x5DAE1800, 0x5DAE2FFF, IpClass::Eu),
@@ -10587,7 +10610,8 @@ pub static RANGES: &[CidrEntry] = &[
     cr(0x5DB32000, 0x5DB33FFF, IpClass::Eu),
     cr(0x5DB38000, 0x5DB3FFFF, IpClass::Eu),
     cr(0x5DB44000, 0x5DB457FF, IpClass::Eu),
-    cr(0x5DB48000, 0x5DB482FF, IpClass::Eu),
+    cr(0x5DB48000, 0x5DB480FF, IpClass::Eu),
+    cr(0x5DB48200, 0x5DB482FF, IpClass::Eu),
     cr(0x5DB49800, 0x5DB4BFFF, IpClass::Eu),
     cr(0x5DB4D400, 0x5DB4D7FF, IpClass::Eu),
     cr(0x5DB4F000, 0x5DB5BFFF, IpClass::Eu),
@@ -10812,6 +10836,7 @@ pub static RANGES: &[CidrEntry] = &[
     // ── EU-27 BASELINE (country-level) ──
     cr(0x5E831000, 0x5E8313FF, IpClass::Eu),
     cr(0x5E833000, 0x5E8333FF, IpClass::Eu),
+    cr(0x5E833600, 0x5E8336FF, IpClass::Eu),
     cr(0x5E83C000, 0x5E83DFFF, IpClass::Eu),
     cr(0x5E840000, 0x5E88A7FF, IpClass::Eu),
     cr(0x5E88AC00, 0x5E88BFFF, IpClass::Eu),
@@ -11177,7 +11202,7 @@ pub static RANGES: &[CidrEntry] = &[
     cr(0x5F8DF000, 0x5F8DF3FF, IpClass::Eu),
     cr(0x5F8DF600, 0x5F8DF7FF, IpClass::Eu),
     cr(0x5F8DFA00, 0x5F8DFAFF, IpClass::Eu),
-    cr(0x5F8DFD00, 0x5F8E0FFF, IpClass::Eu),
+    cr(0x5F8DFE00, 0x5F8E0FFF, IpClass::Eu),
     cr(0x5F8E3000, 0x5F8E4FFF, IpClass::Eu),
     cr(0x5F8E6000, 0x5F8E7FFF, IpClass::Eu),
     cr(0x5F8E9500, 0x5F8E95FF, IpClass::Eu),
@@ -11529,9 +11554,11 @@ pub static RANGES: &[CidrEntry] = &[
     cr(0x68DEB600, 0x68DEB6FF, IpClass::DatacenterEu),
     cr(0x68E1FD00, 0x68E1FDFF, IpClass::DatacenterEu),
     cr(0x68EA3200, 0x68EA32FF, IpClass::DatacenterEu),
-    cr(0x68EA5E00, 0x68EA5EFF, IpClass::DatacenterEu),
+    cr(0x68EA3C00, 0x68EA3CFF, IpClass::DatacenterEu),
+    cr(0x68EA5E00, 0x68EA5FFF, IpClass::DatacenterEu),
     cr(0x68EA8700, 0x68EA87FF, IpClass::DatacenterEu),
     cr(0x68EAA800, 0x68EAA8FF, IpClass::DatacenterEu),
+    cr(0x68EAC600, 0x68EAC6FF, IpClass::DatacenterEu),
     // ── EU-27 BASELINE (country-level) ──
     cr(0x68EF3C00, 0x68EF3FFF, IpClass::Eu),
     // ── EU DATACENTER / CLOUD ──
@@ -11588,7 +11615,11 @@ pub static RANGES: &[CidrEntry] = &[
     cr(0x6D45B800, 0x6D45E7FF, IpClass::Eu),
     cr(0x6D45F000, 0x6D4608FF, IpClass::Eu),
     // ── EU DATACENTER / CLOUD ──
-    cr(0x6D460900, 0x6D460FFF, IpClass::DatacenterEu),
+    cr(0x6D460900, 0x6D4609FF, IpClass::DatacenterEu),
+    // ── EU-27 BASELINE (country-level) ──
+    cr(0x6D460A00, 0x6D460BFF, IpClass::Eu),
+    // ── EU DATACENTER / CLOUD ──
+    cr(0x6D460C00, 0x6D460FFF, IpClass::DatacenterEu),
     // ── EU-27 BASELINE (country-level) ──
     cr(0x6D461000, 0x6D4617FF, IpClass::Eu),
     cr(0x6D462000, 0x6D4627FF, IpClass::Eu),
@@ -11667,7 +11698,7 @@ pub static RANGES: &[CidrEntry] = &[
     cr(0x6D687100, 0x6D6871FF, IpClass::Eu),
     cr(0x6D689200, 0x6D6893FF, IpClass::Eu),
     cr(0x6D68C000, 0x6D693FFF, IpClass::Eu),
-    cr(0x6D696000, 0x6D699FFF, IpClass::Eu),
+    cr(0x6D696000, 0x6D697FFF, IpClass::Eu),
     // ── EU DATACENTER / CLOUD ──
     cr(0x6D69C300, 0x6D69C3FF, IpClass::DatacenterEu),
     // ── EU-27 BASELINE (country-level) ──
@@ -12102,6 +12133,7 @@ pub static RANGES: &[CidrEntry] = &[
     // ── EU-27 BASELINE (country-level) ──
     cr(0x824E0000, 0x824E5FFF, IpClass::Eu),
     cr(0x824E7800, 0x824EAFFF, IpClass::Eu),
+    cr(0x824EB100, 0x824EB1FF, IpClass::Eu),
     cr(0x824EB800, 0x824ED7FF, IpClass::Eu),
     cr(0x824EDC00, 0x824FFFFF, IpClass::Eu),
     cr(0x82530000, 0x8254FFFF, IpClass::Eu),
@@ -12460,6 +12492,8 @@ pub static RANGES: &[CidrEntry] = &[
     cr(0x88901600, 0x889023FF, IpClass::Eu),
     cr(0x88902800, 0x88902FFF, IpClass::Eu),
     cr(0x88906000, 0x8890FFFF, IpClass::Eu),
+    cr(0x88948000, 0x889483FF, IpClass::Eu),
+    cr(0x88948C00, 0x88948FFF, IpClass::Eu),
     cr(0x8894D000, 0x8894DFFF, IpClass::Eu),
     cr(0x889B0000, 0x889BFFFF, IpClass::Eu),
     // ── EU GOVERNMENT / RESEARCH ──
@@ -12476,7 +12510,7 @@ pub static RANGES: &[CidrEntry] = &[
     cr(0x88ADD300, 0x88ADD4FF, IpClass::ResidentialEu),
     // ── EU-27 BASELINE (country-level) ──
     cr(0x88ADD500, 0x88ADFFFF, IpClass::Eu),
-    cr(0x88B0A000, 0x88B0BFFF, IpClass::Eu),
+    cr(0x88B0A000, 0x88B0DFFF, IpClass::Eu),
     cr(0x88C70000, 0x88C7FFFF, IpClass::Eu),
     cr(0x88C90000, 0x88C9FFFF, IpClass::Eu),
     cr(0x88CE0000, 0x88CEFFFF, IpClass::Eu),
@@ -12671,7 +12705,8 @@ pub static RANGES: &[CidrEntry] = &[
     // ── EU DATACENTER / CLOUD ──
     cr(0x8B630000, 0x8B63FFFF, IpClass::DatacenterEu),
     // ── EU-27 BASELINE (country-level) ──
-    cr(0x8B640200, 0x8B641FFF, IpClass::Eu),
+    cr(0x8B640200, 0x8B640FFF, IpClass::Eu),
+    cr(0x8B641200, 0x8B641FFF, IpClass::Eu),
     cr(0x8B646200, 0x8B6462FF, IpClass::Eu),
     cr(0x8B64B000, 0x8B64BFFF, IpClass::Eu),
     cr(0x8B7A0000, 0x8B7CFFFF, IpClass::Eu),
@@ -12754,7 +12789,11 @@ pub static RANGES: &[CidrEntry] = &[
     // ── EU DATACENTER / CLOUD ──
     cr(0x8D0B2D00, 0x8D0B2DFF, IpClass::DatacenterEu),
     // ── EU-27 BASELINE (country-level) ──
-    cr(0x8D0B2E00, 0x8D0B49FF, IpClass::Eu),
+    cr(0x8D0B2E00, 0x8D0B30FF, IpClass::Eu),
+    // ── EU DATACENTER / CLOUD ──
+    cr(0x8D0B3100, 0x8D0B31FF, IpClass::DatacenterEu),
+    // ── EU-27 BASELINE (country-level) ──
+    cr(0x8D0B3200, 0x8D0B49FF, IpClass::Eu),
     // ── EU DATACENTER / CLOUD ──
     cr(0x8D0B4A00, 0x8D0B4BFF, IpClass::DatacenterEu),
     // ── EU-27 BASELINE (country-level) ──
@@ -13057,6 +13096,7 @@ pub static RANGES: &[CidrEntry] = &[
     cr(0x8E848000, 0x8E84FFFF, IpClass::DatacenterEu),
     // ── EU-27 BASELINE (country-level) ──
     cr(0x8EDD0000, 0x8EDDFFFF, IpClass::Eu),
+    cr(0x8EE43400, 0x8EE437FF, IpClass::Eu),
     cr(0x8EEA2000, 0x8EEA27FF, IpClass::Eu),
     // ── EU DATACENTER / CLOUD ──
     cr(0x8EF95C00, 0x8EF95CFF, IpClass::DatacenterEu),
@@ -13578,7 +13618,11 @@ pub static RANGES: &[CidrEntry] = &[
     // ── EU RESIDENTIAL ISPs ──
     cr(0x935A7000, 0x935A70FF, IpClass::ResidentialEu),
     // ── EU-27 BASELINE (country-level) ──
-    cr(0x935A7100, 0x935AFFFF, IpClass::Eu),
+    cr(0x935A7100, 0x935ABBFF, IpClass::Eu),
+    // ── EU DATACENTER / CLOUD ──
+    cr(0x935ABC00, 0x935ABCFF, IpClass::DatacenterEu),
+    // ── EU-27 BASELINE (country-level) ──
+    cr(0x935ABD00, 0x935AFFFF, IpClass::Eu),
     cr(0x935D0000, 0x935D96FF, IpClass::Eu),
     // ── EU DATACENTER / CLOUD ──
     cr(0x935D9700, 0x935D97FF, IpClass::DatacenterEu),
@@ -13763,6 +13807,7 @@ pub static RANGES: &[CidrEntry] = &[
     cr(0x959AC000, 0x959AFFFF, IpClass::Eu),
     cr(0x959C0000, 0x959DFFFF, IpClass::Eu),
     cr(0x95AA3A00, 0x95AA3BFF, IpClass::Eu),
+    cr(0x95AA9000, 0x95AA91FF, IpClass::Eu),
     // ── EU RESIDENTIAL ISPs ──
     cr(0x95AC0000, 0x95ACFFFF, IpClass::ResidentialEu),
     // ── EU-27 BASELINE (country-level) ──
@@ -13847,6 +13892,7 @@ pub static RANGES: &[CidrEntry] = &[
     // ── EU-27 BASELINE (country-level) ──
     cr(0x96E30000, 0x96E3FFFF, IpClass::Eu),
     cr(0x96EC0000, 0x96ECFFFF, IpClass::Eu),
+    cr(0x96ED4000, 0x96ED7FFF, IpClass::Eu),
     cr(0x96F10000, 0x96F13FFF, IpClass::Eu),
     // ── EU RESIDENTIAL ISPs ──
     cr(0x96F1C000, 0x96F1C3FF, IpClass::ResidentialEu),
@@ -13903,6 +13949,7 @@ pub static RANGES: &[CidrEntry] = &[
     // ── EU-27 BASELINE (country-level) ──
     cr(0x97D80400, 0x97D804FF, IpClass::Eu),
     cr(0x97D80600, 0x97D806FF, IpClass::Eu),
+    cr(0x97D87000, 0x97D87BFF, IpClass::Eu),
     cr(0x97EC0000, 0x97EC1FFF, IpClass::Eu),
     cr(0x97EC8000, 0x97EC9FFF, IpClass::Eu),
     cr(0x97ECC800, 0x97ECCFFF, IpClass::Eu),
@@ -14027,7 +14074,6 @@ pub static RANGES: &[CidrEntry] = &[
     cr(0x99347400, 0x993474FF, IpClass::DatacenterEu),
     // ── EU-27 BASELINE (country-level) ──
     cr(0x99347500, 0x99347FFF, IpClass::Eu),
-    cr(0x99388400, 0x993887FF, IpClass::Eu),
     cr(0x99388F00, 0x99388FFF, IpClass::Eu),
     cr(0x99389500, 0x993895FF, IpClass::Eu),
     cr(0x9938AB00, 0x9938ABFF, IpClass::Eu),
@@ -14038,6 +14084,7 @@ pub static RANGES: &[CidrEntry] = &[
     cr(0x994C2000, 0x994C3FFF, IpClass::Eu),
     cr(0x994CB000, 0x994CB1FF, IpClass::Eu),
     cr(0x994CB400, 0x994CBFFF, IpClass::Eu),
+    cr(0x994CE000, 0x994CE7FF, IpClass::Eu),
     cr(0x994CFC00, 0x994CFFFF, IpClass::Eu),
     cr(0x99580000, 0x9958FFFF, IpClass::Eu),
     cr(0x995C0000, 0x995C28FF, IpClass::Eu),
@@ -14195,6 +14242,7 @@ pub static RANGES: &[CidrEntry] = &[
     cr(0x9B730000, 0x9B73FFFF, IpClass::Eu),
     // ── EU DATACENTER / CLOUD ──
     cr(0x9B750500, 0x9B7506FF, IpClass::DatacenterEu),
+    cr(0x9B750B00, 0x9B750BFF, IpClass::DatacenterEu),
     cr(0x9B750D00, 0x9B750DFF, IpClass::DatacenterEu),
     cr(0x9B757F00, 0x9B757FFF, IpClass::DatacenterEu),
     cr(0x9B75C500, 0x9B75C5FF, IpClass::DatacenterEu),
@@ -14272,15 +14320,7 @@ pub static RANGES: &[CidrEntry] = &[
     // ── EU RESIDENTIAL ISPs ──
     cr(0x9C367000, 0x9C3673FF, IpClass::ResidentialEu),
     // ── EU-27 BASELINE (country-level) ──
-    cr(0x9C367400, 0x9C36C8FF, IpClass::Eu),
-    // ── EU RESIDENTIAL ISPs ──
-    cr(0x9C36C900, 0x9C36C9FF, IpClass::ResidentialEu),
-    // ── EU-27 BASELINE (country-level) ──
-    cr(0x9C36CA00, 0x9C36FAFF, IpClass::Eu),
-    // ── EU RESIDENTIAL ISPs ──
-    cr(0x9C36FB00, 0x9C36FBFF, IpClass::ResidentialEu),
-    // ── EU-27 BASELINE (country-level) ──
-    cr(0x9C36FC00, 0x9C36FFFF, IpClass::Eu),
+    cr(0x9C367400, 0x9C36FFFF, IpClass::Eu),
     cr(0x9C3A0000, 0x9C3AFFFF, IpClass::Eu),
     cr(0x9C430000, 0x9C4307FF, IpClass::Eu),
     cr(0x9C430C00, 0x9C4317FF, IpClass::Eu),
@@ -14315,6 +14355,30 @@ pub static RANGES: &[CidrEntry] = &[
     cr(0x9D5A0000, 0x9D5AFFFF, IpClass::DatacenterEu),
     // ── EU-27 BASELINE (country-level) ──
     cr(0x9D5E0000, 0x9D5EFFFF, IpClass::Eu),
+    cr(0x9D600800, 0x9D6008FF, IpClass::Eu),
+    cr(0x9D600C00, 0x9D600DFF, IpClass::Eu),
+    cr(0x9D601000, 0x9D6013FF, IpClass::Eu),
+    cr(0x9D601600, 0x9D6016FF, IpClass::Eu),
+    cr(0x9D601800, 0x9D6019FF, IpClass::Eu),
+    cr(0x9D602000, 0x9D6020FF, IpClass::Eu),
+    cr(0x9D602200, 0x9D6023FF, IpClass::Eu),
+    cr(0x9D602700, 0x9D6027FF, IpClass::Eu),
+    cr(0x9D602900, 0x9D6029FF, IpClass::Eu),
+    cr(0x9D602B00, 0x9D602EFF, IpClass::Eu),
+    cr(0x9D603C00, 0x9D603CFF, IpClass::Eu),
+    cr(0x9D603E00, 0x9D603EFF, IpClass::Eu),
+    cr(0x9D604100, 0x9D6042FF, IpClass::Eu),
+    cr(0x9D604F00, 0x9D604FFF, IpClass::Eu),
+    cr(0x9D605100, 0x9D6051FF, IpClass::Eu),
+    cr(0x9D605800, 0x9D6058FF, IpClass::Eu),
+    cr(0x9D605C00, 0x9D605DFF, IpClass::Eu),
+    cr(0x9D606000, 0x9D6073FF, IpClass::Eu),
+    cr(0x9D607C00, 0x9D607FFF, IpClass::Eu),
+    cr(0x9D609800, 0x9D609BFF, IpClass::Eu),
+    cr(0x9D60A000, 0x9D60A7FF, IpClass::Eu),
+    cr(0x9D60B000, 0x9D60B3FF, IpClass::Eu),
+    cr(0x9D60C000, 0x9D60F3FF, IpClass::Eu),
+    cr(0x9D60F800, 0x9D60FBFF, IpClass::Eu),
     cr(0x9D612000, 0x9D6160FF, IpClass::Eu),
     // ── EU DATACENTER / CLOUD ──
     cr(0x9D616800, 0x9D616FFF, IpClass::DatacenterEu),
@@ -14351,6 +14415,7 @@ pub static RANGES: &[CidrEntry] = &[
     cr(0x9DBE0000, 0x9DBEFFFF, IpClass::Eu),
     cr(0x9DC10000, 0x9DC1FFFF, IpClass::Eu),
     cr(0x9DC80000, 0x9DC8FFFF, IpClass::Eu),
+    cr(0x9DE4C000, 0x9DE4FFFF, IpClass::Eu),
     cr(0x9DEF8000, 0x9DEF81FF, IpClass::Eu),
     // ── EU RESIDENTIAL ISPs ──
     cr(0x9DF70000, 0x9DF701FF, IpClass::ResidentialEu),
@@ -14506,6 +14571,7 @@ pub static RANGES: &[CidrEntry] = &[
     cr(0x9FC10000, 0x9FC1FFFF, IpClass::Eu),
     cr(0x9FC30000, 0x9FC3FFFF, IpClass::Eu),
     cr(0x9FC8CE00, 0x9FC8CFFF, IpClass::Eu),
+    cr(0x9FC8E600, 0x9FC8E7FF, IpClass::Eu),
     cr(0x9FC8F000, 0x9FC8F3FF, IpClass::Eu),
     cr(0x9FCD0000, 0x9FCDFFFF, IpClass::Eu),
     cr(0x9FD20000, 0x9FD2FFFF, IpClass::Eu),
@@ -14756,7 +14822,7 @@ pub static RANGES: &[CidrEntry] = &[
     // ── EU DATACENTER / CLOUD ──
     cr(0xA4252700, 0xA42527FF, IpClass::DatacenterEu),
     // ── EU-27 BASELINE (country-level) ──
-    cr(0xA4252900, 0xA4252BFF, IpClass::Eu),
+    cr(0xA4252A00, 0xA4252BFF, IpClass::Eu),
     cr(0xA4252E00, 0xA42547FF, IpClass::Eu),
     cr(0xA4255000, 0xA4255FFF, IpClass::Eu),
     cr(0xA4257000, 0xA425FFFF, IpClass::Eu),
@@ -14982,7 +15048,8 @@ pub static RANGES: &[CidrEntry] = &[
     // ── EU DATACENTER / CLOUD ──
     cr(0xAB19E100, 0xAB19E1FF, IpClass::DatacenterEu),
     // ── EU-27 BASELINE (country-level) ──
-    cr(0xAB19E200, 0xAB19E7FF, IpClass::Eu),
+    cr(0xAB19E200, 0xAB19E3FF, IpClass::Eu),
+    cr(0xAB19E500, 0xAB19E7FF, IpClass::Eu),
     cr(0xAB19F000, 0xAB19F0FF, IpClass::Eu),
     cr(0xAB1A0000, 0xAB1AFFFF, IpClass::Eu),
     cr(0xAB1F0000, 0xAB20FFFF, IpClass::Eu),
@@ -14991,6 +15058,9 @@ pub static RANGES: &[CidrEntry] = &[
     cr(0xAB21B000, 0xAB21BFFF, IpClass::Eu),
     cr(0xAB21E000, 0xAB21EFFF, IpClass::Eu),
     cr(0xAB21F100, 0xAB21F1FF, IpClass::Eu),
+    // ── EU RESIDENTIAL ISPs ──
+    cr(0xAC525A00, 0xAC525AFF, IpClass::ResidentialEu),
+    // ── EU-27 BASELINE (country-level) ──
     cr(0xAC535100, 0xAC5351FF, IpClass::Eu),
     // ── EU DATACENTER / CLOUD ──
     cr(0xAC53C900, 0xAC53C9FF, IpClass::DatacenterEu),
@@ -15518,7 +15588,6 @@ pub static RANGES: &[CidrEntry] = &[
     cr(0xB25D3B00, 0xB25D3BFF, IpClass::ResidentialEu),
     // ── EU DATACENTER / CLOUD ──
     cr(0xB25DF700, 0xB25DF7FF, IpClass::DatacenterEu),
-    cr(0xB25F5300, 0xB25F53FF, IpClass::DatacenterEu),
     // ── EU RESIDENTIAL ISPs ──
     cr(0xB25F8C00, 0xB25F8FFF, IpClass::ResidentialEu),
     // ── EU-27 BASELINE (country-level) ──
@@ -15856,9 +15925,6 @@ pub static RANGES: &[CidrEntry] = &[
     cr(0xB9020000, 0xB9020BFF, IpClass::Eu),
     cr(0xB9021000, 0xB90213FF, IpClass::Eu),
     cr(0xB9021800, 0xB9022FFF, IpClass::Eu),
-    // ── EU DATACENTER / CLOUD ──
-    cr(0xB9023100, 0xB90231FF, IpClass::DatacenterEu),
-    // ── EU-27 BASELINE (country-level) ──
     cr(0xB9023400, 0xB90247FF, IpClass::Eu),
     cr(0xB9025000, 0xB90257FF, IpClass::Eu),
     cr(0xB9025C00, 0xB90263FF, IpClass::Eu),
@@ -15881,6 +15947,9 @@ pub static RANGES: &[CidrEntry] = &[
     cr(0xB9031800, 0xB9031BFF, IpClass::Eu),
     cr(0xB9032400, 0xB90333FF, IpClass::Eu),
     cr(0xB9033C00, 0xB90343FF, IpClass::Eu),
+    // ── EU DATACENTER / CLOUD ──
+    cr(0xB9034900, 0xB90349FF, IpClass::DatacenterEu),
+    // ── EU-27 BASELINE (country-level) ──
     cr(0xB9035000, 0xB90353FF, IpClass::Eu),
     cr(0xB9035500, 0xB90355FF, IpClass::Eu),
     cr(0xB9035800, 0xB9035BFF, IpClass::Eu),
@@ -18571,6 +18640,7 @@ pub static RANGES: &[CidrEntry] = &[
     cr(0xB9919000, 0xB99193FF, IpClass::Eu),
     cr(0xB991A000, 0xB991B3FF, IpClass::Eu),
     cr(0xB991BC00, 0xB991BCFF, IpClass::Eu),
+    cr(0xB991BE00, 0xB991BEFF, IpClass::Eu),
     cr(0xB991C000, 0xB991C7FF, IpClass::Eu),
     cr(0xB991CC00, 0xB991D3FF, IpClass::Eu),
     cr(0xB991D800, 0xB991EBFF, IpClass::Eu),
@@ -18901,6 +18971,9 @@ pub static RANGES: &[CidrEntry] = &[
     cr(0xB9A2C400, 0xB9A2CBFF, IpClass::Eu),
     cr(0xB9A2D000, 0xB9A2D7FF, IpClass::Eu),
     cr(0xB9A2DC00, 0xB9A2DFFF, IpClass::Eu),
+    // ── EU DATACENTER / CLOUD ──
+    cr(0xB9A2E900, 0xB9A2E9FF, IpClass::DatacenterEu),
+    // ── EU-27 BASELINE (country-level) ──
     cr(0xB9A2EC00, 0xB9A2EFFF, IpClass::Eu),
     cr(0xB9A2F400, 0xB9A2FBFF, IpClass::Eu),
     cr(0xB9A30000, 0xB9A30FFF, IpClass::Eu),
@@ -19520,7 +19593,8 @@ pub static RANGES: &[CidrEntry] = &[
     cr(0xB9C06000, 0xB9C061FF, IpClass::DatacenterEu),
     // ── EU-27 BASELINE (country-level) ──
     cr(0xB9C06200, 0xB9C06BFF, IpClass::Eu),
-    cr(0xB9C07400, 0xB9C09BFF, IpClass::Eu),
+    cr(0xB9C07400, 0xB9C07FFF, IpClass::Eu),
+    cr(0xB9C08400, 0xB9C09BFF, IpClass::Eu),
     cr(0xB9C0A800, 0xB9C0AFFF, IpClass::Eu),
     cr(0xB9C0B400, 0xB9C0BFFF, IpClass::Eu),
     cr(0xB9C0C400, 0xB9C0D7FF, IpClass::Eu),
@@ -19708,7 +19782,8 @@ pub static RANGES: &[CidrEntry] = &[
     cr(0xB9C82000, 0xB9C823FF, IpClass::Eu),
     cr(0xB9C82800, 0xB9C833FF, IpClass::Eu),
     cr(0xB9C83800, 0xB9C83BFF, IpClass::Eu),
-    cr(0xB9C84000, 0xB9C85BFF, IpClass::Eu),
+    cr(0xB9C84000, 0xB9C853FF, IpClass::Eu),
+    cr(0xB9C85800, 0xB9C85BFF, IpClass::Eu),
     cr(0xB9C86000, 0xB9C86FFF, IpClass::Eu),
     cr(0xB9C87400, 0xB9C877FF, IpClass::Eu),
     cr(0xB9C87A00, 0xB9C87BFF, IpClass::Eu),
@@ -20323,7 +20398,7 @@ pub static RANGES: &[CidrEntry] = &[
     cr(0xB9E27800, 0xB9E27BFF, IpClass::Eu),
     cr(0xB9E28800, 0xB9E28BFF, IpClass::Eu),
     cr(0xB9E29000, 0xB9E293FF, IpClass::Eu),
-    cr(0xB9E29800, 0xB9E29BFF, IpClass::Eu),
+    cr(0xB9E29800, 0xB9E29FFF, IpClass::Eu),
     cr(0xB9E2A400, 0xB9E2B4FF, IpClass::Eu),
     // ── EU DATACENTER / CLOUD ──
     cr(0xB9E2B500, 0xB9E2B5FF, IpClass::DatacenterEu),
@@ -21305,6 +21380,7 @@ pub static RANGES: &[CidrEntry] = &[
     // ── EU DATACENTER / CLOUD ──
     cr(0xBCDC2600, 0xBCDC26FF, IpClass::DatacenterEu),
     // ── EU RESIDENTIAL ISPs ──
+    cr(0xBCDC7D00, 0xBCDC7DFF, IpClass::ResidentialEu),
     cr(0xBCDC8000, 0xBCDC80FF, IpClass::ResidentialEu),
     // ── EU DATACENTER / CLOUD ──
     cr(0xBCDC9600, 0xBCDC96FF, IpClass::DatacenterEu),
@@ -21419,11 +21495,7 @@ pub static RANGES: &[CidrEntry] = &[
     // ── EU DATACENTER / CLOUD ──
     cr(0xBF2C6300, 0xBF2C63FF, IpClass::DatacenterEu),
     // ── EU-27 BASELINE (country-level) ──
-    cr(0xBF2C6400, 0xBF2C7BFF, IpClass::Eu),
-    // ── EU DATACENTER / CLOUD ──
-    cr(0xBF2C7C00, 0xBF2C7CFF, IpClass::DatacenterEu),
-    // ── EU-27 BASELINE (country-level) ──
-    cr(0xBF2C7D00, 0xBF2C7FFF, IpClass::Eu),
+    cr(0xBF2C6400, 0xBF2C7FFF, IpClass::Eu),
     cr(0xBF2D0000, 0xBF2D1FFF, IpClass::Eu),
     // ── EU DATACENTER / CLOUD ──
     cr(0xBF608000, 0xBF6080FF, IpClass::DatacenterEu),
@@ -23562,7 +23634,8 @@ pub static RANGES: &[CidrEntry] = &[
     // ── EU GOVERNMENT / RESEARCH ──
     cr(0xC12B7400, 0xC12B75FF, IpClass::GovEu),
     // ── EU-27 BASELINE (country-level) ──
-    cr(0xC12B7600, 0xC12B7EFF, IpClass::Eu),
+    cr(0xC12B7600, 0xC12B77FF, IpClass::Eu),
+    cr(0xC12B7D00, 0xC12B7EFF, IpClass::Eu),
     cr(0xC12B8000, 0xC12B8BFF, IpClass::Eu),
     // ── EU GOVERNMENT / RESEARCH ──
     cr(0xC12B8D00, 0xC12B8DFF, IpClass::GovEu),
@@ -25057,8 +25130,7 @@ pub static RANGES: &[CidrEntry] = &[
     cr(0xC1C91800, 0xC1C91DFF, IpClass::Eu),
     cr(0xC1C92000, 0xC1C920FF, IpClass::Eu),
     cr(0xC1C92200, 0xC1C929FF, IpClass::Eu),
-    cr(0xC1C92B00, 0xC1C92EFF, IpClass::Eu),
-    cr(0xC1C93000, 0xC1C937FF, IpClass::Eu),
+    cr(0xC1C92B00, 0xC1C937FF, IpClass::Eu),
     cr(0xC1C94400, 0xC1C945FF, IpClass::Eu),
     cr(0xC1C94C00, 0xC1C94FFF, IpClass::Eu),
     cr(0xC1C95200, 0xC1C952FF, IpClass::Eu),
@@ -25094,18 +25166,15 @@ pub static RANGES: &[CidrEntry] = &[
     cr(0xC1CA0000, 0xC1CA00FF, IpClass::Eu),
     cr(0xC1CA1100, 0xC1CA11FF, IpClass::Eu),
     cr(0xC1CA1300, 0xC1CA14FF, IpClass::Eu),
-    cr(0xC1CA1600, 0xC1CA19FF, IpClass::Eu),
-    // ── EU GOVERNMENT / RESEARCH ──
-    cr(0xC1CA1A00, 0xC1CA1AFF, IpClass::GovEu),
-    // ── EU-27 BASELINE (country-level) ──
-    cr(0xC1CA1B00, 0xC1CA2DFF, IpClass::Eu),
+    cr(0xC1CA1600, 0xC1CA2DFF, IpClass::Eu),
     cr(0xC1CA4000, 0xC1CA4FFF, IpClass::Eu),
     cr(0xC1CA5800, 0xC1CA68FF, IpClass::Eu),
     cr(0xC1CA6B00, 0xC1CA70FF, IpClass::Eu),
     cr(0xC1CA7200, 0xC1CA72FF, IpClass::Eu),
     cr(0xC1CA7400, 0xC1CA75FF, IpClass::Eu),
     cr(0xC1CA7700, 0xC1CA77FF, IpClass::Eu),
-    cr(0xC1CA7900, 0xC1CADFFF, IpClass::Eu),
+    cr(0xC1CA7900, 0xC1CA7CFF, IpClass::Eu),
+    cr(0xC1CA7E00, 0xC1CADFFF, IpClass::Eu),
     cr(0xC1CB0000, 0xC1CB04FF, IpClass::Eu),
     cr(0xC1CB0C00, 0xC1CB0EFF, IpClass::Eu),
     // ── EU DATACENTER / CLOUD ──
@@ -25687,7 +25756,8 @@ pub static RANGES: &[CidrEntry] = &[
     cr(0xC208FA00, 0xC208FDFF, IpClass::Eu),
     cr(0xC2090000, 0xC20901FF, IpClass::Eu),
     cr(0xC2090400, 0xC2090BFF, IpClass::Eu),
-    cr(0xC2091000, 0xC20919FF, IpClass::Eu),
+    cr(0xC2091000, 0xC20913FF, IpClass::Eu),
+    cr(0xC2091600, 0xC20919FF, IpClass::Eu),
     cr(0xC2091D00, 0xC2091DFF, IpClass::Eu),
     cr(0xC2092A00, 0xC2092BFF, IpClass::Eu),
     cr(0xC2092E00, 0xC2092FFF, IpClass::Eu),
@@ -25726,11 +25796,7 @@ pub static RANGES: &[CidrEntry] = &[
     // ── EU RESIDENTIAL ISPs ──
     cr(0xC20D0700, 0xC20D07FF, IpClass::ResidentialEu),
     // ── EU-27 BASELINE (country-level) ──
-    cr(0xC20D0800, 0xC20D0FFF, IpClass::Eu),
-    // ── EU GOVERNMENT / RESEARCH ──
-    cr(0xC20D1000, 0xC20D1FFF, IpClass::GovEu),
-    // ── EU-27 BASELINE (country-level) ──
-    cr(0xC20D2000, 0xC20D6BFF, IpClass::Eu),
+    cr(0xC20D0800, 0xC20D6BFF, IpClass::Eu),
     cr(0xC20D6E00, 0xC20D6FFF, IpClass::Eu),
     // ── EU GOVERNMENT / RESEARCH ──
     cr(0xC20D7000, 0xC20D77FF, IpClass::GovEu),
@@ -27166,7 +27232,8 @@ pub static RANGES: &[CidrEntry] = &[
     // ── EU RESIDENTIAL ISPs ──
     cr(0xC27F6000, 0xC27F60FF, IpClass::ResidentialEu),
     // ── EU-27 BASELINE (country-level) ──
-    cr(0xC27F6100, 0xC27F67FF, IpClass::Eu),
+    cr(0xC27F6100, 0xC27F64FF, IpClass::Eu),
+    cr(0xC27F6600, 0xC27F67FF, IpClass::Eu),
     cr(0xC27F6A00, 0xC27F6AFF, IpClass::Eu),
     // ── EU RESIDENTIAL ISPs ──
     cr(0xC27F6B00, 0xC27F6BFF, IpClass::ResidentialEu),
@@ -28557,7 +28624,7 @@ pub static RANGES: &[CidrEntry] = &[
     cr(0xC34E6A00, 0xC34E6DFF, IpClass::Eu),
     cr(0xC34E7200, 0xC34E72FF, IpClass::Eu),
     cr(0xC34E7600, 0xC34E77FF, IpClass::Eu),
-    cr(0xC34E7A00, 0xC34E7DFF, IpClass::Eu),
+    cr(0xC34E7900, 0xC34E7DFF, IpClass::Eu),
     cr(0xC34E8000, 0xC34EE7FF, IpClass::Eu),
     cr(0xC34EEC00, 0xC34EF3FF, IpClass::Eu),
     cr(0xC34EF800, 0xC34EF8FF, IpClass::Eu),
@@ -28846,7 +28913,9 @@ pub static RANGES: &[CidrEntry] = &[
     // ── EU RESIDENTIAL ISPs ──
     cr(0xC3850700, 0xC38507FF, IpClass::ResidentialEu),
     // ── EU-27 BASELINE (country-level) ──
-    cr(0xC3850800, 0xC3857FFF, IpClass::Eu),
+    cr(0xC3850800, 0xC38537FF, IpClass::Eu),
+    cr(0xC3853A00, 0xC3853BFF, IpClass::Eu),
+    cr(0xC3853E00, 0xC3857FFF, IpClass::Eu),
     cr(0xC3859000, 0xC38597FF, IpClass::Eu),
     cr(0xC385A000, 0xC385BFFF, IpClass::Eu),
     cr(0xC385C200, 0xC385C9FF, IpClass::Eu),
@@ -29636,6 +29705,7 @@ pub static RANGES: &[CidrEntry] = &[
     cr(0xC6390A00, 0xC6390AFF, IpClass::ResidentialEu),
     // ── EU-27 BASELINE (country-level) ──
     cr(0xC63CC100, 0xC63CC1FF, IpClass::Eu),
+    cr(0xC63CD800, 0xC63CD8FF, IpClass::Eu),
     // ── EU RESIDENTIAL ISPs ──
     cr(0xC643E000, 0xC643FFFF, IpClass::ResidentialEu),
     // ── EU DATACENTER / CLOUD ──
@@ -29700,6 +29770,7 @@ pub static RANGES: &[CidrEntry] = &[
     cr(0xC7C38200, 0xC7C383FF, IpClass::Eu),
     // ── EU DATACENTER / CLOUD ──
     cr(0xC7C38C00, 0xC7C38DFF, IpClass::DatacenterEu),
+    cr(0xC7CC1800, 0xC7CC18FF, IpClass::DatacenterEu),
     cr(0xC7DFD400, 0xC7DFD4FF, IpClass::DatacenterEu),
     cr(0xC7DFD600, 0xC7DFD7FF, IpClass::DatacenterEu),
     // ── EU-27 BASELINE (country-level) ──
@@ -29759,6 +29830,9 @@ pub static RANGES: &[CidrEntry] = &[
     cr(0xCAA23000, 0xCAA23FFF, IpClass::Eu),
     cr(0xCAAA5000, 0xCAAA57FF, IpClass::Eu),
     cr(0xCAAAC400, 0xCAAAC7FF, IpClass::Eu),
+    // ── EU DATACENTER / CLOUD ──
+    cr(0xCAB50000, 0xCAB500FF, IpClass::DatacenterEu),
+    // ── EU-27 BASELINE (country-level) ──
     cr(0xCAB59400, 0xCAB594FF, IpClass::Eu),
     cr(0xCAB59900, 0xCAB599FF, IpClass::Eu),
     cr(0xCAB5BC00, 0xCAB5BCFF, IpClass::Eu),
@@ -29881,7 +29955,6 @@ pub static RANGES: &[CidrEntry] = &[
     // ── EU DATACENTER / CLOUD ──
     cr(0xCFA6CD00, 0xCFA6CEFF, IpClass::DatacenterEu),
     cr(0xCFB40D00, 0xCFB40DFF, IpClass::DatacenterEu),
-    cr(0xCFB41500, 0xCFB415FF, IpClass::DatacenterEu),
     // ── EU RESIDENTIAL ISPs ──
     cr(0xCFB42900, 0xCFB429FF, IpClass::ResidentialEu),
     // ── EU DATACENTER / CLOUD ──
@@ -31047,7 +31120,11 @@ pub static RANGES: &[CidrEntry] = &[
     cr(0xD5B80000, 0xD5B83FFF, IpClass::Eu),
     cr(0xD5B84800, 0xD5B857FF, IpClass::Eu),
     cr(0xD5B86000, 0xD5B87FFF, IpClass::Eu),
-    cr(0xD5B90000, 0xD5B95FFF, IpClass::Eu),
+    cr(0xD5B90000, 0xD5B957FF, IpClass::Eu),
+    // ── EU RESIDENTIAL ISPs ──
+    cr(0xD5B95800, 0xD5B95BFF, IpClass::ResidentialEu),
+    // ── EU-27 BASELINE (country-level) ──
+    cr(0xD5B95C00, 0xD5B95FFF, IpClass::Eu),
     cr(0xD5B98000, 0xD5B99FFF, IpClass::Eu),
     cr(0xD5B9E000, 0xD5BA1FFF, IpClass::Eu),
     // ── EU DATACENTER / CLOUD ──
@@ -31249,6 +31326,9 @@ pub static RANGES: &[CidrEntry] = &[
     cr(0xD8573500, 0xD85736FF, IpClass::Eu),
     cr(0xD878AE00, 0xD878AFFF, IpClass::Eu),
     cr(0xD878B400, 0xD878B5FF, IpClass::Eu),
+    // ── EU DATACENTER / CLOUD ──
+    cr(0xD87A7B00, 0xD87A7BFF, IpClass::DatacenterEu),
+    // ── EU-27 BASELINE (country-level) ──
     cr(0xD8936000, 0xD8936FFF, IpClass::Eu),
     cr(0xD8960500, 0xD89605FF, IpClass::Eu),
     cr(0xD89E6000, 0xD89E6FFF, IpClass::Eu),
@@ -31665,7 +31745,10 @@ pub static RANGES: &[CidrEntry] = &[
     cr(0xD99A7000, 0xD99A79FF, IpClass::DatacenterEu),
     cr(0xD99A7C00, 0xD99A7EFF, IpClass::DatacenterEu),
     // ── EU-27 BASELINE (country-level) ──
-    cr(0xD99A8000, 0xD99A82FF, IpClass::Eu),
+    cr(0xD99A8000, 0xD99A81FF, IpClass::Eu),
+    // ── EU DATACENTER / CLOUD ──
+    cr(0xD99A8200, 0xD99A82FF, IpClass::DatacenterEu),
+    // ── EU-27 BASELINE (country-level) ──
     cr(0xD99A8800, 0xD99A88FF, IpClass::Eu),
     cr(0xD99A8B00, 0xD99A8CFF, IpClass::Eu),
     // ── EU DATACENTER / CLOUD ──
@@ -32634,6 +32717,8 @@ pub static RANGES6: &[CidrEntry6] = &[
     cr6(0x2001067812E400000000000000000000, 0x2001067812E4FFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2001067812E800000000000000000000, 0x2001067812E8FFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2001067812EC00000000000000000000, 0x2001067812ECFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
+    cr6(0x2001067812F000000000000000000000, 0x2001067812F0FFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
+    cr6(0x2001067812F800000000000000000000, 0x2001067812F8FFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2001067C000000000000000000000000, 0x2001067C0000FFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2001067C000400000000000000000000, 0x2001067C0004FFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2001067C000C00000000000000000000, 0x2001067C000CFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
@@ -32797,7 +32882,6 @@ pub static RANGES6: &[CidrEntry6] = &[
     cr6(0x2001067C039400000000000000000000, 0x2001067C0394FFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2001067C039C00000000000000000000, 0x2001067C039CFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2001067C03A000000000000000000000, 0x2001067C03A0FFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
-    cr6(0x2001067C03A400000000000000000000, 0x2001067C03A4FFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2001067C03A800000000000000000000, 0x2001067C03A8FFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2001067C03B000000000000000000000, 0x2001067C03B0FFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2001067C03B400000000000000000000, 0x2001067C03B4FFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
@@ -34030,7 +34114,6 @@ pub static RANGES6: &[CidrEntry6] = &[
     cr6(0x2001067C265800000000000000000000, 0x2001067C2658FFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2001067C265C00000000000000000000, 0x2001067C265CFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2001067C266000000000000000000000, 0x2001067C2660FFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
-    cr6(0x2001067C266400000000000000000000, 0x2001067C2664FFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2001067C266C00000000000000000000, 0x2001067C266CFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2001067C267000000000000000000000, 0x2001067C2670FFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2001067C267400000000000000000000, 0x2001067C2674FFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
@@ -35021,7 +35104,6 @@ pub static RANGES6: &[CidrEntry6] = &[
     cr6(0x2A0013D8000000000000000000000000, 0x2A0013DFFFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2A0013F0000000000000000000000000, 0x2A0013F0FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2A001420000000000000000000000000, 0x2A001420FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
-    cr6(0x2A001428000000000000000000000000, 0x2A00142FFFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2A001450000000000000000000000000, 0x2A001458FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2A001470000000000000000000000000, 0x2A001470FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2A001478000000000000000000000000, 0x2A001480FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
@@ -35586,7 +35668,6 @@ pub static RANGES6: &[CidrEntry6] = &[
     cr6(0x2A009B60000000000000000000000000, 0x2A009B60FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2A009C00000000000000000000000000, 0x2A009C00FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2A009C20000000000000000000000000, 0x2A009C20FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
-    cr6(0x2A009C60000000000000000000000000, 0x2A009C60FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2A009C80000000000000000000000000, 0x2A009C80FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2A009CA0000000000000000000000000, 0x2A009CA0FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2A009CC0000000000000000000000000, 0x2A009CC0FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
@@ -36619,7 +36700,6 @@ pub static RANGES6: &[CidrEntry6] = &[
     cr6(0x2A01B740000000000000000000000000, 0x2A01B747FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2A01B760000000000000000000000000, 0x2A01B760FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2A01B7E0000000000000000000000000, 0x2A01B7E0FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
-    cr6(0x2A01B840000000000000000000000000, 0x2A01B840FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2A01B860000000000000000000000000, 0x2A01B860FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2A01B880000000000000000000000000, 0x2A01B880FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2A01B8E0000000000000000000000000, 0x2A01B8E0FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
@@ -38264,7 +38344,6 @@ pub static RANGES6: &[CidrEntry6] = &[
     cr6(0x2A038E20000000000000000000000000, 0x2A038E20FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2A038E60000000000000000000000000, 0x2A038E60FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2A038E80000000000000000000000000, 0x2A038E80FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
-    cr6(0x2A038EA0000000000000000000000000, 0x2A038EA0FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2A038F00000000000000000000000000, 0x2A038F07FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2A038F60000000000000000000000000, 0x2A038F60FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2A038F80000000000000000000000000, 0x2A038F87FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
@@ -39384,13 +39463,9 @@ pub static RANGES6: &[CidrEntry6] = &[
     // ── EU DATACENTER / CLOUD ──
     cr6(0x2A0535C0000000000000000000000000, 0x2A0535C00005FFFFFFFFFFFFFFFFFFFF, IpClass::DatacenterEu),
     cr6(0x2A0535C0000700000000000000000000, 0x2A0535C00010FFFFFFFFFFFFFFFFFFFF, IpClass::DatacenterEu),
-    cr6(0x2A0535C0001200000000000000000000, 0x2A0535C1A39EFFFFFFFFFFFFFFFFFFFF, IpClass::DatacenterEu),
-    cr6(0x2A0535C1A3A000000000000000000000, 0x2A0535C1F43CFFFFFFFFFFFFFFFFFFFF, IpClass::DatacenterEu),
-    cr6(0x2A0535C1F43E00000000000000000000, 0x2A0535C236E2FFFFFFFFFFFFFFFFFFFF, IpClass::DatacenterEu),
-    cr6(0x2A0535C236E400000000000000000000, 0x2A0535C2BF0AFFFFFFFFFFFFFFFFFFFF, IpClass::DatacenterEu),
-    cr6(0x2A0535C2BF0C00000000000000000000, 0x2A0535C37826FFFFFFFFFFFFFFFFFFFF, IpClass::DatacenterEu),
-    cr6(0x2A0535C3782800000000000000000000, 0x2A0535C3BB3FFFFFFFFFFFFFFFFFFFFF, IpClass::DatacenterEu),
-    cr6(0x2A0535C3BB4100000000000000000000, 0x2A0535C7FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::DatacenterEu),
+    cr6(0x2A0535C0001200000000000000000000, 0x2A0535C1F43CFFFFFFFFFFFFFFFFFFFF, IpClass::DatacenterEu),
+    cr6(0x2A0535C1F43E00000000000000000000, 0x2A0535C2BF0AFFFFFFFFFFFFFFFFFFFF, IpClass::DatacenterEu),
+    cr6(0x2A0535C2BF0C00000000000000000000, 0x2A0535C7FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::DatacenterEu),
     // ── EU-27 BASELINE (country-level) ──
     cr6(0x2A053600000000000000000000000000, 0x2A053607FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2A053640000000000000000000000000, 0x2A053647FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
@@ -39860,10 +39935,7 @@ pub static RANGES6: &[CidrEntry6] = &[
     cr6(0x2A061140000000000000000000000000, 0x2A061147FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     // ── EU DATACENTER / CLOUD ──
     cr6(0x2A061180000200000000000000000000, 0x2A0611800002FFFFFFFFFFFFFFFFFFFF, IpClass::DatacenterEu),
-    cr6(0x2A061180010000000000000000000000, 0x2A0611800100FFFFFFFFFFFFFFFFFFFF, IpClass::DatacenterEu),
-    cr6(0x2A06118001C500000000000000000000, 0x2A06118001C5FFFFFFFFFFFFFFFFFFFF, IpClass::DatacenterEu),
     cr6(0x2A061181001100000000000000000000, 0x2A0611810011FFFFFFFFFFFFFFFFFFFF, IpClass::DatacenterEu),
-    cr6(0x2A061184004400000000000000000000, 0x2A0611840044FFFFFFFFFFFFFFFFFFFF, IpClass::DatacenterEu),
     cr6(0x2A061184006600000000000000000000, 0x2A0611840066FFFFFFFFFFFFFFFFFFFF, IpClass::DatacenterEu),
     cr6(0x2A061184ACAB00000000000000000000, 0x2A061184ACABFFFFFFFFFFFFFFFFFFFF, IpClass::DatacenterEu),
     // ── EU-27 BASELINE (country-level) ──
@@ -41083,7 +41155,6 @@ pub static RANGES6: &[CidrEntry6] = &[
     // ── EU DATACENTER / CLOUD ──
     cr6(0x2A0917C0003300000000000000000000, 0x2A0917C00033FFFFFFFFFFFFFFFFFFFF, IpClass::DatacenterEu),
     cr6(0x2A0917C0ACAB00000000000000000000, 0x2A0917C0ACABFFFFFFFFFFFFFFFFFFFF, IpClass::DatacenterEu),
-    cr6(0x2A0917C1000300000000000000000000, 0x2A0917C10003FFFFFFFFFFFFFFFFFFFF, IpClass::DatacenterEu),
     cr6(0x2A0917C1002200000000000000000000, 0x2A0917C10022FFFFFFFFFFFFFFFFFFFF, IpClass::DatacenterEu),
     cr6(0x2A0917C1003300000000000000000000, 0x2A0917C10033FFFFFFFFFFFFFFFFFFFF, IpClass::DatacenterEu),
     // ── EU-27 BASELINE (country-level) ──
@@ -43001,7 +43072,6 @@ pub static RANGES6: &[CidrEntry6] = &[
     cr6(0x2A0C7881131200000000000000000000, 0x2A0C78811312FFFFFFFFFFFFFFFFFFFF, IpClass::DatacenterEu),
     cr6(0x2A0C7881AA2300000000000000000000, 0x2A0C7881AA23FFFFFFFFFFFFFFFFFFFF, IpClass::DatacenterEu),
     cr6(0x2A0C7882001100000000000000000000, 0x2A0C78820011FFFFFFFFFFFFFFFFFFFF, IpClass::DatacenterEu),
-    cr6(0x2A0C7883000100000000000000000000, 0x2A0C78830001FFFFFFFFFFFFFFFFFFFF, IpClass::DatacenterEu),
     cr6(0x2A0C7885000100000000000000000000, 0x2A0C78850001FFFFFFFFFFFFFFFFFFFF, IpClass::DatacenterEu),
     cr6(0x2A0C7886004400000000000000000000, 0x2A0C78860044FFFFFFFFFFFFFFFFFFFF, IpClass::DatacenterEu),
     cr6(0x2A0C7887000000000000000000000000, 0x2A0C7887FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::DatacenterEu),
@@ -43224,9 +43294,11 @@ pub static RANGES6: &[CidrEntry6] = &[
     cr6(0x2A0CCE40000000000000000000000000, 0x2A0CCE40FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2A0CCE80000000000000000000000000, 0x2A0CCE87FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2A0CCF00000000000000000000000000, 0x2A0CCF07FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
+    cr6(0x2A0CCF40000000000000000000000000, 0x2A0CCF47FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2A0CCF80000000000000000000000000, 0x2A0CCF87FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2A0CD040000000000000000000000000, 0x2A0CD047FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2A0CD100000000000000000000000000, 0x2A0CD107FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
+    cr6(0x2A0CD140000000000000000000000000, 0x2A0CD147FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2A0CD180000000000000000000000000, 0x2A0CD187FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2A0CD1C0000000000000000000000000, 0x2A0CD1C7FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2A0CD240000000000000000000000000, 0x2A0CD247FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
@@ -43285,13 +43357,16 @@ pub static RANGES6: &[CidrEntry6] = &[
     cr6(0x2A0CEA40000000000000000000000000, 0x2A0CEA47FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2A0CEA80000000000000000000000000, 0x2A0CEA87FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2A0CEB00000000000000000000000000, 0x2A0CEB00FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
+    cr6(0x2A0CEC00000000000000000000000000, 0x2A0CEC07FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2A0CEC80000000000000000000000000, 0x2A0CEC80FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2A0CED40000000000000000000000000, 0x2A0CED47FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2A0CED80000000000000000000000000, 0x2A0CED87FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2A0CEDC0000000000000000000000000, 0x2A0CEDC7FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
+    cr6(0x2A0CEE40000000000000000000000000, 0x2A0CEE40FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2A0CEE80000000000000000000000000, 0x2A0CEE87FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2A0CEEC0000000000000000000000000, 0x2A0CEEC7FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2A0CEF00000000000000000000000000, 0x2A0CEF00FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
+    cr6(0x2A0CEF40000000000000000000000000, 0x2A0CEF47FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2A0CEF80000000000000000000000000, 0x2A0CEF80FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2A0CEFC0000000000000000000000000, 0x2A0CEFC7FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2A0CF040000000000000000000000000, 0x2A0CF047FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
@@ -43457,6 +43532,7 @@ pub static RANGES6: &[CidrEntry6] = &[
     cr6(0x2A0D3600000000000000000000000000, 0x2A0D3607FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2A0D3640000000000000000000000000, 0x2A0D3647FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2A0D3700000000000000000000000000, 0x2A0D3707FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
+    cr6(0x2A0D3780000000000000000000000000, 0x2A0D3787FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2A0D37C0000000000000000000000000, 0x2A0D37C7FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2A0D3800000000000000000000000000, 0x2A0D3807FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2A0D38C0000000000000000000000000, 0x2A0D38C7FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
@@ -44591,7 +44667,6 @@ pub static RANGES6: &[CidrEntry6] = &[
     cr6(0x2A0F5880000000000000000000000000, 0x2A0F5887FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2A0F5900000000000000000000000000, 0x2A0F5907FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2A0F5A80000000000000000000000000, 0x2A0F5A87FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
-    cr6(0x2A0F5AC0000000000000000000000000, 0x2A0F5AC0FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2A0F5B00000000000000000000000000, 0x2A0F5B07FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2A0F5B40000000000000000000000000, 0x2A0F5B47FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2A0F5B80000000000000000000000000, 0x2A0F5B87FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
@@ -45577,7 +45652,6 @@ pub static RANGES6: &[CidrEntry6] = &[
     cr6(0x2A10F400000000000000000000000000, 0x2A10F407FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2A10F480000000000000000000000000, 0x2A10F487FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2A10F4C0000000000000000000000000, 0x2A10F4C7FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
-    cr6(0x2A10F580000000000000000000000000, 0x2A10F587FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2A10F5C0000000000000000000000000, 0x2A10F5C7FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2A10F600000000000000000000000000, 0x2A10F607FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2A10F680000000000000000000000000, 0x2A10F687FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
@@ -45873,7 +45947,6 @@ pub static RANGES6: &[CidrEntry6] = &[
     cr6(0x2A11A440000000000000000000000000, 0x2A11A447FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2A11A480000000000000000000000000, 0x2A11A487FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2A11A4C0000000000000000000000000, 0x2A11A4C7FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
-    cr6(0x2A11A500000000000000000000000000, 0x2A11A500FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2A11A580000000000000000000000000, 0x2A11A587FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2A11A5C0000000000000000000000000, 0x2A11A5C7FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     cr6(0x2A11A640000000000000000000000000, 0x2A11A647FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
@@ -46860,7 +46933,6 @@ pub static RANGES6: &[CidrEntry6] = &[
     cr6(0x2A13C880000000000000000000000000, 0x2A13C887FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::Eu),
     // ── EU DATACENTER / CLOUD ──
     cr6(0x2A13C900003300000000000000000000, 0x2A13C9000033FFFFFFFFFFFFFFFFFFFF, IpClass::DatacenterEu),
-    cr6(0x2A13C900024F00000000000000000000, 0x2A13C900024FFFFFFFFFFFFFFFFFFFFF, IpClass::DatacenterEu),
     cr6(0x2A13C901000000000000000000000000, 0x2A13C901FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::DatacenterEu),
     cr6(0x2A13C905000000000000000000000000, 0x2A13C905FFFFFFFFFFFFFFFFFFFFFFFF, IpClass::DatacenterEu),
     // ── EU-27 BASELINE (country-level) ──


### PR DESCRIPTION
Automated weekly refresh of EU-27 ASN/CIDR ranges from authoritative sources.

**Sources:**
- RIPE NCC delegated stats: `ftp.ripe.net/pub/stats/ripencc/delegated-ripencc-latest`
- IPtoASN (Team Cymru): `iptoasn.com/data/ip2asn-v4.tsv.gz`

**Verification:** Review the diff to ensure no unexpected ranges were added/removed.
The `ranges_are_sorted` and `ranges_dont_overlap` tests will run in CI.