### PR TITLE
ci(supply-chain): repair workflow rejected at run creation (runner context in job env)

### DIFF
--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -54,9 +54,13 @@ jobs:
     # dtolnay/rust-toolchain's reinstall abort ("failure removing component
     # rust-std … .rmeta"). Only RUSTUP_HOME moves — CARGO_HOME is untouched, so
     # the rustup/cargo binaries stay on PATH and crate caching is unaffected.
-    env:
-      RUSTUP_HOME: ${{ runner.temp }}/rustup
+    # NOTE: exported via GITHUB_ENV in the first step, NOT job-level `env:` —
+    # the `runner` context is not available there, and an expression that uses
+    # it makes GitHub reject the whole workflow file at run creation (zero
+    # jobs, required checks never report, every PR blocked).
     steps:
+      - name: Isolate rustup store (see comment above)
+        run: echo "RUSTUP_HOME=$RUNNER_TEMP/rustup" >> "$GITHUB_ENV"
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       # Prebuilt binary, not `cargo install` from source: building the tool
@@ -131,10 +135,11 @@ jobs:
     name: cargo-geiger (unsafe surface)
     runs-on: [self-hosted, Linux, X64]
     continue-on-error: true   # geiger is a *report*, not a gate
-    # Isolated rustup store — see the `audit` job for the rationale.
-    env:
-      RUSTUP_HOME: ${{ runner.temp }}/rustup
+    # Isolated rustup store — see the `audit` job for the rationale (and for
+    # why it's a GITHUB_ENV step, not job-level `env:`).
     steps:
+      - name: Isolate rustup store
+        run: echo "RUSTUP_HOME=$RUNNER_TEMP/rustup" >> "$GITHUB_ENV"
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
@@ -174,10 +179,11 @@ jobs:
     if: github.event_name != 'pull_request'
     permissions:
       contents: read
-    # Isolated rustup store — see the `audit` job for the rationale.
-    env:
-      RUSTUP_HOME: ${{ runner.temp }}/rustup
+    # Isolated rustup store — see the `audit` job for the rationale (and for
+    # why it's a GITHUB_ENV step, not job-level `env:`).
     steps:
+      - name: Isolate rustup store
+        run: echo "RUSTUP_HOME=$RUNNER_TEMP/rustup" >> "$GITHUB_ENV"
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2


### PR DESCRIPTION
Root cause of every PR sitting at **BLOCKED** since 2026-08-25 (and master's red supply-chain runs): #387 set `RUSTUP_HOME: ${{ runner.temp }}/rustup` at **job-level** `env:` in three jobs (audit, geiger, sbom). The `runner` context is not available in job-level `env`, so GitHub rejects the whole workflow file at run creation — the run fails with **zero jobs**, the six required status checks (cargo-audit, cargo-deny ×4, cargo-vet) never report, and auto-merge waits forever (bit #393 first).

Fix: export `RUSTUP_HOME` via `GITHUB_ENV` in a first step of each job, where `$RUNNER_TEMP` exists. Same per-job rustup isolation #387 wanted, valid workflow file. `actionlint` is clean of context errors across all workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)