### PR TITLE
feat(tls-fp): allowlist enforcement — the JA4 gate (#27, commit 3/5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Client -> TLS 1.3 -> Security Gates -> Radix Router -> WAF Pipeline (5 gates) ->
 ```
 
 <!-- zion-stats:modules-lines (kept in sync by scripts/update-readme-stats.sh) -->
-49 modules, ~43,200 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
+49 modules, ~43,400 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Client -> TLS 1.3 -> Security Gates -> Radix Router -> WAF Pipeline (5 gates) ->
 ```
 
 <!-- zion-stats:modules-lines (kept in sync by scripts/update-readme-stats.sh) -->
-49 modules, ~43,400 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
+49 modules, ~43,500 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
 
 ## Features
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -905,6 +905,18 @@ fn semantic_errors(config: &ZionConfig) -> Vec<String> {
                     .to_string(),
             );
         }
+        // A malformed allowlist entry can never match a computed JA4, so under
+        // on_unknown = drop it is a silent deny-all the empty-list check above
+        // misses. Surface the typo at boot instead of as a production outage.
+        for a in &fp.allowed {
+            if !crate::tls_fp::looks_like_ja4(&a.ja4) {
+                errors.push(format!(
+                    "[tls.fingerprint] allowed entry '{}' has an invalid JA4 '{}' \
+                     (expected e.g. t13d1516h2_8daaf6152771_e5627efa2ab1)",
+                    a.name, a.ja4
+                ));
+            }
+        }
     }
 
     // SNI entries need a subject to match on (file existence is deploy-time)
@@ -1651,6 +1663,22 @@ mod tests {
         let cfg = parse_schema(deny_all, "test").expect("parse");
         let err = validate_semantics(&cfg, "test").err().unwrap_or_default();
         assert!(err.contains("drop EVERY connection"), "got: {err}");
+    }
+
+    #[cfg(feature = "tls-fingerprint")]
+    #[test]
+    fn allowlist_malformed_ja4_is_rejected() {
+        // A non-empty allowlist of unmatchable entries is an equivalent deny-all;
+        // surface the typo at boot, not as a silent production outage.
+        let bad = "[server]\nlisten_http=\"0.0.0.0:80\"\nlisten_https=\"0.0.0.0:443\"\n\
+             [tls]\ncert_path=\"/c\"\nkey_path=\"/k\"\n\
+             [tls.fingerprint]\nmode=\"allowlist\"\non_unknown=\"drop\"\n\
+             allowed=[{name=\"typo\",ja4=\"not-a-ja4\"}]\n\
+             [upstreams]\nbe=\"http://127.0.0.1:8000\"\n\
+             [[route]]\npath=\"/{*rest}\"\nupstream=\"be\"\n";
+        let cfg = parse_schema(bad, "test").expect("parse");
+        let err = validate_semantics(&cfg, "test").err().unwrap_or_default();
+        assert!(err.contains("invalid JA4"), "got: {err}");
     }
 
     #[cfg(feature = "tls-fingerprint")]

