### PR TITLE
feat(tls-fp): shadow mode — config + accept-path JA4 observation (#27, commit 2/5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Client -> TLS 1.3 -> Security Gates -> Radix Router -> WAF Pipeline (5 gates) ->
 ```
 
 <!-- zion-stats:modules-lines (kept in sync by scripts/update-readme-stats.sh) -->
-49 modules, ~42,900 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
+49 modules, ~43,200 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
 
 ## Features
 

--- a/src/acme.rs
+++ b/src/acme.rs
@@ -518,6 +518,7 @@ pub async fn run_soak() -> i32 {
         acme: None,
         client_ca_path: None,
         client_auth: "none".into(),
+        fingerprint: None,
     };
 
     // HTTP-01 responder: Pebble (via challtestsrv DNS) resolves `domain`

--- a/src/config.rs
+++ b/src/config.rs
@@ -352,6 +352,50 @@ pub struct TlsConfig {
     /// Client auth mode: "none" (default), "optional", "required".
     #[serde(default = "default_client_auth")]
     pub client_auth: String,
+    /// JA4 TLS client fingerprinting (`--features tls-fingerprint`, issue #27).
+    /// Absent or `mode = "off"` → zero overhead, no ClientHello peek.
+    #[serde(default)]
+    pub fingerprint: Option<FingerprintConfig>,
+}
+
+/// JA4 TLS client-fingerprinting config (`[tls.fingerprint]`). Always parsed so
+/// a typo is a clear error on any build; only *acted upon* under the
+/// `tls-fingerprint` feature (a feature-off `mode != off` is warned — see
+/// `warn_feature_config_gaps`). `allowed` is only read under the feature, hence
+/// the targeted allow (mirrors `AcmeConfig`).
+#[allow(dead_code)]
+#[derive(Deserialize, Clone, Debug, Default)]
+#[serde(deny_unknown_fields)]
+pub struct FingerprintConfig {
+    /// `off` (default) | `shadow` | `allowlist`. Commit 2 (#27) implements
+    /// off + shadow — compute JA4, count known/unknown, log, but NEVER block.
+    /// `allowlist` enforcement (socket close before the handshake) lands in
+    /// commit 3; until then it behaves like `shadow`.
+    #[serde(default)]
+    pub mode: FingerprintMode,
+    /// Known-good fingerprints. In `shadow` they label a connection known vs
+    /// unknown for the metrics; in `allowlist` (later) they are the allowlist.
+    #[serde(default)]
+    pub allowed: Vec<AllowedFingerprint>,
+}
+
+#[derive(Deserialize, Clone, Debug, Default, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum FingerprintMode {
+    #[default]
+    Off,
+    Shadow,
+    Allowlist,
+}
+
+#[allow(dead_code)] // fields read only under `--features tls-fingerprint`
+#[derive(Deserialize, Clone, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct AllowedFingerprint {
+    /// Human label for metrics/logs (e.g. `chrome-131`, `corp-agent`).
+    pub name: String,
+    /// The JA4 string, e.g. `t13d1516h2_8daaf6152771_e5627efa2ab1`.
+    pub ja4: String,
 }
 
 #[derive(Deserialize, Clone, Debug)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -222,6 +222,11 @@ pub(crate) struct ResolvedAppConfig {
     /// `ZionConfig.access_log` with header names already lowercased
     /// at config-load time.
     pub(crate) access_log: config::AccessLogConfig,
+    /// Resolved JA4 fingerprinting runtime (#27). `None` when the feature is off
+    /// or `[tls.fingerprint] mode = "off"` — the accept path then does no
+    /// ClientHello peek (zero overhead).
+    #[cfg(feature = "tls-fingerprint")]
+    pub(crate) tls_fingerprint: Option<tls_fp::TlsFpRuntime>,
 }
 
 impl ResolvedAppConfig {
@@ -249,6 +254,8 @@ impl ResolvedAppConfig {
             #[cfg(any(feature = "geo-ita", feature = "geo-eu"))]
             sovereign_log_classification: false,
             access_log: config::AccessLogConfig::default(),
+            #[cfg(feature = "tls-fingerprint")]
+            tls_fingerprint: None,
         }
     }
 
@@ -441,6 +448,12 @@ impl ResolvedAppConfig {
             #[cfg(any(feature = "geo-ita", feature = "geo-eu"))]
             sovereign_log_classification,
             access_log: config.access_log.clone(),
+            #[cfg(feature = "tls-fingerprint")]
+            tls_fingerprint: config
+                .tls
+                .fingerprint
+                .as_ref()
+                .and_then(tls_fp::TlsFpRuntime::from_config),
         })
     }
 }
@@ -829,7 +842,24 @@ fn warn_feature_config_gaps(config: &config::ZionConfig) {
             );
         }
     }
-    // In a build where every referenced feature is present, both blocks above
+    #[cfg(not(feature = "tls-fingerprint"))]
+    {
+        let fp_active = config
+            .tls
+            .fingerprint
+            .as_ref()
+            .is_some_and(|fp| fp.mode != config::FingerprintMode::Off);
+        if fp_active {
+            logging::warn(
+                "config",
+                "[tls.fingerprint] is set to a non-off mode but this binary was \
+                 built WITHOUT `--features tls-fingerprint` — JA4 fingerprints \
+                 are NOT computed and no connection is observed or gated. \
+                 Rebuild with `--features tls-fingerprint`.",
+            );
+        }
+    }
+    // In a build where every referenced feature is present, all blocks above
     // compile out and `config` is otherwise unused here.
     let _ = config;
 }
@@ -1786,6 +1816,12 @@ fn spawn_https_handler(
         let _conn_guard = metrics::ConnectionGuard::new();
         let _ = tcp_stream.set_nodelay(true);
         net::tune_accepted(&tcp_stream);
+        // Shadow-mode JA4 fingerprinting (#27): peek the ClientHello before the
+        // handshake and count it known/unknown. MSG_PEEK leaves the bytes in the
+        // kernel buffer for rustls to re-read. Zero cost when the feature is off
+        // or `[tls.fingerprint] mode = "off"` (resolved to `None`).
+        #[cfg(feature = "tls-fingerprint")]
+        tls_fp::shadow_observe(&tcp_stream, &state).await;
         metrics::METRICS
             .connections_total
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/src/main.rs
+++ b/src/main.rs
@@ -226,7 +226,7 @@ pub(crate) struct ResolvedAppConfig {
     /// or `[tls.fingerprint] mode = "off"` — the accept path then does no
     /// ClientHello peek (zero overhead).
     #[cfg(feature = "tls-fingerprint")]
-    pub(crate) tls_fingerprint: Option<tls_fp::TlsFpRuntime>,
+    pub(crate) tls_fingerprint: Option<std::sync::Arc<tls_fp::TlsFpRuntime>>,
 }
 
 impl ResolvedAppConfig {
@@ -453,7 +453,8 @@ impl ResolvedAppConfig {
                 .tls
                 .fingerprint
                 .as_ref()
-                .and_then(tls_fp::TlsFpRuntime::from_config),
+                .and_then(tls_fp::TlsFpRuntime::from_config)
+                .map(std::sync::Arc::new),
         })
     }
 }
@@ -1818,8 +1819,8 @@ fn spawn_https_handler(
         net::tune_accepted(&tcp_stream);
         // Shadow-mode JA4 fingerprinting (#27): peek the ClientHello before the
         // handshake and count it known/unknown. MSG_PEEK leaves the bytes in the
-        // kernel buffer for rustls to re-read. Zero cost when the feature is off
-        // or `[tls.fingerprint] mode = "off"` (resolved to `None`).
+        // kernel buffer for rustls to re-read. No peek — no syscall — when the
+        // feature is off or `[tls.fingerprint] mode = "off"` (resolved to `None`).
         #[cfg(feature = "tls-fingerprint")]
         tls_fp::shadow_observe(&tcp_stream, &state).await;
         metrics::METRICS

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -407,6 +407,11 @@ pub struct Metrics {
     pub websocket_upgrades: AtomicU64,
     pub connections_total: AtomicU64,
     pub tls_handshake_errors: AtomicU64,
+    /// JA4 client fingerprints observed in shadow mode (#27): matched an
+    /// allowlist entry (`known`) vs not (`unknown`). Advisory only — shadow
+    /// mode never gates a connection.
+    pub tls_fp_known: AtomicU64,
+    pub tls_fp_unknown: AtomicU64,
     /// Connections closed at accept because the source IP was already at
     /// its `max_connections_per_ip` concurrent cap (anti-DDoS lever).
     pub connections_rejected_per_ip: AtomicU64,
@@ -506,6 +511,8 @@ impl Metrics {
             websocket_upgrades: AtomicU64::new(0),
             connections_total: AtomicU64::new(0),
             tls_handshake_errors: AtomicU64::new(0),
+            tls_fp_known: AtomicU64::new(0),
+            tls_fp_unknown: AtomicU64::new(0),
             connections_rejected_per_ip: AtomicU64::new(0),
             enforcement_denied_class: AtomicU64::new(0),
             enforcement_denied_mesh_score: AtomicU64::new(0),
@@ -757,6 +764,26 @@ impl Metrics {
         out.extend_from_slice(
             itoa_buf
                 .format(self.connections_total.load(Relaxed))
+                .as_bytes(),
+        );
+        out.extend_from_slice(b"\n");
+
+        out.extend_from_slice(
+            b"# HELP zion_tls_fp_known Shadow-mode JA4 fingerprints matching an allowlist entry.\n\
+                                # TYPE zion_tls_fp_known counter\n\
+                                zion_tls_fp_known ",
+        );
+        out.extend_from_slice(itoa_buf.format(self.tls_fp_known.load(Relaxed)).as_bytes());
+        out.extend_from_slice(b"\n");
+
+        out.extend_from_slice(
+            b"# HELP zion_tls_fp_unknown Shadow-mode JA4 fingerprints not on the allowlist.\n\
+                                # TYPE zion_tls_fp_unknown counter\n\
+                                zion_tls_fp_unknown ",
+        );
+        out.extend_from_slice(
+            itoa_buf
+                .format(self.tls_fp_unknown.load(Relaxed))
                 .as_bytes(),
         );
         out.extend_from_slice(b"\n");

--- a/src/tls_fp.rs
+++ b/src/tls_fp.rs
@@ -426,6 +426,16 @@ impl TlsFpRuntime {
     }
 }
 
+/// Bytes peeked to cover a full ClientHello — big enough for a TLS 1.3 hybrid
+/// post-quantum key share (X25519MLKEM768 pushes the record past ~1.5 KB); a
+/// 1 KB buffer would silently truncate exactly the modern browsers we most want
+/// to fingerprint.
+const PEEK_CAP: usize = 4096;
+
+/// Upper bound on the pre-handshake peek. A real ClientHello is the first thing
+/// sent after TCP connect, so this only bites a client that connects and stalls.
+const PEEK_BUDGET: std::time::Duration = std::time::Duration::from_secs(3);
+
 /// Shadow-mode observation on the accept path: `MSG_PEEK` the ClientHello
 /// (leaving the bytes in the kernel buffer for rustls to re-read), compute JA4,
 /// and count it known vs unknown against the allowlist. It NEVER blocks — the
@@ -434,13 +444,24 @@ impl TlsFpRuntime {
 /// A ClientHello that can't be peeked or parsed yet (fragmented, not buffered)
 /// is silently skipped: shadow mode observes, it never fails a connection.
 pub async fn shadow_observe(stream: &tokio::net::TcpStream, state: &crate::AppState) {
-    let cfg = state.config.load();
-    let Some(fp) = cfg.tls_fingerprint.as_ref() else {
-        return; // mode = off → nothing resolved → zero cost
+    // Clone the resolved runtime out (a cheap Arc clone) and DROP the arc-swap
+    // Guard before awaiting — never hold a config Guard across an await point.
+    let fp = {
+        let cfg = state.config.load();
+        match cfg.tls_fingerprint.as_ref() {
+            Some(fp) => fp.clone(),
+            None => return, // mode = off → no peek, no syscall
+        }
     };
-    let mut buf = [0u8; 1024];
-    let n = match stream.peek(&mut buf).await {
-        Ok(n) if n > 0 => n,
+    // Bound the peek. This runs BEFORE the rustls accept (which is 10s-bounded),
+    // while already holding the connection permit + per-IP slot, so an unbounded
+    // wait on a client that connects and sends nothing would be a slow-loris
+    // amplification. On timeout/short/EOF, skip fingerprinting and let the
+    // connection proceed into the bounded handshake — shadow mode must never
+    // extend a connection's pre-handshake lifetime.
+    let mut buf = [0u8; PEEK_CAP];
+    let n = match tokio::time::timeout(PEEK_BUDGET, stream.peek(&mut buf)).await {
+        Ok(Ok(n)) if n > 0 => n,
         _ => return,
     };
     // A truncated / fragmented / not-a-ClientHello peek is skipped silently —

--- a/src/tls_fp.rs
+++ b/src/tls_fp.rs
@@ -436,6 +436,49 @@ const PEEK_CAP: usize = 4096;
 /// sent after TCP connect, so this only bites a client that connects and stalls.
 const PEEK_BUDGET: std::time::Duration = std::time::Duration::from_secs(3);
 
+/// Does the buffer already hold a complete first TLS record (5-byte header +
+/// its declared payload)?
+fn first_record_complete(buf: &[u8]) -> bool {
+    buf.len() >= 5 && buf.len() >= 5 + (((buf[3] as usize) << 8) | buf[4] as usize)
+}
+
+/// `MSG_PEEK` the first TLS record (the ClientHello) without consuming it,
+/// waiting — up to `PEEK_BUDGET` — for the rest of a ClientHello that arrives
+/// split across TCP segments (a TLS 1.3 hybrid post-quantum ClientHello exceeds
+/// one MSS, so its first peek is otherwise a partial record and gets dropped).
+/// Returns the peeked length, or `None` on timeout / EOF / error. Every byte is
+/// left in the kernel buffer for rustls to re-read.
+///
+/// This runs BEFORE the 10s-bounded rustls accept, while already holding the
+/// connection permit + per-IP slot, so it MUST be bounded: an unbounded wait on
+/// a client that connects and sends nothing is a slow-loris amplification.
+async fn peek_client_hello(stream: &tokio::net::TcpStream, buf: &mut [u8]) -> Option<usize> {
+    let deadline = tokio::time::Instant::now() + PEEK_BUDGET;
+    loop {
+        let n = match tokio::time::timeout_at(deadline, stream.peek(buf)).await {
+            Ok(Ok(n)) if n > 0 => n,
+            _ => return None,
+        };
+        // Not a handshake record (don't wait on non-TLS/garbage), the whole
+        // first record is here, or the buffer is full → classify what we have.
+        if buf[0] != 0x16 || first_record_complete(&buf[..n]) || n == buf.len() {
+            return Some(n);
+        }
+        // Partial handshake record — briefly wait for the rest, bounded by the
+        // deadline. Sleeping (not spinning): the next TCP segment arrives within
+        // an RTT, and a stalled client is capped by PEEK_BUDGET.
+        if tokio::time::timeout_at(
+            deadline,
+            tokio::time::sleep(std::time::Duration::from_millis(2)),
+        )
+        .await
+        .is_err()
+        {
+            return Some(n); // deadline hit — classify what we have (likely Truncated → skip)
+        }
+    }
+}
+
 /// Shadow-mode observation on the accept path: `MSG_PEEK` the ClientHello
 /// (leaving the bytes in the kernel buffer for rustls to re-read), compute JA4,
 /// and count it known vs unknown against the allowlist. It NEVER blocks — the
@@ -453,19 +496,12 @@ pub async fn shadow_observe(stream: &tokio::net::TcpStream, state: &crate::AppSt
             None => return, // mode = off → no peek, no syscall
         }
     };
-    // Bound the peek. This runs BEFORE the rustls accept (which is 10s-bounded),
-    // while already holding the connection permit + per-IP slot, so an unbounded
-    // wait on a client that connects and sends nothing would be a slow-loris
-    // amplification. On timeout/short/EOF, skip fingerprinting and let the
-    // connection proceed into the bounded handshake — shadow mode must never
-    // extend a connection's pre-handshake lifetime.
     let mut buf = [0u8; PEEK_CAP];
-    let n = match tokio::time::timeout(PEEK_BUDGET, stream.peek(&mut buf)).await {
-        Ok(Ok(n)) if n > 0 => n,
-        _ => return,
+    let Some(n) = peek_client_hello(stream, &mut buf).await else {
+        return; // timeout / EOF / stalled client — never extend the pre-handshake lifetime
     };
-    // A truncated / fragmented / not-a-ClientHello peek is skipped silently —
-    // shadow mode observes, it never fails a connection.
+    // A truncated / not-a-ClientHello peek is skipped silently — shadow mode
+    // observes, it never fails a connection.
     if let Ok(ja4) = ja4_from_tls_record(&buf[..n]) {
         if fp.known_name(&ja4).is_some() {
             crate::metrics::METRICS
@@ -600,6 +636,16 @@ mod tests {
         let rec = wrap_record(&chrome_client_hello());
         let ja4 = ja4_from_tls_record(&rec).expect("record parse");
         assert_eq!(ja4.as_str(), "t13d1516h2_8daaf6152771_e5627efa2ab1");
+    }
+
+    #[test]
+    fn first_record_complete_boundary() {
+        // Drives the peek-completion loop: keep waiting until the whole first
+        // record is buffered (so a multi-segment PQ ClientHello isn't dropped).
+        let rec = wrap_record(&chrome_client_hello());
+        assert!(first_record_complete(&rec));
+        assert!(!first_record_complete(&rec[..rec.len() - 1])); // one byte short
+        assert!(!first_record_complete(&[0x16, 0x03, 0x01])); // header not even complete
     }
 
     #[test]

--- a/src/tls_fp.rs
+++ b/src/tls_fp.rs
@@ -368,6 +368,97 @@ pub fn ja4_from_client_hello(bytes: &[u8]) -> Result<Ja4, TlsFpError> {
     Ok(Ja4(format!("{ja4_a}_{ja4_b}_{ja4_c}")))
 }
 
+/// Compute JA4 from a raw TLS record buffer as `MSG_PEEK`'d off the socket — the
+/// buffer starts at the 5-byte TLS record header (`content_type`, legacy
+/// version, length). Strips the header and fingerprints the ClientHello in the
+/// first handshake record.
+///
+/// Only the first record is inspected. A ClientHello fragmented across multiple
+/// TLS records (rare, and something a peek may also simply not have buffered
+/// yet) yields `Truncated` — the shadow-mode caller treats that as "not
+/// fingerprinted this time" rather than an error to act on. Bytes beyond the
+/// first record (a coalesced second record) are ignored.
+pub fn ja4_from_tls_record(bytes: &[u8]) -> Result<Ja4, TlsFpError> {
+    let mut r = Reader::new(bytes);
+    // TLS record: content_type(1) = 22 handshake, legacy_version(2), length(2).
+    if r.u8()? != 0x16 {
+        return Err(TlsFpError::NotClientHello);
+    }
+    let _legacy_version = r.u16()?;
+    let rec_len = r.u16()? as usize;
+    // The handshake message (starting at the 0x01 ClientHello msg_type) is the
+    // record payload. ja4_from_client_hello clamps to the handshake's own 24-bit
+    // length, so a short/fragmented payload comes back as Truncated.
+    let payload = r.take(rec_len)?;
+    ja4_from_client_hello(payload)
+}
+
+/// Runtime-resolved fingerprint state, read on the accept path. Built once per
+/// config load from `[tls.fingerprint]`; the resolver returns `None` for
+/// `mode = off` so the hot path pays nothing when the feature is unused.
+#[derive(Clone, Debug)]
+pub struct TlsFpRuntime {
+    pub mode: crate::config::FingerprintMode,
+    /// JA4 string → allowlist entry name (for the known/unknown metric split).
+    allowed: std::collections::HashMap<String, String>,
+}
+
+impl TlsFpRuntime {
+    /// Resolve from config; `None` for `mode = off` (zero hot-path cost).
+    pub fn from_config(cfg: &crate::config::FingerprintConfig) -> Option<Self> {
+        if cfg.mode == crate::config::FingerprintMode::Off {
+            return None;
+        }
+        let allowed = cfg
+            .allowed
+            .iter()
+            .map(|a| (a.ja4.clone(), a.name.clone()))
+            .collect();
+        Some(TlsFpRuntime {
+            mode: cfg.mode.clone(),
+            allowed,
+        })
+    }
+
+    /// The allowlist entry name for a fingerprint, if it is known.
+    pub fn known_name(&self, ja4: &Ja4) -> Option<&str> {
+        self.allowed.get(ja4.as_str()).map(String::as_str)
+    }
+}
+
+/// Shadow-mode observation on the accept path: `MSG_PEEK` the ClientHello
+/// (leaving the bytes in the kernel buffer for rustls to re-read), compute JA4,
+/// and count it known vs unknown against the allowlist. It NEVER blocks — the
+/// allowlist gate (closing the socket before the handshake) is #27 commit 3.
+///
+/// A ClientHello that can't be peeked or parsed yet (fragmented, not buffered)
+/// is silently skipped: shadow mode observes, it never fails a connection.
+pub async fn shadow_observe(stream: &tokio::net::TcpStream, state: &crate::AppState) {
+    let cfg = state.config.load();
+    let Some(fp) = cfg.tls_fingerprint.as_ref() else {
+        return; // mode = off → nothing resolved → zero cost
+    };
+    let mut buf = [0u8; 1024];
+    let n = match stream.peek(&mut buf).await {
+        Ok(n) if n > 0 => n,
+        _ => return,
+    };
+    // A truncated / fragmented / not-a-ClientHello peek is skipped silently —
+    // shadow mode observes, it never fails a connection.
+    if let Ok(ja4) = ja4_from_tls_record(&buf[..n]) {
+        if fp.known_name(&ja4).is_some() {
+            crate::metrics::METRICS
+                .tls_fp_known
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        } else {
+            crate::metrics::METRICS
+                .tls_fp_unknown
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            tracing::info!(ja4 = %ja4, "tls-fp: unknown ClientHello fingerprint (shadow mode)");
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -472,6 +563,60 @@ mod tests {
         assert_eq!(ja4.as_str(), "t13d1516h2_8daaf6152771_e5627efa2ab1");
     }
 
+    /// Wrap a handshake-message body in a TLS handshake record header
+    /// (`0x16`, legacy version 0x0301, length).
+    fn wrap_record(body: &[u8]) -> Vec<u8> {
+        let mut rec = vec![0x16, 0x03, 0x01];
+        rec.extend_from_slice(&(body.len() as u16).to_be_bytes());
+        rec.extend_from_slice(body);
+        rec
+    }
+
+    #[test]
+    fn tls_record_wrapper_matches_reference() {
+        // The record-framed ClientHello (as MSG_PEEK'd off the socket) yields the
+        // same fingerprint as the bare handshake body.
+        let rec = wrap_record(&chrome_client_hello());
+        let ja4 = ja4_from_tls_record(&rec).expect("record parse");
+        assert_eq!(ja4.as_str(), "t13d1516h2_8daaf6152771_e5627efa2ab1");
+    }
+
+    #[test]
+    fn tls_record_ignores_a_coalesced_second_record() {
+        // A peek that also grabbed the start of a second record must not corrupt
+        // the fingerprint — only the first record's payload is read.
+        let mut rec = wrap_record(&chrome_client_hello());
+        rec.extend_from_slice(&[0x17, 0x03, 0x03, 0x00, 0x05, 1, 2, 3, 4, 5]); // app-data record
+        let ja4 = ja4_from_tls_record(&rec).unwrap();
+        assert_eq!(ja4.as_str(), "t13d1516h2_8daaf6152771_e5627efa2ab1");
+    }
+
+    #[test]
+    fn non_handshake_record_is_rejected() {
+        // 0x17 = application_data, not a handshake record.
+        let mut rec = vec![0x17, 0x03, 0x03];
+        rec.extend_from_slice(&4u16.to_be_bytes());
+        rec.extend_from_slice(&[0, 0, 0, 0]);
+        assert_eq!(ja4_from_tls_record(&rec), Err(TlsFpError::NotClientHello));
+    }
+
+    #[test]
+    fn fragmented_record_payload_is_truncated_not_a_panic() {
+        // A record whose declared length exceeds the buffer (peek caught only a
+        // fragment) → Truncated, never a panic.
+        let rec = wrap_record(&chrome_client_hello());
+        for n in 0..rec.len() {
+            let _ = ja4_from_tls_record(&rec[..n]); // must not panic
+        }
+        // A record header claiming more payload than present.
+        let hello = chrome_client_hello();
+        let mut rec = wrap_record(&hello);
+        let inflated = (hello.len() as u16 + 50).to_be_bytes();
+        rec[3] = inflated[0];
+        rec[4] = inflated[1];
+        assert_eq!(ja4_from_tls_record(&rec), Err(TlsFpError::Truncated));
+    }
+
     #[test]
     fn ja4_a_fields_decompose() {
         let ja4 = ja4_from_client_hello(&chrome_client_hello()).unwrap();
@@ -486,6 +631,31 @@ mod tests {
         // supported_versions; the reference JA4 only matches if all are stripped.
         let ja4 = ja4_from_client_hello(&chrome_client_hello()).unwrap();
         assert_eq!(ja4.as_str(), "t13d1516h2_8daaf6152771_e5627efa2ab1");
+    }
+
+    #[test]
+    fn runtime_resolves_off_to_none_and_classifies() {
+        use crate::config::{AllowedFingerprint, FingerprintConfig, FingerprintMode};
+        // mode = off → None, so the accept path pays nothing.
+        let off = FingerprintConfig {
+            mode: FingerprintMode::Off,
+            allowed: vec![],
+        };
+        assert!(TlsFpRuntime::from_config(&off).is_none());
+
+        // shadow with an allowlist → Some; known_name classifies known vs unknown.
+        let cfg = FingerprintConfig {
+            mode: FingerprintMode::Shadow,
+            allowed: vec![AllowedFingerprint {
+                name: "chrome".into(),
+                ja4: "t13d1516h2_8daaf6152771_e5627efa2ab1".into(),
+            }],
+        };
+        let rt = TlsFpRuntime::from_config(&cfg).expect("shadow resolves to Some");
+        let known = ja4_from_client_hello(&chrome_client_hello()).unwrap();
+        assert_eq!(rt.known_name(&known), Some("chrome"));
+        let unknown = Ja4("t00i0000_000000000000_000000000000".into());
+        assert_eq!(rt.known_name(&unknown), None);
     }
 
     #[test]


### PR DESCRIPTION
**Phase 3a (#27), commit 2 of 5** — wires the merged commit-1 JA4 library into a **non-blocking shadow mode**. Every ClientHello is fingerprinted and counted known/unknown against a configured allowlist. **Never gates a connection** — the socket-close gate is commit 3.

## What

```toml
[tls.fingerprint]
mode = "shadow"          # off (default) | shadow | allowlist
allowed = [
  { name = "chrome",  ja4 = "t13d1516h2_8daaf6152771_e5627efa2ab1" },
  { name = "firefox", ja4 = "t13d1715h2_5b57614c22b0_7121afd63204" },
]
```

- **`ja4_from_tls_record`** — strips the 5-byte TLS record header off a `MSG_PEEK`'d buffer. First record only; a fragmented/short peek returns `Truncated` (never panics — a truncation sweep + coalesced-second-record test prove it).
- **`shadow_observe`** — the accept-path hook in `spawn_https_handler`, one cfg-gated line **before** the rustls handshake: `MSG_PEEK` the ClientHello (bytes stay in the kernel buffer for rustls to re-read → no handshake interference), compute JA4, bump `zion_tls_fp_known` / `zion_tls_fp_unknown`, log unknowns.
- **`TlsFpRuntime`** — resolved allowlist map; `from_config` returns `None` for `mode = off`, so the hot path pays **nothing** when unused. Resolved into `ResolvedAppConfig`, so it **hot-reloads** via the existing arcswap snapshot.
- Config always parses (clear errors on any build, mirrors `AcmeConfig`); a feature-off non-off mode is caught by `warn_feature_config_gaps`.

## Zero-overhead-when-off

Feature off → the module + hook compile out. Feature on + `mode = off` (or no `[tls.fingerprint]`) → runtime resolves to `None` → no peek. `--no-default-features` and default builds unaffected.

## Verification

- 19 `tls_fp` unit tests (record wrapper, runtime resolution off→None, known/unknown classification) + the commit-1 JA4 suite.
- `cargo clippy` (feature on + default, `--all-targets`) clean · `cargo fmt --check` clean · full pre-commit suite green · DCO-signed.

`allowlist` mode currently behaves like `shadow` (observe, don't block) until **commit 3** adds enforcement + `on_unknown` policy + the banned-set short-circuit. Recommended rollout: run `shadow` in production for 7–30 days, watch `zion_tls_fp_unknown`, build the allowlist from real traffic, *then* enable `allowlist`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)