### PR TITLE
chore(gitignore): ignore .pytest_cache/ and .ruff_cache/ tool caches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,8 @@ GEMINI_IMPRO.md
 .venv/
 __pycache__/
 *.pyc
+.pytest_cache/
+.ruff_cache/
 benchmarks/backend/target/
 benchmarks/backend/Cargo.lock
 


### PR DESCRIPTION
Both were sitting untracked-but-unignored (`.ruff_cache/` at the root, `ml/.pytest_cache/`), one absent-minded `git add -A` away from being committed. Flagged by the fleet hygiene audit.

No code changes — two lines under the existing `# Python` section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)