--- a/src/config.rs
+++ b/src/config.rs
@@ -367,10 +367,12 @@ pub struct TlsConfig {
 #[derive(Deserialize, Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct FingerprintConfig {
-    /// `off` (default) | `shadow` | `allowlist`. Commit 2 (#27) implements
-    /// off + shadow — compute JA4, count known/unknown, log, but NEVER block.
-    /// `allowlist` enforcement (socket close before the handshake) lands in
-    /// commit 3; until then it behaves like `shadow`.
+    /// `off` (default) | `shadow` | `allowlist`.
+    /// - `off`: no fingerprinting; zero overhead.
+    /// - `shadow`: compute JA4, count known/unknown, log — but never block.
+    /// - `allowlist`: additionally enforce — a fingerprint not in `allowed` is
+    ///   handled per `on_unknown`, an unfingerprintable ClientHello per
+    ///   `on_unfingerprintable` (a `drop` closes the socket before the handshake).
     #[serde(default)]
     pub mode: FingerprintMode,
     /// Known-good fingerprints. In `shadow` they label a connection known vs

--- a/src/config.rs
+++ b/src/config.rs
@@ -374,9 +374,19 @@ pub struct FingerprintConfig {
     #[serde(default)]
     pub mode: FingerprintMode,
     /// Known-good fingerprints. In `shadow` they label a connection known vs
-    /// unknown for the metrics; in `allowlist` (later) they are the allowlist.
+    /// unknown for the metrics; in `allowlist` they are the enforced allowlist.
     #[serde(default)]
     pub allowed: Vec<AllowedFingerprint>,
+    /// `allowlist` mode: what to do with a fingerprint not in `allowed`.
+    /// Default `log_only` — observe without blocking. `drop` closes the socket
+    /// before the TLS handshake.
+    #[serde(default)]
+    pub on_unknown: OnUnknown,
+    /// `allowlist` mode: what to do with a connection whose ClientHello can't be
+    /// fingerprinted (peek timed out, record larger than the buffer, not TLS).
+    /// Default `allow` — availability first; `drop` fails closed for the strict.
+    #[serde(default)]
+    pub on_unfingerprintable: OnUnfingerprintable,
 }
 
 #[derive(Deserialize, Clone, Debug, Default, PartialEq, Eq)]
@@ -386,6 +396,26 @@ pub enum FingerprintMode {
     Off,
     Shadow,
     Allowlist,
+}
+
+#[derive(Deserialize, Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum OnUnknown {
+    /// Log + count the unknown fingerprint; let the connection proceed.
+    #[default]
+    LogOnly,
+    /// Close the socket before the TLS handshake.
+    Drop,
+}
+
+#[derive(Deserialize, Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum OnUnfingerprintable {
+    /// Let the connection proceed into the handshake (availability first).
+    #[default]
+    Allow,
+    /// Close the socket before the TLS handshake.
+    Drop,
 }
 
 #[allow(dead_code)] // fields read only under `--features tls-fingerprint`
@@ -856,6 +886,25 @@ fn semantic_errors(config: &ZionConfig) -> Vec<String> {
             "server.listen_https '{}' is not a valid address",
             config.server.listen_https
         ));
+    }
+
+    // [tls.fingerprint]: an allowlist that drops every unknown but lists no
+    // allowed entries would deny ALL traffic — refuse to boot into a total
+    // outage. Only enforced where it would actually bite (feature on); a
+    // feature-off build is handled by warn_feature_config_gaps instead.
+    #[cfg(feature = "tls-fingerprint")]
+    if let Some(fp) = &config.tls.fingerprint {
+        if fp.mode == FingerprintMode::Allowlist
+            && fp.on_unknown == OnUnknown::Drop
+            && fp.allowed.is_empty()
+        {
+            errors.push(
+                "[tls.fingerprint] mode = \"allowlist\" with on_unknown = \"drop\" and an \
+                 empty `allowed` list would drop EVERY connection. Add allowed entries, set \
+                 on_unknown = \"log_only\", or use mode = \"shadow\"."
+                    .to_string(),
+            );
+        }
     }
 
     // SNI entries need a subject to match on (file existence is deploy-time)
@@ -1587,6 +1636,38 @@ mod tests {
             waf_shadow: false,
             cors: None,
         }
