### PR TITLE
ci(supply-chain): wipe the stale rustup store before each isolated job

### DIFF
--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -47,20 +47,27 @@ jobs:
   audit:
     name: cargo-audit (advisories)
     runs-on: [self-hosted, Linux, X64]
-    # Give this job its OWN rustup toolchain store under runner.temp (wiped at
-    # the start of every job on self-hosted runners). The persistent Contabo
-    # runners otherwise share one mutable ~/.rustup across jobs, and a
-    # half-removed rust-std leaves a stale component manifest that makes
-    # dtolnay/rust-toolchain's reinstall abort ("failure removing component
-    # rust-std … .rmeta"). Only RUSTUP_HOME moves — CARGO_HOME is untouched, so
-    # the rustup/cargo binaries stay on PATH and crate caching is unaffected.
+    # Give this job its OWN rustup toolchain store under runner.temp. The
+    # persistent Contabo runners otherwise share one mutable ~/.rustup across
+    # jobs, and a half-removed rust-std leaves a stale component manifest that
+    # makes dtolnay/rust-toolchain's reinstall abort ("failure removing
+    # component rust-std … .rmeta"). Only RUSTUP_HOME moves — CARGO_HOME is
+    # untouched, so the rustup/cargo binaries stay on PATH and crate caching
+    # is unaffected.
+    # The `rm -rf` is what actually makes it per-job: on these runners
+    # $RUNNER_TEMP is NOT wiped between jobs, so a job killed mid-install
+    # leaves a manifest-less toolchain there that rustup then reports as
+    # "unchanged" and never repairs ("error: Missing manifest in toolchain
+    # 'stable'"), poisoning every later job on that runner.
     # NOTE: exported via GITHUB_ENV in the first step, NOT job-level `env:` —
     # the `runner` context is not available there, and an expression that uses
     # it makes GitHub reject the whole workflow file at run creation (zero
     # jobs, required checks never report, every PR blocked).
     steps:
       - name: Isolate rustup store (see comment above)
-        run: echo "RUSTUP_HOME=$RUNNER_TEMP/rustup" >> "$GITHUB_ENV"
+        run: |
+          rm -rf "$RUNNER_TEMP/rustup"
+          echo "RUSTUP_HOME=$RUNNER_TEMP/rustup" >> "$GITHUB_ENV"
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       # Prebuilt binary, not `cargo install` from source: building the tool
@@ -139,7 +146,9 @@ jobs:
     # why it's a GITHUB_ENV step, not job-level `env:`).
     steps:
       - name: Isolate rustup store
-        run: echo "RUSTUP_HOME=$RUNNER_TEMP/rustup" >> "$GITHUB_ENV"
+        run: |
+          rm -rf "$RUNNER_TEMP/rustup"
+          echo "RUSTUP_HOME=$RUNNER_TEMP/rustup" >> "$GITHUB_ENV"
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
@@ -183,7 +192,9 @@ jobs:
     # why it's a GITHUB_ENV step, not job-level `env:`).
     steps:
       - name: Isolate rustup store
-        run: echo "RUSTUP_HOME=$RUNNER_TEMP/rustup" >> "$GITHUB_ENV"
+        run: |
+          rm -rf "$RUNNER_TEMP/rustup"
+          echo "RUSTUP_HOME=$RUNNER_TEMP/rustup" >> "$GITHUB_ENV"
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2


### PR DESCRIPTION
Follow-up to #394. Its isolation assumed `$RUNNER_TEMP` is wiped between jobs on the self-hosted runners — **it is not** (rustup even warns about the pre-existing `_temp/rustup/settings.toml`). A job killed mid-install leaves a manifest-less toolchain there that rustup reports as `unchanged` and never repairs (`error: Missing manifest in toolchain 'stable'`), poisoning every later job on that runner — bit `cargo-audit` twice in a row on two different Contabo runners (zion-2, zion-3) on #393.

Fix: `rm -rf "$RUNNER_TEMP/rustup"` in the isolate step, so the isolation is actually per-job. The forced minimal-profile stable install costs ~1s. actionlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)