### PR TITLE
chore(equivalence): pin harness to current release 0.7.4 (SWAP-prep)

### DIFF
--- a/tests/equivalence/run.sh
+++ b/tests/equivalence/run.sh
@@ -35,7 +35,7 @@
 set -euo pipefail
 
 SCENARIO="${1:-multi-vhost}"
-ZION_IMAGE="${ZION_IMAGE:-ghcr.io/fabriziosalmi/zion:0.7.3}"
+ZION_IMAGE="${ZION_IMAGE:-ghcr.io/fabriziosalmi/zion:0.7.4}"
 ZION_RUNTIME_IMAGE="${ZION_RUNTIME_IMAGE:-ubuntu:24.04}"
 NGINX_IMAGE="nginx:1.27-alpine"
 CADDY_IMAGE="caddy:2-alpine"


### PR DESCRIPTION
Point the routing-equivalence harness at the current frozen release (v0.7.4) instead of the stale 0.7.3 default, so a local `tests/equivalence/run.sh <scenario>` validates the binary that will actually be deployed during the real-site validation window. One-line test-tooling change; freeze-neutral (no dependency bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)