### PR TITLE
feat(tls-fp): JA4 client fingerprint library (#27, commit 1/5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5195,6 +5195,7 @@ dependencies = [
  "ryu",
  "serde",
  "serde_json",
+ "sha2",
  "simd-json",
  "socket2",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,6 +190,16 @@ default-features = false
 version = "1"
 optional = true
 
+# Track D — TLS client fingerprinting (JA4, `--features tls-fingerprint`).
+# SHA-256 over the sorted, GREASE-stripped cipher/extension lists. `sha2 0.10`
+# is ALREADY in the tree (ring/aws-lc closure, 0.10.9), so this adds ZERO new
+# audited crates. Pinned to 0.10 on purpose: the crates.io `ja4` crate wants
+# sha2 ^0.11, which would fork a second major — we hand-roll the parser instead.
+[dependencies.sha2]
+version = "0.10"
+optional = true
+default-features = false
+
 [features]
 default = []
 io-uring-accept = ["io-uring"]
@@ -243,6 +253,11 @@ ml-waf = ["dep:tract-onnx"]
 # serverless gossip of WAF rules / IP reputation / threat intel via
 # Merkle-CRDT. Implies sovereign-signals (the existing Phase 3 hook).
 sovereign-aimp = ["sovereign-signals", "dep:aimp_node", "dep:rmp-serde"]
+# Track D — TLS client fingerprinting (JA4). Hand-rolled ClientHello parser +
+# JA4 hasher (FoxIO standard); the only dep is `sha2`, already resolved
+# transitively, so no new audited crates. MSRV-1.82-clean (no edition-2024
+# pull) — intentionally NOT in `dist`. See src/tls_fp.rs and issue #27.
+tls-fingerprint = ["dep:sha2"]
 
 # Track C — property-based testing (proptest) only used by `cargo test`.
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Client -> TLS 1.3 -> Security Gates -> Radix Router -> WAF Pipeline (5 gates) ->
 ```
 
 <!-- zion-stats:modules-lines (kept in sync by scripts/update-readme-stats.sh) -->
-48 modules, ~42,300 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
+49 modules, ~42,900 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
 
 ## Features
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,6 +93,10 @@ mod ktls;
 // and drop your own scorer.
 #[cfg(feature = "ml-waf")]
 mod waf_ml;
+// TLS client fingerprinting (JA4). Phase 3a (#27): a pure JA4 library over the
+// ClientHello; the allowlist gate, config, and peek hook land in later commits.
+#[cfg(feature = "tls-fingerprint")]
+mod tls_fp;
 // AIMP-as-control-plane: serverless gossip of WAF rules and IP reputation
 // via Merkle-CRDT. Top-level `aimp_cp` instead of nesting under `sovereign::`
 // so it does not pull in geo-* features by accident.

--- a/src/tls_fp.rs
+++ b/src/tls_fp.rs
@@ -123,7 +123,10 @@ fn u16_list(bytes: &[u8]) -> Result<Vec<u16>, TlsFpError> {
         .collect())
 }
 
-/// Map a TLS version code point to its 2-char JA4 token.
+/// Map a TLS version code point to its 2-char JA4 token. TLS-over-TCP only:
+/// DTLS (`d1`/`d2`/`d3`) is out of scope for Phase 3a — the transport char is
+/// hardcoded `t` and this parser doesn't understand the DTLS ClientHello layout,
+/// so DTLS code points fall through to the `00` unknown token like anything else.
 fn version_token(v: u16) -> &'static str {
     match v {
         0x0304 => "13",
@@ -132,9 +135,6 @@ fn version_token(v: u16) -> &'static str {
         0x0301 => "10",
         0x0300 => "s3",
         0x0002 => "s2",
-        0xfeff => "d1",
-        0xfefd => "d2",
-        0xfefc => "d3",
         _ => "00",
     }
 }
@@ -168,9 +168,20 @@ fn sha256_12(input: &str) -> String {
     out
 }
 
-/// Zero-padded 4-char lowercase hex of a code point (for sorting + hashing).
-fn hex4(v: u16) -> String {
-    format!("{v:04x}")
+/// Comma-joined 4-char zero-padded lowercase hex of a code-point slice, in the
+/// slice's current order. Callers sort (ciphers, extension types) or preserve
+/// wire order (signature_algorithms) beforehand. Formats once — no per-element
+/// `String` allocation — and zero-padded 4-hex sorts identically to numeric u16
+/// order, so sorting the `u16`s is equivalent to sorting the hex strings.
+fn csv_hex(vals: &[u16]) -> String {
+    let mut out = String::with_capacity(vals.len() * 5);
+    for (i, v) in vals.iter().enumerate() {
+        if i > 0 {
+            out.push(',');
+        }
+        out.push_str(&format!("{v:04x}"));
+    }
+    out
 }
 
 /// Fields extracted from a `ClientHello` that JA4 needs.
@@ -179,6 +190,10 @@ struct ClientHelloParts {
     ciphers: Vec<u16>,
     ext_types: Vec<u16>,
     sni_present: bool,
+    /// Whether the `supported_versions` (0x002b) extension was present — the JA4
+    /// version rule branches on presence, not on whether a non-GREASE value
+    /// survives.
+    sv_present: bool,
     supported_versions: Vec<u16>,
     sig_algs: Vec<u16>,
     first_alpn: Vec<u8>,
@@ -192,7 +207,16 @@ fn parse_client_hello(bytes: &[u8]) -> Result<ClientHelloParts, TlsFpError> {
     if r.u8()? != 0x01 {
         return Err(TlsFpError::NotClientHello);
     }
-    let _body_len = r.take(3)?; // 24-bit length — informational; we walk fields directly
+    // 24-bit handshake body length. Clamp the whole walk to it so a hostile
+    // length field can never make an extension read spill past the declared
+    // message into trailing bytes (a second record, or record framing, is the
+    // peek/hook commit's concern). The buffer must actually contain the message.
+    let blen = r.take(3)?;
+    let body_len = ((blen[0] as usize) << 16) | ((blen[1] as usize) << 8) | (blen[2] as usize);
+    let body_end = 4usize.checked_add(body_len).ok_or(TlsFpError::Malformed)?;
+    let body = bytes.get(4..body_end).ok_or(TlsFpError::Truncated)?;
+    let mut r = Reader::new(body);
+
     let legacy_version = r.u16()?;
     let _random = r.take(32)?;
     let sid_len = r.u8()? as usize;
@@ -209,6 +233,7 @@ fn parse_client_hello(bytes: &[u8]) -> Result<ClientHelloParts, TlsFpError> {
         ciphers,
         ext_types: Vec::new(),
         sni_present: false,
+        sv_present: false,
         supported_versions: Vec::new(),
         sig_algs: Vec::new(),
         first_alpn: Vec::new(),
@@ -230,11 +255,18 @@ fn parse_client_hello(bytes: &[u8]) -> Result<ClientHelloParts, TlsFpError> {
         match ext_type {
             0x0000 => parts.sni_present = true,
             0x0010 => {
-                // ALPN: [list_len u16][ {proto_len u8, proto bytes} … ]. Keep first.
+                // ALPN: [list_len u16][ {proto_len u8, proto bytes} … ]. Keep the
+                // first protocol. Best-effort: a well-formed but EMPTY list (body
+                // [0x00,0x00]) is valid and must yield the "00" token, not fail
+                // the whole fingerprint (which would drop a legitimate client).
                 let mut a = Reader::new(data);
-                let _list_len = a.u16()?;
-                let plen = a.u8()? as usize;
-                parts.first_alpn = a.take(plen)?.to_vec();
+                if a.u16().is_ok() {
+                    if let Ok(plen) = a.u8() {
+                        if let Ok(proto) = a.take(plen as usize) {
+                            parts.first_alpn = proto.to_vec();
+                        }
+                    }
+                }
             }
             0x000d => {
                 // signature_algorithms: [list_len u16][ u16 … ] — WIRE order.
@@ -244,6 +276,7 @@ fn parse_client_hello(bytes: &[u8]) -> Result<ClientHelloParts, TlsFpError> {
             }
             0x002b => {
                 // supported_versions: [list_len u8][ u16 … ].
+                parts.sv_present = true;
                 let mut s = Reader::new(data);
                 let list_len = s.u8()? as usize;
                 parts.supported_versions = u16_list(s.take(list_len)?)?;
@@ -263,70 +296,71 @@ fn parse_client_hello(bytes: &[u8]) -> Result<ClientHelloParts, TlsFpError> {
 pub fn ja4_from_client_hello(bytes: &[u8]) -> Result<Ja4, TlsFpError> {
     let p = parse_client_hello(bytes)?;
 
-    // ── JA4_a ─────────────────────────────────────────────────────────────
-    // Version: max of the GREASE-stripped supported_versions, else legacy.
-    let sv_max = p
-        .supported_versions
-        .iter()
-        .copied()
-        .filter(|v| !is_grease(*v))
-        .max();
-    let version = version_token(sv_max.unwrap_or(p.legacy_version));
-
-    let sni = if p.sni_present { 'd' } else { 'i' };
-
-    let cipher_ct = p.ciphers.iter().filter(|v| !is_grease(**v)).count().min(99);
-    let ext_ct = p
-        .ext_types
-        .iter()
-        .filter(|v| !is_grease(**v))
-        .count()
-        .min(99);
-
-    let (alpn0, alpn1) = alpn_token(&p.first_alpn);
-
-    let ja4_a = format!("t{version}{sni}{cipher_ct:02}{ext_ct:02}{alpn0}{alpn1}");
-
-    // ── JA4_b: sorted, GREASE-stripped ciphers, hashed ─────────────────────
-    let mut cipher_hex: Vec<String> = p
+    // GREASE-stripped working sets (used for both the counts and the hashes).
+    let ciphers: Vec<u16> = p
         .ciphers
         .iter()
         .copied()
         .filter(|v| !is_grease(*v))
-        .map(hex4)
         .collect();
-    cipher_hex.sort();
-    let ja4_b = if cipher_hex.is_empty() {
-        "000000000000".to_string()
-    } else {
-        sha256_12(&cipher_hex.join(","))
-    };
-
-    // ── JA4_c: sorted ext types (minus SNI+ALPN) + wire-order sig-algs ─────
-    let mut ext_hex: Vec<String> = p
+    let ext_types: Vec<u16> = p
         .ext_types
         .iter()
         .copied()
-        .filter(|v| !is_grease(*v) && *v != 0x0000 && *v != 0x0010)
-        .map(hex4)
+        .filter(|v| !is_grease(*v))
         .collect();
-    ext_hex.sort();
 
-    let ja4_c = if ext_hex.is_empty() {
+    // ── JA4_a ─────────────────────────────────────────────────────────────
+    // Version: the JA4 rule branches on whether supported_versions is PRESENT.
+    // If so, use the highest non-GREASE entry (or "00" when the list is empty /
+    // all-GREASE); otherwise use the legacy record version.
+    let version = if p.sv_present {
+        p.supported_versions
+            .iter()
+            .copied()
+            .filter(|v| !is_grease(*v))
+            .max()
+            .map_or("00", version_token)
+    } else {
+        version_token(p.legacy_version)
+    };
+
+    let sni = if p.sni_present { 'd' } else { 'i' };
+    // The extension count includes SNI + ALPN — they are only removed from JA4_c.
+    let cipher_ct = ciphers.len().min(99);
+    let ext_ct = ext_types.len().min(99);
+    let (alpn0, alpn1) = alpn_token(&p.first_alpn);
+    let ja4_a = format!("t{version}{sni}{cipher_ct:02}{ext_ct:02}{alpn0}{alpn1}");
+
+    // ── JA4_b: sorted ciphers, hashed ─────────────────────────────────────
+    let mut sorted_ciphers = ciphers;
+    sorted_ciphers.sort_unstable();
+    let ja4_b = if sorted_ciphers.is_empty() {
         "000000000000".to_string()
     } else {
-        let sig_hex: Vec<String> = p
+        sha256_12(&csv_hex(&sorted_ciphers))
+    };
+
+    // ── JA4_c: sorted ext types (minus SNI+ALPN) + wire-order sig-algs ─────
+    let mut sorted_exts: Vec<u16> = ext_types
+        .into_iter()
+        .filter(|v| *v != 0x0000 && *v != 0x0010)
+        .collect();
+    sorted_exts.sort_unstable();
+    let ja4_c = if sorted_exts.is_empty() {
+        "000000000000".to_string()
+    } else {
+        let sig_algs: Vec<u16> = p
             .sig_algs
             .iter()
             .copied()
             .filter(|v| !is_grease(*v))
-            .map(hex4)
             .collect();
         // No sig-algs → NO trailing underscore (a classic JA4 off-by-one).
-        let combined = if sig_hex.is_empty() {
-            ext_hex.join(",")
+        let combined = if sig_algs.is_empty() {
+            csv_hex(&sorted_exts)
         } else {
-            format!("{}_{}", ext_hex.join(","), sig_hex.join(","))
+            format!("{}_{}", csv_hex(&sorted_exts), csv_hex(&sig_algs))
         };
         sha256_12(&combined)
     };
@@ -509,6 +543,54 @@ mod tests {
         // ja4_c hashes only 0017 (SNI+ALPN removed).
         let c = ja4.as_str().split('_').nth(2).unwrap();
         assert_eq!(c, sha256_12("0017"));
+    }
+
+    #[test]
+    fn empty_alpn_list_yields_00_token_not_error() {
+        // A well-formed but EMPTY ALPN ProtocolNameList (body [0x00,0x00]) is
+        // valid and must fingerprint with ALPN token "00" — not error out, which
+        // would fail-open by dropping a legitimate client at the gate.
+        let ciphers: [u16; 1] = [0x1301];
+        let mut ext = Vec::new();
+        push_ext(&mut ext, 0x0000, &[0x00, 0x00]); // SNI
+        push_ext(&mut ext, 0x0010, &[0x00, 0x00]); // ALPN: empty ProtocolNameList
+        push_ext(&mut ext, 0x0017, &[]);
+        let hello = assemble_body(0x0303, &ciphers, &ext);
+        let ja4 = ja4_from_client_hello(&hello).expect("empty ALPN must not error");
+        let a = ja4.as_str().split('_').next().unwrap();
+        assert_eq!(a, "t12d010300"); // 1 cipher, 3 exts, SNI, ALPN token "00"
+    }
+
+    #[test]
+    fn all_grease_supported_versions_yields_00() {
+        // supported_versions PRESENT but only GREASE → version token "00", not a
+        // silent fall-back to the legacy record version.
+        let ciphers: [u16; 1] = [0x1301];
+        let mut ext = Vec::new();
+        push_ext(&mut ext, 0x002b, &[0x02, 0x0a, 0x0a]); // [len=2][GREASE 0x0a0a]
+        let hello = assemble_body(0x0303, &ciphers, &ext);
+        let ja4 = ja4_from_client_hello(&hello).unwrap();
+        assert_eq!(&ja4.as_str()[1..3], "00");
+    }
+
+    #[test]
+    fn body_len_larger_than_buffer_is_truncated() {
+        // The 24-bit handshake length claims more than the buffer holds → the
+        // clamp rejects it up front instead of walking a short buffer.
+        let mut hello = chrome_client_hello();
+        hello[1] = 0xff; // inflate the high byte of the 24-bit body length
+        assert_eq!(ja4_from_client_hello(&hello), Err(TlsFpError::Truncated));
+    }
+
+    #[test]
+    fn trailing_bytes_after_message_are_ignored() {
+        // Extra bytes beyond the declared handshake message (a second record, or
+        // peek slack) do not corrupt the fingerprint — the clamp keeps the walk
+        // inside body_len.
+        let mut hello = chrome_client_hello();
+        hello.extend_from_slice(&[0xde, 0xad, 0xbe, 0xef]);
+        let ja4 = ja4_from_client_hello(&hello).unwrap();
+        assert_eq!(ja4.as_str(), "t13d1516h2_8daaf6152771_e5627efa2ab1");
     }
 
     #[test]

--- a/src/tls_fp.rs
+++ b/src/tls_fp.rs
@@ -1,0 +1,551 @@
+//! JA4 TLS client fingerprinting — Phase 3a (#27).
+//!
+//! Compile with `--features tls-fingerprint`.
+//!
+//! This module is a **pure library**: given the bytes of a TLS `ClientHello`
+//! handshake message, it computes the canonical [FoxIO JA4] client fingerprint
+//! (`ja4_a_ja4_b_ja4_c`, e.g. `t13d1516h2_8daaf6152771_e5627efa2ab1`). It does
+//! nothing else — no socket peeking, no allowlist, no config, no metrics. Those
+//! land in later commits (see #27). The parser is hand-rolled and every read is
+//! bounds-checked, so arbitrary/adversarial input yields a typed `Err`, never a
+//! panic.
+//!
+//! JA4 is deliberately reproducible across TLS libraries: GREASE values are
+//! stripped everywhere, ciphers and extension types are sorted, and only the
+//! signature-algorithms list keeps its wire order.
+//!
+//! [FoxIO JA4]: https://github.com/FoxIO-LLC/ja4/blob/main/technical_details/JA4.md
+
+// Phase 3a commit 1 ships this as a standalone library — its only consumers are
+// this module's own tests. The allowlist gate, config, and pre-handshake peek
+// hook (later #27 commits) are what wire `ja4_from_client_hello`/`Ja4`/
+// `TlsFpError` into the binary; until then they read as dead code. Drop this
+// allow when the hook lands.
+#![allow(dead_code)]
+
+use sha2::{Digest, Sha256};
+
+/// A computed JA4 client fingerprint, e.g. `t13d1516h2_8daaf6152771_e5627efa2ab1`.
+///
+/// Wraps the canonical `String`. Cheap `Hash`/`Eq` so a later commit can key an
+/// allowlist `HashSet<Ja4>` on it directly.
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+pub struct Ja4(pub String);
+
+impl Ja4 {
+    /// The fingerprint as a string slice.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for Ja4 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// Why a `ClientHello` could not be fingerprinted.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum TlsFpError {
+    /// The buffer ended mid-field (short read).
+    Truncated,
+    /// First handshake byte was not `0x01` (ClientHello).
+    NotClientHello,
+    /// A length field was internally inconsistent (e.g. odd cipher-list length).
+    Malformed,
+}
+
+impl std::fmt::Display for TlsFpError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            TlsFpError::Truncated => "truncated ClientHello",
+            TlsFpError::NotClientHello => "not a ClientHello",
+            TlsFpError::Malformed => "malformed ClientHello",
+        };
+        f.write_str(s)
+    }
+}
+
+impl std::error::Error for TlsFpError {}
+
+/// The 16 GREASE code points (RFC 8701). Stripped from ciphers, extension
+/// types, `supported_versions`, and `signature_algorithms` before counting,
+/// sorting, or hashing.
+///
+/// Predicate form (used directly): the two bytes are equal and the low nibble
+/// is `0xa` — i.e. `0x0a0a, 0x1a1a, … 0xfafa`.
+fn is_grease(v: u16) -> bool {
+    (v >> 8) == (v & 0x00ff) && (v & 0x000f) == 0x000a
+}
+
+/// A forward-only, bounds-checked cursor over a byte slice. Every accessor
+/// returns `Err(Truncated)` rather than panicking on a short read.
+struct Reader<'a> {
+    buf: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Reader<'a> {
+    fn new(buf: &'a [u8]) -> Self {
+        Reader { buf, pos: 0 }
+    }
+
+    fn remaining(&self) -> usize {
+        self.buf.len() - self.pos
+    }
+
+    fn take(&mut self, n: usize) -> Result<&'a [u8], TlsFpError> {
+        let end = self.pos.checked_add(n).ok_or(TlsFpError::Truncated)?;
+        let slice = self.buf.get(self.pos..end).ok_or(TlsFpError::Truncated)?;
+        self.pos = end;
+        Ok(slice)
+    }
+
+    fn u8(&mut self) -> Result<u8, TlsFpError> {
+        Ok(self.take(1)?[0])
+    }
+
+    fn u16(&mut self) -> Result<u16, TlsFpError> {
+        let b = self.take(2)?;
+        Ok(u16::from_be_bytes([b[0], b[1]]))
+    }
+}
+
+/// Parse a `[u16]` list packed big-endian; the slice length must be even.
+fn u16_list(bytes: &[u8]) -> Result<Vec<u16>, TlsFpError> {
+    if bytes.len() % 2 != 0 {
+        return Err(TlsFpError::Malformed);
+    }
+    Ok(bytes
+        .chunks_exact(2)
+        .map(|c| u16::from_be_bytes([c[0], c[1]]))
+        .collect())
+}
+
+/// Map a TLS version code point to its 2-char JA4 token.
+fn version_token(v: u16) -> &'static str {
+    match v {
+        0x0304 => "13",
+        0x0303 => "12",
+        0x0302 => "11",
+        0x0301 => "10",
+        0x0300 => "s3",
+        0x0002 => "s2",
+        0xfeff => "d1",
+        0xfefd => "d2",
+        0xfefc => "d3",
+        _ => "00",
+    }
+}
+
+fn is_alnum(b: u8) -> bool {
+    b.is_ascii_alphanumeric()
+}
+
+fn hex_nibble(n: u8) -> char {
+    char::from_digit((n & 0x0f) as u32, 16).unwrap_or('0')
+}
+
+/// JA4 ALPN token from the first advertised protocol id: first+last byte if both
+/// are alphanumeric (`h2` → `h2`, `http/1.1` → `h1`), else `hex(hi nibble of
+/// first) + hex(lo nibble of last)`. `00` when ALPN is absent/empty.
+fn alpn_token(first: &[u8]) -> (char, char) {
+    match (first.first(), first.last()) {
+        (Some(&f), Some(&l)) if is_alnum(f) && is_alnum(l) => (f as char, l as char),
+        (Some(&f), Some(&l)) => (hex_nibble(f >> 4), hex_nibble(l)),
+        _ => ('0', '0'),
+    }
+}
+
+/// First 12 lowercase-hex chars (6 bytes) of `SHA256(input)`.
+fn sha256_12(input: &str) -> String {
+    let digest = Sha256::digest(input.as_bytes());
+    let mut out = String::with_capacity(12);
+    for b in digest.iter().take(6) {
+        out.push_str(&format!("{b:02x}"));
+    }
+    out
+}
+
+/// Zero-padded 4-char lowercase hex of a code point (for sorting + hashing).
+fn hex4(v: u16) -> String {
+    format!("{v:04x}")
+}
+
+/// Fields extracted from a `ClientHello` that JA4 needs.
+struct ClientHelloParts {
+    legacy_version: u16,
+    ciphers: Vec<u16>,
+    ext_types: Vec<u16>,
+    sni_present: bool,
+    supported_versions: Vec<u16>,
+    sig_algs: Vec<u16>,
+    first_alpn: Vec<u8>,
+}
+
+/// Walk a `ClientHello` handshake-message body (starting at the `0x01` msg_type)
+/// and pull out the JA4-relevant fields.
+fn parse_client_hello(bytes: &[u8]) -> Result<ClientHelloParts, TlsFpError> {
+    let mut r = Reader::new(bytes);
+
+    if r.u8()? != 0x01 {
+        return Err(TlsFpError::NotClientHello);
+    }
+    let _body_len = r.take(3)?; // 24-bit length — informational; we walk fields directly
+    let legacy_version = r.u16()?;
+    let _random = r.take(32)?;
+    let sid_len = r.u8()? as usize;
+    let _session_id = r.take(sid_len)?;
+
+    let cs_len = r.u16()? as usize;
+    let ciphers = u16_list(r.take(cs_len)?)?;
+
+    let comp_len = r.u8()? as usize;
+    let _compression = r.take(comp_len)?;
+
+    let mut parts = ClientHelloParts {
+        legacy_version,
+        ciphers,
+        ext_types: Vec::new(),
+        sni_present: false,
+        supported_versions: Vec::new(),
+        sig_algs: Vec::new(),
+        first_alpn: Vec::new(),
+    };
+
+    // Extensions are optional (a bare TLS 1.2 hello may omit the block).
+    if r.remaining() == 0 {
+        return Ok(parts);
+    }
+    let ext_total = r.u16()? as usize;
+    let mut ext = Reader::new(r.take(ext_total)?);
+
+    while ext.remaining() >= 4 {
+        let ext_type = ext.u16()?;
+        let ext_len = ext.u16()? as usize;
+        let data = ext.take(ext_len)?;
+        parts.ext_types.push(ext_type);
+
+        match ext_type {
+            0x0000 => parts.sni_present = true,
+            0x0010 => {
+                // ALPN: [list_len u16][ {proto_len u8, proto bytes} … ]. Keep first.
+                let mut a = Reader::new(data);
+                let _list_len = a.u16()?;
+                let plen = a.u8()? as usize;
+                parts.first_alpn = a.take(plen)?.to_vec();
+            }
+            0x000d => {
+                // signature_algorithms: [list_len u16][ u16 … ] — WIRE order.
+                let mut s = Reader::new(data);
+                let list_len = s.u16()? as usize;
+                parts.sig_algs = u16_list(s.take(list_len)?)?;
+            }
+            0x002b => {
+                // supported_versions: [list_len u8][ u16 … ].
+                let mut s = Reader::new(data);
+                let list_len = s.u8()? as usize;
+                parts.supported_versions = u16_list(s.take(list_len)?)?;
+            }
+            _ => {}
+        }
+    }
+
+    Ok(parts)
+}
+
+/// Compute the JA4 client fingerprint from a `ClientHello` handshake-message
+/// body (the buffer must start at the `0x01` msg_type byte; a later peek/hook
+/// commit strips the 5-byte TLS record header before calling).
+///
+/// Always TLS-over-TCP (`t`); QUIC (`q`) is out of scope for Phase 3a.
+pub fn ja4_from_client_hello(bytes: &[u8]) -> Result<Ja4, TlsFpError> {
+    let p = parse_client_hello(bytes)?;
+
+    // ── JA4_a ─────────────────────────────────────────────────────────────
+    // Version: max of the GREASE-stripped supported_versions, else legacy.
+    let sv_max = p
+        .supported_versions
+        .iter()
+        .copied()
+        .filter(|v| !is_grease(*v))
+        .max();
+    let version = version_token(sv_max.unwrap_or(p.legacy_version));
+
+    let sni = if p.sni_present { 'd' } else { 'i' };
+
+    let cipher_ct = p.ciphers.iter().filter(|v| !is_grease(**v)).count().min(99);
+    let ext_ct = p
+        .ext_types
+        .iter()
+        .filter(|v| !is_grease(**v))
+        .count()
+        .min(99);
+
+    let (alpn0, alpn1) = alpn_token(&p.first_alpn);
+
+    let ja4_a = format!("t{version}{sni}{cipher_ct:02}{ext_ct:02}{alpn0}{alpn1}");
+
+    // ── JA4_b: sorted, GREASE-stripped ciphers, hashed ─────────────────────
+    let mut cipher_hex: Vec<String> = p
+        .ciphers
+        .iter()
+        .copied()
+        .filter(|v| !is_grease(*v))
+        .map(hex4)
+        .collect();
+    cipher_hex.sort();
+    let ja4_b = if cipher_hex.is_empty() {
+        "000000000000".to_string()
+    } else {
+        sha256_12(&cipher_hex.join(","))
+    };
+
+    // ── JA4_c: sorted ext types (minus SNI+ALPN) + wire-order sig-algs ─────
+    let mut ext_hex: Vec<String> = p
+        .ext_types
+        .iter()
+        .copied()
+        .filter(|v| !is_grease(*v) && *v != 0x0000 && *v != 0x0010)
+        .map(hex4)
+        .collect();
+    ext_hex.sort();
+
+    let ja4_c = if ext_hex.is_empty() {
+        "000000000000".to_string()
+    } else {
+        let sig_hex: Vec<String> = p
+            .sig_algs
+            .iter()
+            .copied()
+            .filter(|v| !is_grease(*v))
+            .map(hex4)
+            .collect();
+        // No sig-algs → NO trailing underscore (a classic JA4 off-by-one).
+        let combined = if sig_hex.is_empty() {
+            ext_hex.join(",")
+        } else {
+            format!("{}_{}", ext_hex.join(","), sig_hex.join(","))
+        };
+        sha256_12(&combined)
+    };
+
+    Ok(Ja4(format!("{ja4_a}_{ja4_b}_{ja4_c}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Append a TLS extension `[type u16][len u16][data]`.
+    fn push_ext(out: &mut Vec<u8>, etype: u16, data: &[u8]) {
+        out.extend_from_slice(&etype.to_be_bytes());
+        out.extend_from_slice(&(data.len() as u16).to_be_bytes());
+        out.extend_from_slice(data);
+    }
+
+    /// Build a canonical modern-Chrome `ClientHello` (handshake-message body)
+    /// whose GREASE-stripped, sorted cipher/extension/sig-alg lists reproduce
+    /// the FoxIO reference fingerprint `t13d1516h2_8daaf6152771_e5627efa2ab1`.
+    /// The two sub-hashes were verified independently with `shasum -a 256`.
+    fn chrome_client_hello() -> Vec<u8> {
+        // 16 ciphers = 1 GREASE + 15 real (post-GREASE count = 15).
+        let ciphers: [u16; 16] = [
+            0x0a0a, 0x1301, 0x1302, 0x1303, 0xc02b, 0xc02f, 0xc02c, 0xc030, 0xcca9, 0xcca8, 0xc013,
+            0xc014, 0x009c, 0x009d, 0x002f, 0x0035,
+        ];
+
+        // 17 extensions = 1 GREASE + 16 real (post-GREASE count = 16, incl SNI+ALPN).
+        let mut ext = Vec::new();
+        push_ext(&mut ext, 0x0a0a, &[]); // GREASE
+
+        // SNI (0x0000): server_name_list = [list_len u16][type u8=0][name_len u16][name]
+        let host = b"example.com";
+        let mut snl = vec![0x00];
+        snl.extend_from_slice(&(host.len() as u16).to_be_bytes());
+        snl.extend_from_slice(host);
+        let mut sni = (snl.len() as u16).to_be_bytes().to_vec();
+        sni.extend_from_slice(&snl);
+        push_ext(&mut ext, 0x0000, &sni);
+
+        push_ext(&mut ext, 0x0017, &[]); // extended_master_secret
+        push_ext(&mut ext, 0xff01, &[0x00]); // renegotiation_info
+        push_ext(&mut ext, 0x000a, &[0x00, 0x02, 0x00, 0x1d]); // supported_groups
+        push_ext(&mut ext, 0x000b, &[0x01, 0x00]); // ec_point_formats
+        push_ext(&mut ext, 0x0023, &[]); // session_ticket
+
+        // ALPN (0x0010): [list_len u16][proto_len u8=2]["h2"]
+        let mut alpn = 3u16.to_be_bytes().to_vec();
+        alpn.push(0x02);
+        alpn.extend_from_slice(b"h2");
+        push_ext(&mut ext, 0x0010, &alpn);
+
+        push_ext(&mut ext, 0x0005, &[0x01, 0x00, 0x00, 0x00, 0x00]); // status_request
+
+        // signature_algorithms (0x000d): WIRE order preserved in ja4_c.
+        let sig_algs: [u16; 8] = [
+            0x0403, 0x0804, 0x0401, 0x0503, 0x0805, 0x0501, 0x0806, 0x0601,
+        ];
+        let mut sa = ((sig_algs.len() * 2) as u16).to_be_bytes().to_vec();
+        for s in sig_algs {
+            sa.extend_from_slice(&s.to_be_bytes());
+        }
+        push_ext(&mut ext, 0x000d, &sa);
+
+        push_ext(&mut ext, 0x0012, &[]); // signed_certificate_timestamp
+        push_ext(&mut ext, 0x0033, &[0x00, 0x00]); // key_share (unparsed by JA4)
+        push_ext(&mut ext, 0x002d, &[0x01, 0x01]); // psk_key_exchange_modes
+
+        // supported_versions (0x002b): [len u8=6][GREASE 0x0a0a][0x0304 TLS1.3][0x0303]
+        push_ext(
+            &mut ext,
+            0x002b,
+            &[0x06, 0x0a, 0x0a, 0x03, 0x04, 0x03, 0x03],
+        );
+
+        push_ext(&mut ext, 0x0015, &[]); // padding
+        push_ext(&mut ext, 0x001b, &[0x02, 0x00, 0x02]); // compress_certificate
+        push_ext(&mut ext, 0x4469, &[0x00, 0x00]); // application_settings (ALPS)
+
+        assemble_body(0x0303, &ciphers, &ext)
+    }
+
+    /// Wrap fields into a full ClientHello handshake-message body.
+    fn assemble_body(legacy_version: u16, ciphers: &[u16], ext: &[u8]) -> Vec<u8> {
+        let mut inner = Vec::new();
+        inner.extend_from_slice(&legacy_version.to_be_bytes());
+        inner.extend_from_slice(&[0u8; 32]); // random
+        inner.push(0x00); // session_id len = 0
+        inner.extend_from_slice(&((ciphers.len() * 2) as u16).to_be_bytes());
+        for c in ciphers {
+            inner.extend_from_slice(&c.to_be_bytes());
+        }
+        inner.extend_from_slice(&[0x01, 0x00]); // 1 compression method: null
+        inner.extend_from_slice(&(ext.len() as u16).to_be_bytes());
+        inner.extend_from_slice(ext);
+
+        let mut body = vec![0x01]; // ClientHello msg_type
+        body.extend_from_slice(&(inner.len() as u32).to_be_bytes()[1..]); // 24-bit length
+        body.extend_from_slice(&inner);
+        body
+    }
+
+    #[test]
+    fn chrome_reference_fingerprint() {
+        let hello = chrome_client_hello();
+        let ja4 = ja4_from_client_hello(&hello).expect("parse");
+        assert_eq!(ja4.as_str(), "t13d1516h2_8daaf6152771_e5627efa2ab1");
+    }
+
+    #[test]
+    fn ja4_a_fields_decompose() {
+        let ja4 = ja4_from_client_hello(&chrome_client_hello()).unwrap();
+        let a = ja4.as_str().split('_').next().unwrap();
+        assert_eq!(a, "t13d1516h2");
+        // t=TCP, 13=TLS1.3, d=SNI, 15 ciphers, 16 exts, h2 ALPN.
+    }
+
+    #[test]
+    fn grease_is_stripped_from_counts_and_hashes() {
+        // The fixture carries GREASE in ciphers, extensions, and
+        // supported_versions; the reference JA4 only matches if all are stripped.
+        let ja4 = ja4_from_client_hello(&chrome_client_hello()).unwrap();
+        assert_eq!(ja4.as_str(), "t13d1516h2_8daaf6152771_e5627efa2ab1");
+    }
+
+    #[test]
+    fn sub_hashes_match_independent_sha256() {
+        // ja4_b = sha256_12 of the sorted GREASE-stripped cipher CSV.
+        assert_eq!(
+            sha256_12("002f,0035,009c,009d,1301,1302,1303,c013,c014,c02b,c02c,c02f,c030,cca8,cca9"),
+            "8daaf6152771"
+        );
+        // ja4_c = sha256_12 of "sorted exts (no SNI/ALPN)_wire-order sigalgs".
+        assert_eq!(
+            sha256_12("0005,000a,000b,000d,0012,0015,0017,001b,0023,002b,002d,0033,4469,ff01_0403,0804,0401,0503,0805,0501,0806,0601"),
+            "e5627efa2ab1"
+        );
+    }
+
+    #[test]
+    fn empty_ciphers_yield_zero_hash() {
+        // All ciphers GREASE → nothing remains → ja4_b is the literal zero hash.
+        let ciphers: [u16; 2] = [0x0a0a, 0x1a1a];
+        let mut ext = Vec::new();
+        push_ext(&mut ext, 0x002b, &[0x02, 0x03, 0x04]); // supported_versions = TLS1.3
+        let hello = assemble_body(0x0303, &ciphers, &ext);
+        let ja4 = ja4_from_client_hello(&hello).unwrap();
+        let b = ja4.as_str().split('_').nth(1).unwrap();
+        assert_eq!(b, "000000000000");
+    }
+
+    #[test]
+    fn no_sigalgs_has_no_trailing_underscore() {
+        // One non-SNI/ALPN extension (0x0017), no signature_algorithms: the
+        // hashed ja4_c input must be the ext CSV alone — no trailing '_'.
+        let ciphers: [u16; 1] = [0x1301];
+        let mut ext = Vec::new();
+        push_ext(&mut ext, 0x0017, &[]);
+        let hello = assemble_body(0x0303, &ciphers, &ext);
+        let ja4 = ja4_from_client_hello(&hello).unwrap();
+        let c = ja4.as_str().split('_').nth(2).unwrap();
+        assert_eq!(c, sha256_12("0017"));
+    }
+
+    #[test]
+    fn sni_and_alpn_counted_in_a_but_removed_from_c() {
+        // ja4_a ext count includes SNI(0000)+ALPN(0010); ja4_c hashes neither.
+        let ciphers: [u16; 1] = [0x1301];
+        let mut ext = Vec::new();
+        push_ext(&mut ext, 0x0000, &[0x00, 0x00]); // SNI (empty list)
+        push_ext(&mut ext, 0x0010, &[0x00, 0x03, 0x02, b'h', b'2']); // ALPN h2
+        push_ext(&mut ext, 0x0017, &[]); // one real ext left for ja4_c
+        let hello = assemble_body(0x0303, &ciphers, &ext);
+        let ja4 = ja4_from_client_hello(&hello).unwrap();
+        let a = ja4.as_str().split('_').next().unwrap();
+        // 1 cipher, 3 exts counted, SNI present, ALPN h2.
+        assert_eq!(a, "t12d0103h2");
+        // ja4_c hashes only 0017 (SNI+ALPN removed).
+        let c = ja4.as_str().split('_').nth(2).unwrap();
+        assert_eq!(c, sha256_12("0017"));
+    }
+
+    #[test]
+    fn not_a_client_hello_is_rejected() {
+        // 0x02 = ServerHello.
+        assert_eq!(
+            ja4_from_client_hello(&[0x02, 0x00, 0x00, 0x00]),
+            Err(TlsFpError::NotClientHello)
+        );
+    }
+
+    #[test]
+    fn truncated_buffers_never_panic() {
+        // Every prefix of a valid hello must return Err, never index-panic.
+        let hello = chrome_client_hello();
+        for n in 0..hello.len() {
+            let _ = ja4_from_client_hello(&hello[..n]); // must not panic
+        }
+        // A lone msg_type byte with no length is truncated.
+        assert_eq!(ja4_from_client_hello(&[0x01]), Err(TlsFpError::Truncated));
+        // Empty input is truncated, not a panic.
+        assert_eq!(ja4_from_client_hello(&[]), Err(TlsFpError::Truncated));
+    }
+
+    #[test]
+    fn odd_cipher_list_is_malformed() {
+        // cipher_suites length = 3 (odd) → Malformed, not a partial parse.
+        let mut body = vec![0x01, 0x00, 0x00, 0x00];
+        body.extend_from_slice(&0x0303u16.to_be_bytes());
+        body.extend_from_slice(&[0u8; 32]); // random
+        body.push(0x00); // session_id len
+        body.extend_from_slice(&3u16.to_be_bytes()); // cipher list len = 3 (odd)
+        body.extend_from_slice(&[0x13, 0x01, 0x13]);
+        body.extend_from_slice(&[0x01, 0x00]); // compression
+                                               // fix the 24-bit length to cover what we wrote
+        let inner_len = (body.len() - 4) as u32;
+        body[1..4].copy_from_slice(&inner_len.to_be_bytes()[1..]);
+        assert_eq!(ja4_from_client_hello(&body), Err(TlsFpError::Malformed));
+    }
+}


### PR DESCRIPTION
**Phase 3a (#27), commit 1 of 5** — a **pure JA4 library**, nothing wired yet. Ships behind a new opt-in `tls-fingerprint` cargo feature.

## What

`ja4_from_client_hello(bytes) -> Result<Ja4, TlsFpError>` computes the canonical [FoxIO JA4](https://github.com/FoxIO-LLC/ja4/blob/main/technical_details/JA4.md) client fingerprint from a TLS ClientHello handshake-message body — e.g. `t13d1516h2_8daaf6152771_e5627efa2ab1`.

- **Hand-rolled, fully bounds-checked** ClientHello parser. Every read goes through a cursor that returns `Err` on overrun; a truncation sweep asserts **every prefix** of a valid hello returns `Err` and never index-panics. Typed errors (`Truncated` / `NotClientHello` / `Malformed`) instead of panics on adversarial bytes.
- Correct JA4 construction: GREASE stripped from ciphers / extensions / `supported_versions` / sig-algs; ciphers + extension **types sorted**; `signature_algorithms` kept in **wire order**; SNI+ALPN **counted in `ja4_a` but removed from `ja4_c`**; `ja4_b`/`ja4_c` empty→`000000000000`; no-sig-algs → no trailing `_`.
- Public surface: `Ja4(String)` (cheap `Hash`/`Eq` for the later allowlist `HashSet`), `TlsFpError`, `ja4_from_client_hello`.

## Supply-chain / freeze

**Zero new audited crates.** The only dependency is `sha2 0.10`, already resolved transitively (0.10.9) — no version bump, so **in-policy under the v0.7.4 freeze** (#381). MSRV-1.82-clean, `--no-default-features` unaffected (verified).

## Explicitly NOT in this commit (2–5)

`[tls.fingerprint]` config + arcswap hot-reload · `off|shadow|allowlist` modes · MSG_PEEK peek · socket close/RST · ban-set DashMap · metrics · `X-Client-TLS-*` header inject/strip · the `spawn_https_handler` hook.

## Verification

- 10 unit tests incl. the **FoxIO reference vector** (both sub-hashes independently verified with `shasum -a 256`), GREASE stripping, SNI/ALPN asymmetry, empty-cipher + no-sig-algs edges, odd-cipher-list `Malformed`, and the truncation sweep.
- `cargo clippy --features tls-fingerprint --all-targets` clean · `cargo fmt --check` clean · `cargo build --no-default-features` clean · full pre-commit suite green · DCO-signed.

Roadmap for #27 continues in commit 2 (config + shadow mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)