+    }
+
+    #[cfg(feature = "tls-fingerprint")]
+    #[test]
+    fn allowlist_drop_empty_list_refuses_boot() {
+        // mode=allowlist + on_unknown=drop + empty allowed = drop EVERYTHING.
+        let deny_all = "[server]\nlisten_http=\"0.0.0.0:80\"\nlisten_https=\"0.0.0.0:443\"\n\
+             [tls]\ncert_path=\"/c\"\nkey_path=\"/k\"\n\
+             [tls.fingerprint]\nmode=\"allowlist\"\non_unknown=\"drop\"\nallowed=[]\n\
+             [upstreams]\nbe=\"http://127.0.0.1:8000\"\n\
+             [[route]]\npath=\"/{*rest}\"\nupstream=\"be\"\n";
+        // Semantic (filesystem-free) validation — the cert paths need not exist.
+        let cfg = parse_schema(deny_all, "test").expect("parse");
+        let err = validate_semantics(&cfg, "test").err().unwrap_or_default();
+        assert!(err.contains("drop EVERY connection"), "got: {err}");
+    }
+
+    #[cfg(feature = "tls-fingerprint")]
+    #[test]
+    fn allowlist_log_only_empty_list_boots() {
+        // log_only never drops, so an empty allowlist is harmless — must pass.
+        let ok = "[server]\nlisten_http=\"0.0.0.0:80\"\nlisten_https=\"0.0.0.0:443\"\n\
+             [tls]\ncert_path=\"/c\"\nkey_path=\"/k\"\n\
+             [tls.fingerprint]\nmode=\"allowlist\"\non_unknown=\"log_only\"\nallowed=[]\n\
+             [upstreams]\nbe=\"http://127.0.0.1:8000\"\n\
+             [[route]]\npath=\"/{*rest}\"\nupstream=\"be\"\n";
+        let cfg = parse_schema(ok, "test").expect("parse");
+        assert!(
+            validate_semantics(&cfg, "test").is_ok(),
+            "log_only empty allowlist must pass semantics, got: {:?}",
+            validate_semantics(&cfg, "test").err()
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -860,6 +860,26 @@ fn warn_feature_config_gaps(config: &config::ZionConfig) {
             );
         }
     }
+    // Enforcement with an open side door: an allowlist that drops unknown
+    // fingerprints but lets un-fingerprintable ClientHellos through can be
+    // bypassed by a client that fragments/oversizes its hello. Warn so the
+    // operator opts into on_unfingerprintable = "drop" deliberately.
+    #[cfg(feature = "tls-fingerprint")]
+    if let Some(fp) = &config.tls.fingerprint {
+        if fp.mode == config::FingerprintMode::Allowlist
+            && fp.on_unknown == config::OnUnknown::Drop
+            && fp.on_unfingerprintable == config::OnUnfingerprintable::Allow
+        {
+            logging::warn(
+                "config",
+                "[tls.fingerprint] allowlist drops unknown fingerprints but \
+                 on_unfingerprintable = \"allow\" (default) — a client can BYPASS \
+                 the allowlist by fragmenting or oversizing its ClientHello so it \
+                 can't be fingerprinted. Set on_unfingerprintable = \"drop\" for \
+                 strict zero-trust.",
+            );
+        }
+    }
     // In a build where every referenced feature is present, all blocks above
     // compile out and `config` is otherwise unused here.
     let _ = config;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1817,12 +1817,17 @@ fn spawn_https_handler(
         let _conn_guard = metrics::ConnectionGuard::new();
         let _ = tcp_stream.set_nodelay(true);
         net::tune_accepted(&tcp_stream);
-        // Shadow-mode JA4 fingerprinting (#27): peek the ClientHello before the
-        // handshake and count it known/unknown. MSG_PEEK leaves the bytes in the
-        // kernel buffer for rustls to re-read. No peek — no syscall — when the
-        // feature is off or `[tls.fingerprint] mode = "off"` (resolved to `None`).
+        // JA4 fingerprint gate (#27): peek the ClientHello before the handshake,
+        // compute JA4, count known/unknown. MSG_PEEK leaves the bytes in the
+        // kernel buffer for rustls to re-read. In allowlist mode a rejected
+        // fingerprint closes the connection HERE, before any handshake. No peek —
+        // no syscall — when the feature is off or mode = off (runtime `None`).
         #[cfg(feature = "tls-fingerprint")]
-        tls_fp::shadow_observe(&tcp_stream, &state).await;
+        if tls_fp::fingerprint_gate(&tcp_stream, &state).await == tls_fp::GateDecision::Reject {
+            // Dropping tcp_stream closes the socket; the connection permit and
+            // per-IP slot release when their guards drop at end of scope.
+            return;
+        }
         metrics::METRICS
             .connections_total
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -412,6 +412,10 @@ pub struct Metrics {
     /// mode never gates a connection.
     pub tls_fp_known: AtomicU64,
     pub tls_fp_unknown: AtomicU64,
+    /// Connections closed before the TLS handshake by the JA4 allowlist gate
+    /// (#27): an unknown fingerprint under `on_unknown = drop`, or an
+    /// unfingerprintable ClientHello under `on_unfingerprintable = drop`.
+    pub tls_fp_rejected: AtomicU64,
     /// Connections closed at accept because the source IP was already at
     /// its `max_connections_per_ip` concurrent cap (anti-DDoS lever).
     pub connections_rejected_per_ip: AtomicU64,
@@ -513,6 +517,7 @@ impl Metrics {
             tls_handshake_errors: AtomicU64::new(0),
             tls_fp_known: AtomicU64::new(0),
             tls_fp_unknown: AtomicU64::new(0),
+            tls_fp_rejected: AtomicU64::new(0),
             connections_rejected_per_ip: AtomicU64::new(0),
             enforcement_denied_class: AtomicU64::new(0),
             enforcement_denied_mesh_score: AtomicU64::new(0),
@@ -784,6 +789,18 @@ impl Metrics {
         out.extend_from_slice(
             itoa_buf
                 .format(self.tls_fp_unknown.load(Relaxed))
+                .as_bytes(),
+        );
+        out.extend_from_slice(b"\n");
+
+        out.extend_from_slice(
+            b"# HELP zion_tls_fp_rejected Connections closed before the handshake by the JA4 allowlist gate.\n\
+                                # TYPE zion_tls_fp_rejected counter\n\
+                                zion_tls_fp_rejected ",
+        );
+        out.extend_from_slice(
+            itoa_buf
+                .format(self.tls_fp_rejected.load(Relaxed))
                 .as_bytes(),
         );
         out.extend_from_slice(b"\n");

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -407,9 +407,9 @@ pub struct Metrics {
     pub websocket_upgrades: AtomicU64,
     pub connections_total: AtomicU64,
     pub tls_handshake_errors: AtomicU64,
-    /// JA4 client fingerprints observed in shadow mode (#27): matched an
-    /// allowlist entry (`known`) vs not (`unknown`). Advisory only — shadow
-    /// mode never gates a connection.
+    /// JA4 client fingerprints observed (#27, in `shadow` or `allowlist` mode):
+    /// matched an allowlist entry (`known`) vs not (`unknown`). In `allowlist`
+    /// mode an unknown may then be rejected — see `tls_fp_rejected`.
     pub tls_fp_known: AtomicU64,
     pub tls_fp_unknown: AtomicU64,
     /// Connections closed before the TLS handshake by the JA4 allowlist gate
@@ -774,7 +774,7 @@ impl Metrics {
         out.extend_from_slice(b"\n");
 
         out.extend_from_slice(
-            b"# HELP zion_tls_fp_known Shadow-mode JA4 fingerprints matching an allowlist entry.\n\
+            b"# HELP zion_tls_fp_known JA4 fingerprints matching an allowlist entry (shadow or allowlist mode).\n\
                                 # TYPE zion_tls_fp_known counter\n\
                                 zion_tls_fp_known ",
         );
@@ -782,7 +782,7 @@ impl Metrics {
         out.extend_from_slice(b"\n");
 
         out.extend_from_slice(
-            b"# HELP zion_tls_fp_unknown Shadow-mode JA4 fingerprints not on the allowlist.\n\
+            b"# HELP zion_tls_fp_unknown JA4 fingerprints not on the allowlist (shadow or allowlist mode).\n\
                                 # TYPE zion_tls_fp_unknown counter\n\
                                 zion_tls_fp_unknown ",
         );

--- a/src/tls_fp.rs
+++ b/src/tls_fp.rs
@@ -393,6 +393,26 @@ pub fn ja4_from_tls_record(bytes: &[u8]) -> Result<Ja4, TlsFpError> {
     ja4_from_client_hello(payload)
 }
 
+/// Cheap shape check for a configured JA4 string: `<10-char a>_<12 hex b>_<12
+/// hex c>`. Catches a typo / wrong case / truncation at config load rather than
+/// as a silent never-matches outage (a malformed allowlist entry matches nothing,
+/// which under `on_unknown = drop` is a total outage the empty-list guard misses).
+/// Case is not enforced here — [`TlsFpRuntime::from_config`] lowercases entries.
+pub fn looks_like_ja4(s: &str) -> bool {
+    let mut parts = s.trim().split('_');
+    match (parts.next(), parts.next(), parts.next(), parts.next()) {
+        (Some(a), Some(b), Some(c), None) => {
+            a.len() == 10
+                && a.bytes().all(|x| x.is_ascii_alphanumeric())
+                && b.len() == 12
+                && b.bytes().all(|x| x.is_ascii_hexdigit())
+                && c.len() == 12
+                && c.bytes().all(|x| x.is_ascii_hexdigit())
+        }
+        _ => false,
+    }
+}
+
 /// Runtime-resolved fingerprint state, read on the accept path. Built once per
 /// config load from `[tls.fingerprint]`; the resolver returns `None` for
 /// `mode = off` so the hot path pays nothing when the feature is unused.
@@ -411,10 +431,13 @@ impl TlsFpRuntime {
         if cfg.mode == crate::config::FingerprintMode::Off {
             return None;
         }
+        // Normalize entries (trim + lowercase) so a configured JA4 that differs
+        // only in case/whitespace from the computed (lowercase) fingerprint still
+        // matches instead of silently never matching.
         let allowed = cfg
             .allowed
             .iter()
-            .map(|a| (a.ja4.clone(), a.name.clone()))
+            .map(|a| (a.ja4.trim().to_ascii_lowercase(), a.name.clone()))
             .collect();
         Some(TlsFpRuntime {
             mode: cfg.mode.clone(),
@@ -795,6 +818,35 @@ mod tests {
             OnUnfingerprintable::Drop,
         );
         assert_eq!(strict.unfingerprintable_decision(), GateDecision::Reject);
+    }
+
+    #[test]
+    fn looks_like_ja4_accepts_valid_rejects_garbage() {
+        assert!(looks_like_ja4("t13d1516h2_8daaf6152771_e5627efa2ab1"));
+        // case + surrounding whitespace tolerated (from_config lowercases).
+        assert!(looks_like_ja4("  T13D1516H2_8DAAF6152771_E5627EFA2AB1  "));
+        assert!(!looks_like_ja4("t13d1516h2_8daaf6152771")); // 2 parts
+        assert!(!looks_like_ja4("t13d1516h2_8daaf6152771_e5627efa2ab1_x")); // 4 parts
+        assert!(!looks_like_ja4("short_8daaf6152771_e5627efa2ab1")); // a not 10 chars
+        assert!(!looks_like_ja4("t13d1516h2_zzzz6152771_e5627efa2ab1")); // b not hex
+        assert!(!looks_like_ja4("t13d1516h2_8daaf615277_e5627efa2ab1")); // b is 11 chars
+    }
+
+    #[test]
+    fn from_config_normalizes_case_so_uppercase_matches() {
+        use crate::config::{AllowedFingerprint, FingerprintConfig, FingerprintMode};
+        let cfg = FingerprintConfig {
+            mode: FingerprintMode::Allowlist,
+            allowed: vec![AllowedFingerprint {
+                name: "chrome".into(),
+                ja4: "  T13D1516H2_8DAAF6152771_E5627EFA2AB1  ".into(), // upper + spaces
+            }],
+            ..Default::default()
+        };
+        let rt = TlsFpRuntime::from_config(&cfg).unwrap();
+        // The computed JA4 is lowercase; the normalized entry must still match.
+        let computed = ja4_from_client_hello(&chrome_client_hello()).unwrap();
+        assert_eq!(rt.known_name(&computed), Some("chrome"));
     }
 
     #[test]

--- a/src/tls_fp.rs
+++ b/src/tls_fp.rs
@@ -476,6 +476,10 @@ impl TlsFpRuntime {
         if self.mode == FingerprintMode::Allowlist
             && self.on_unfingerprintable == OnUnfingerprintable::Drop
         {
+            tracing::warn!(
+                "tls-fp: rejecting connection — ClientHello could not be fingerprinted \
+                 (on_unfingerprintable = drop)"
+            );
             crate::metrics::METRICS
                 .tls_fp_rejected
                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/src/tls_fp.rs
+++ b/src/tls_fp.rs
@@ -399,6 +399,8 @@ pub fn ja4_from_tls_record(bytes: &[u8]) -> Result<Ja4, TlsFpError> {
 #[derive(Clone, Debug)]
 pub struct TlsFpRuntime {
     pub mode: crate::config::FingerprintMode,
+    on_unknown: crate::config::OnUnknown,
+    on_unfingerprintable: crate::config::OnUnfingerprintable,
     /// JA4 string → allowlist entry name (for the known/unknown metric split).
     allowed: std::collections::HashMap<String, String>,
 }
@@ -416,6 +418,8 @@ impl TlsFpRuntime {
             .collect();
         Some(TlsFpRuntime {
             mode: cfg.mode.clone(),
+            on_unknown: cfg.on_unknown,
+            on_unfingerprintable: cfg.on_unfingerprintable,
             allowed,
         })
     }
@@ -423,6 +427,39 @@ impl TlsFpRuntime {
     /// The allowlist entry name for a fingerprint, if it is known.
     pub fn known_name(&self, ja4: &Ja4) -> Option<&str> {
         self.allowed.get(ja4.as_str()).map(String::as_str)
+    }
+
+    /// Verdict for an unknown fingerprint. Rejects only in `allowlist` mode with
+    /// `on_unknown = drop`; `shadow` and `log_only` observe without blocking.
+    fn unknown_decision(&self, ja4: &Ja4) -> GateDecision {
+        use crate::config::{FingerprintMode, OnUnknown};
+        if self.mode == FingerprintMode::Allowlist && self.on_unknown == OnUnknown::Drop {
+            tracing::warn!(ja4 = %ja4, "tls-fp: rejecting connection — fingerprint not on allowlist");
+            crate::metrics::METRICS
+                .tls_fp_rejected
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            GateDecision::Reject
+        } else {
+            tracing::info!(ja4 = %ja4, "tls-fp: unknown ClientHello fingerprint");
+            GateDecision::Proceed
+        }
+    }
+
+    /// Verdict for a connection whose ClientHello could not be fingerprinted.
+    /// Availability-first: proceed unless `allowlist` + `on_unfingerprintable =
+    /// drop`.
+    fn unfingerprintable_decision(&self) -> GateDecision {
+        use crate::config::{FingerprintMode, OnUnfingerprintable};
+        if self.mode == FingerprintMode::Allowlist
+            && self.on_unfingerprintable == OnUnfingerprintable::Drop
+        {
+            crate::metrics::METRICS
+                .tls_fp_rejected
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            GateDecision::Reject
+        } else {
+            GateDecision::Proceed
+        }
     }
 }
 
@@ -479,40 +516,57 @@ async fn peek_client_hello(stream: &tokio::net::TcpStream, buf: &mut [u8]) -> Op
     }
 }
 
-/// Shadow-mode observation on the accept path: `MSG_PEEK` the ClientHello
-/// (leaving the bytes in the kernel buffer for rustls to re-read), compute JA4,
-/// and count it known vs unknown against the allowlist. It NEVER blocks — the
-/// allowlist gate (closing the socket before the handshake) is #27 commit 3.
+/// The accept-path gate's verdict: proceed into the TLS handshake, or reject
+/// (the caller closes the socket before the handshake starts).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum GateDecision {
+    Proceed,
+    Reject,
+}
+
+/// The accept-path JA4 gate: `MSG_PEEK` the ClientHello (leaving the bytes in
+/// the kernel buffer for rustls to re-read), compute JA4, count it known vs
+/// unknown, and return whether the connection may proceed.
 ///
-/// A ClientHello that can't be peeked or parsed yet (fragmented, not buffered)
-/// is silently skipped: shadow mode observes, it never fails a connection.
-pub async fn shadow_observe(stream: &tokio::net::TcpStream, state: &crate::AppState) {
+/// - `mode = off` (runtime `None`) → `Proceed`, no peek, no syscall.
+/// - `mode = shadow` → always `Proceed`; only observes (counts + logs).
+/// - `mode = allowlist` → `Reject` an unknown fingerprint iff `on_unknown =
+///   drop`, and a ClientHello that couldn't be fingerprinted iff
+///   `on_unfingerprintable = drop`; otherwise `Proceed`.
+pub async fn fingerprint_gate(
+    stream: &tokio::net::TcpStream,
+    state: &crate::AppState,
+) -> GateDecision {
     // Clone the resolved runtime out (a cheap Arc clone) and DROP the arc-swap
     // Guard before awaiting — never hold a config Guard across an await point.
     let fp = {
         let cfg = state.config.load();
         match cfg.tls_fingerprint.as_ref() {
             Some(fp) => fp.clone(),
-            None => return, // mode = off → no peek, no syscall
+            None => return GateDecision::Proceed, // mode = off → no peek, no syscall
         }
     };
     let mut buf = [0u8; PEEK_CAP];
     let Some(n) = peek_client_hello(stream, &mut buf).await else {
-        return; // timeout / EOF / stalled client — never extend the pre-handshake lifetime
+        // Timeout / EOF / stalled client — could not fingerprint.
+        return fp.unfingerprintable_decision();
     };
-    // A truncated / not-a-ClientHello peek is skipped silently — shadow mode
-    // observes, it never fails a connection.
-    if let Ok(ja4) = ja4_from_tls_record(&buf[..n]) {
-        if fp.known_name(&ja4).is_some() {
-            crate::metrics::METRICS
-                .tls_fp_known
-                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        } else {
-            crate::metrics::METRICS
-                .tls_fp_unknown
-                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-            tracing::info!(ja4 = %ja4, "tls-fp: unknown ClientHello fingerprint (shadow mode)");
+    match ja4_from_tls_record(&buf[..n]) {
+        Ok(ja4) => {
+            if fp.known_name(&ja4).is_some() {
+                crate::metrics::METRICS
+                    .tls_fp_known
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                GateDecision::Proceed
+            } else {
+                crate::metrics::METRICS
+                    .tls_fp_unknown
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                fp.unknown_decision(&ja4)
+            }
         }
+        // A not-a-ClientHello / truncated-beyond-budget peek: couldn't fingerprint.
+        Err(_) => fp.unfingerprintable_decision(),
     }
 }
 
@@ -701,12 +755,56 @@ mod tests {
     }
 
     #[test]
+    fn gate_decisions_by_mode_and_policy() {
+        use crate::config::{FingerprintMode, OnUnfingerprintable, OnUnknown};
+        let ja4 = Ja4("t13d1516h2_8daaf6152771_e5627efa2ab1".into());
+        let mk = |mode, on_unknown, on_unfingerprintable| TlsFpRuntime {
+            mode,
+            on_unknown,
+            on_unfingerprintable,
+            allowed: std::collections::HashMap::new(),
+        };
+        // shadow NEVER rejects, whatever the policy knobs say.
+        let sh = mk(
+            FingerprintMode::Shadow,
+            OnUnknown::Drop,
+            OnUnfingerprintable::Drop,
+        );
+        assert_eq!(sh.unknown_decision(&ja4), GateDecision::Proceed);
+        assert_eq!(sh.unfingerprintable_decision(), GateDecision::Proceed);
+        // allowlist + log_only: observe, don't block.
+        let al_log = mk(
+            FingerprintMode::Allowlist,
+            OnUnknown::LogOnly,
+            OnUnfingerprintable::Allow,
+        );
+        assert_eq!(al_log.unknown_decision(&ja4), GateDecision::Proceed);
+        // allowlist + drop: unknown is rejected; unfingerprintable stays fail-open
+        // by default (service first).
+        let al_drop = mk(
+            FingerprintMode::Allowlist,
+            OnUnknown::Drop,
+            OnUnfingerprintable::Allow,
+        );
+        assert_eq!(al_drop.unknown_decision(&ja4), GateDecision::Reject);
+        assert_eq!(al_drop.unfingerprintable_decision(), GateDecision::Proceed);
+        // opting into strict unfingerprintable handling rejects those too.
+        let strict = mk(
+            FingerprintMode::Allowlist,
+            OnUnknown::LogOnly,
+            OnUnfingerprintable::Drop,
+        );
+        assert_eq!(strict.unfingerprintable_decision(), GateDecision::Reject);
+    }
+
+    #[test]
     fn runtime_resolves_off_to_none_and_classifies() {
         use crate::config::{AllowedFingerprint, FingerprintConfig, FingerprintMode};
         // mode = off → None, so the accept path pays nothing.
         let off = FingerprintConfig {
             mode: FingerprintMode::Off,
             allowed: vec![],
+            ..Default::default()
         };
         assert!(TlsFpRuntime::from_config(&off).is_none());
 
@@ -717,6 +815,7 @@ mod tests {
                 name: "chrome".into(),
                 ja4: "t13d1516h2_8daaf6152771_e5627efa2ab1".into(),
             }],
+            ..Default::default()
         };
         let rt = TlsFpRuntime::from_config(&cfg).expect("shadow resolves to Some");
         let known = ja4_from_client_hello(&chrome_client_hello()).unwrap();


### PR DESCRIPTION
**Phase 3a (#27), commit 3 of 5** — turns shadow mode into an **enforcing gate**. In `allowlist` mode, a connection whose ClientHello fingerprint isn't on the allowlist is **closed before the TLS handshake**. Policy defaults follow your call: **service availability first, fail-safe against self-inflicted outages.**

## Config

```toml
[tls.fingerprint]
mode = "allowlist"                 # off | shadow | allowlist
on_unknown = "log_only"            # log_only (default) | drop
on_unfingerprintable = "allow"     # allow (default) | drop
allowed = [ { name = "chrome", ja4 = "t13d1516h2_…" } ]
```

- **`on_unknown`** — an unknown fingerprint: `log_only` observes (default), `drop` closes the socket.
- **`on_unfingerprintable`** — a ClientHello we couldn't peek/parse (stalled, oversized, non-TLS): `allow` proceeds (default — **fail-open, service > defence**), `drop` fails closed for the strict.

## Enforcement

`shadow_observe` → **`fingerprint_gate`** returning `GateDecision { Proceed | Reject }`. `off`/`shadow` always `Proceed`; `allowlist` rejects an unknown iff `on_unknown=drop` and an unfingerprintable hello iff `on_unfingerprintable=drop`. `spawn_https_handler` closes the socket on `Reject` — before any handshake; the connection permit + per-IP slot release on drop.

## Boot fail-safe

`validate_semantics` **refuses to start** when `mode=allowlist` + `on_unknown=drop` + empty `allowed` — that config would drop **every** connection. `log_only`, or a non-empty allowlist, boots normally. (Your call #2: refuse only the genuinely-fatal config, don't over-restrict.)

## Metric

`zion_tls_fp_rejected` — connections closed by the gate.

## Verification

Across `default` / `acme` / `tls-fingerprint` / `all-features`: clippy + fmt clean. Unit tests for **every** gate decision (shadow-never-rejects, log_only-proceeds, drop-rejects-unknown, fail-open-unfingerprintable, strict-opt-in) and both boot-validation branches. Zero overhead when off.

**Rollout:** run `shadow` for 7–30 days → build the allowlist from `zion_tls_fp_unknown` → switch to `allowlist` with `on_unknown=log_only` first (still non-blocking, but now it's the enforced set) → flip to `on_unknown=drop` once confident.

Commit 4: banned-set short-circuit + per-fingerprint routes/rate limits. Commit 5: hot-reload polish + `X-Client-TLS-*` headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)