### PR TITLE
feat(tls-fp): banned-set fast path + per-fingerprint connection rate limit (#27, commit 4/5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Client -> TLS 1.3 -> Security Gates -> Radix Router -> WAF Pipeline (5 gates) ->
 ```
 
 <!-- zion-stats:modules-lines (kept in sync by scripts/update-readme-stats.sh) -->
-49 modules, ~43,500 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
+49 modules, ~44,000 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Client -> TLS 1.3 -> Security Gates -> Radix Router -> WAF Pipeline (5 gates) ->
 ```
 
 <!-- zion-stats:modules-lines (kept in sync by scripts/update-readme-stats.sh) -->
-49 modules, ~44,000 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
+49 modules, ~44,200 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
 
 ## Features
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -405,6 +405,12 @@ fn default_ban_ttl_secs() -> u64 {
     600
 }
 
+/// Upper bound accepted for `ban_ttl_secs` (1 year). Anything larger is an
+/// operator error (see the validator) — and, unvalidated, would overflow
+/// `Instant + Duration` on the first ban insert.
+#[allow(dead_code)] // read only by the `tls-fingerprint`-gated validator block
+pub const MAX_BAN_TTL_SECS: u64 = 31_536_000;
+
 // Manual impl (not derived) so `FingerprintConfig::default()` and a TOML block
 // that omits `ban_ttl_secs` agree on 600 — a derived Default would say 0
 // (bans disabled) while serde says 600.
@@ -955,6 +961,35 @@ fn semantic_errors(config: &ZionConfig) -> Vec<String> {
                     a.name, a.ja4
                 ));
             }
+        }
+        // Duplicate JA4s would silently last-win in the runtime's HashMap —
+        // harmless when entries only carried a name, but now the surviving
+        // entry's rate_limit_cps (or lack of one) silently replaces the
+        // other's. Make the collision an operator error instead.
+        let mut seen = std::collections::HashMap::new();
+        for a in &fp.allowed {
+            let norm = a.ja4.trim().to_ascii_lowercase();
+            if let Some(first) = seen.insert(norm, &a.name) {
+                errors.push(format!(
+                    "[tls.fingerprint] entries '{}' and '{}' list the same JA4 '{}' — \
+                     merge them (only one would take effect, chosen arbitrarily)",
+                    first,
+                    a.name,
+                    a.ja4.trim()
+                ));
+            }
+        }
+        // An absurd ban TTL would overflow `Instant + Duration` on the first
+        // ban insert — a panic, and with the release profile's panic=abort a
+        // dead proxy. Bans are process-local; "permanent" is not a thing here.
+        if fp.ban_ttl_secs > MAX_BAN_TTL_SECS {
+            errors.push(format!(
+                "[tls.fingerprint] ban_ttl_secs = {} exceeds the maximum {} (1 year). \
+                 The ban set is process-local and never outlives a restart — for a \
+                 permanent block, remove the fingerprint from `allowed` and keep \
+                 on_unknown = \"drop\".",
+                fp.ban_ttl_secs, MAX_BAN_TTL_SECS
+            ));
         }
     }
 
@@ -1718,6 +1753,41 @@ mod tests {
         let cfg = parse_schema(bad, "test").expect("parse");
         let err = validate_semantics(&cfg, "test").err().unwrap_or_default();
         assert!(err.contains("invalid JA4"), "got: {err}");
+    }
+
+    #[cfg(feature = "tls-fingerprint")]
+    #[test]
+    fn allowlist_duplicate_ja4_is_rejected() {
+        // Two entries with the same (normalized) JA4 would silently last-win in
+        // the runtime map — and one of them may carry a rate_limit_cps the
+        // other silently disables. Refuse at boot.
+        let dup = "[server]\nlisten_http=\"0.0.0.0:80\"\nlisten_https=\"0.0.0.0:443\"\n\
+             [tls]\ncert_path=\"/c\"\nkey_path=\"/k\"\n\
+             [tls.fingerprint]\nmode=\"allowlist\"\non_unknown=\"drop\"\n\
+             allowed=[{name=\"a\",ja4=\"t13d1516h2_8daaf6152771_e5627efa2ab1\",rate_limit_cps=10},\
+                      {name=\"b\",ja4=\"T13D1516H2_8DAAF6152771_E5627EFA2AB1\"}]\n\
+             [upstreams]\nbe=\"http://127.0.0.1:8000\"\n\
+             [[route]]\npath=\"/{*rest}\"\nupstream=\"be\"\n";
+        let cfg = parse_schema(dup, "test").expect("parse");
+        let err = validate_semantics(&cfg, "test").err().unwrap_or_default();
+        assert!(err.contains("same JA4"), "got: {err}");
+    }
+
+    #[cfg(feature = "tls-fingerprint")]
+    #[test]
+    fn ban_ttl_over_a_year_is_rejected() {
+        // An absurd TTL is an operator error (and, far enough out, would
+        // overflow Instant + Duration on the first ban insert — TOML itself
+        // already rejects anything above i64::MAX). Two years must refuse.
+        let huge = "[server]\nlisten_http=\"0.0.0.0:80\"\nlisten_https=\"0.0.0.0:443\"\n\
+             [tls]\ncert_path=\"/c\"\nkey_path=\"/k\"\n\
+             [tls.fingerprint]\nmode=\"allowlist\"\non_unknown=\"drop\"\nban_ttl_secs=63072000\n\
+             allowed=[{name=\"a\",ja4=\"t13d1516h2_8daaf6152771_e5627efa2ab1\"}]\n\
+             [upstreams]\nbe=\"http://127.0.0.1:8000\"\n\
+             [[route]]\npath=\"/{*rest}\"\nupstream=\"be\"\n";
+        let cfg = parse_schema(huge, "test").expect("parse");
+        let err = validate_semantics(&cfg, "test").err().unwrap_or_default();
+        assert!(err.contains("ban_ttl_secs"), "got: {err}");
     }
 
     #[cfg(feature = "tls-fingerprint")]

--- a/src/config.rs
+++ b/src/config.rs
@@ -364,7 +364,7 @@ pub struct TlsConfig {
 /// `warn_feature_config_gaps`). `allowed` is only read under the feature, hence
 /// the targeted allow (mirrors `AcmeConfig`).
 #[allow(dead_code)]
-#[derive(Deserialize, Clone, Debug, Default)]
+#[derive(Deserialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct FingerprintConfig {
     /// `off` (default) | `shadow` | `allowlist`.
@@ -389,6 +389,35 @@ pub struct FingerprintConfig {
     /// Default `allow` — availability first; `drop` fails closed for the strict.
     #[serde(default)]
     pub on_unfingerprintable: OnUnfingerprintable,
+    /// `allowlist` + `on_unknown = "drop"`: once an unknown fingerprint is
+    /// rejected it goes on a ban set for this many seconds, and repeat
+    /// connections with the same JA4 are rejected on a fast path — one map
+    /// lookup, a debug-level log instead of a warn per connection, counted in
+    /// `zion_tls_fp_banned_hits`. Under a flood of one fingerprint this is
+    /// what keeps the log readable. `0` disables the ban set (every rejection
+    /// logs individually). Default 600 (10 minutes). Bans survive config
+    /// reloads but never outlive the process.
+    #[serde(default = "default_ban_ttl_secs")]
+    pub ban_ttl_secs: u64,
+}
+
+fn default_ban_ttl_secs() -> u64 {
+    600
+}
+
+// Manual impl (not derived) so `FingerprintConfig::default()` and a TOML block
+// that omits `ban_ttl_secs` agree on 600 — a derived Default would say 0
+// (bans disabled) while serde says 600.
+impl Default for FingerprintConfig {
+    fn default() -> Self {
+        Self {
+            mode: FingerprintMode::default(),
+            allowed: Vec::new(),
+            on_unknown: OnUnknown::default(),
+            on_unfingerprintable: OnUnfingerprintable::default(),
+            ban_ttl_secs: default_ban_ttl_secs(),
+        }
+    }
 }
 
 #[derive(Deserialize, Clone, Debug, Default, PartialEq, Eq)]
@@ -428,6 +457,14 @@ pub struct AllowedFingerprint {
     pub name: String,
     /// The JA4 string, e.g. `t13d1516h2_8daaf6152771_e5627efa2ab1`.
     pub ja4: String,
+    /// Cap on NEW TLS connections per second for this fingerprint —
+    /// connections, not HTTP requests: the gate runs before the handshake,
+    /// where requests don't exist yet. Over-cap connections are dropped
+    /// pre-handshake in `allowlist` mode and only counted
+    /// (`zion_tls_fp_rate_limited`) in `shadow`. `0` (default) = no limit,
+    /// consistent with `[server] rate_limit_rps`.
+    #[serde(default)]
+    pub rate_limit_cps: u32,
 }
 
 #[derive(Deserialize, Clone, Debug)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -523,7 +523,7 @@ struct AppState {
     /// about the client's behaviour, not about the config — and is only ever
     /// consulted while the CURRENT config drops unknown fingerprints.
     #[cfg(feature = "tls-fingerprint")]
-    pub(crate) tls_fp_bans: tls_fp::BanMap,
+    pub(crate) tls_fp_bans: tls_fp::BanSet,
 }
 
 impl AppState {
@@ -1094,7 +1094,7 @@ async fn async_main(platform: &'static bootstrap::Platform) -> error::ZionResult
         conn_per_ip: Arc::new(connlimit::PerIpConnLimiter::new()),
         inflight: numa::NumaAwareMap::new(),
         #[cfg(feature = "tls-fingerprint")]
-        tls_fp_bans: tls_fp::BanMap::new(),
+        tls_fp_bans: tls_fp::BanSet::new(),
         audit: audit_handle,
         redact: compiled_redact,
         http_builder: Arc::new({

--- a/src/main.rs
+++ b/src/main.rs
@@ -518,6 +518,12 @@ struct AppState {
     /// local block to the mesh). Cloning is cheap — internal `Arc`s.
     #[cfg(feature = "sovereign-aimp")]
     pub(crate) aimp_cp: Option<aimp_cp::AimpControlPlane>,
+    /// Rejected-unknown JA4 ban set (#27 commit 4): fingerprint → banned
+    /// until. Like `rate_map`, it persists across config reloads — a ban is
+    /// about the client's behaviour, not about the config — and is only ever
+    /// consulted while the CURRENT config drops unknown fingerprints.
+    #[cfg(feature = "tls-fingerprint")]
+    pub(crate) tls_fp_bans: tls_fp::BanMap,
 }
 
 impl AppState {
@@ -1087,6 +1093,8 @@ async fn async_main(platform: &'static bootstrap::Platform) -> error::ZionResult
         rate_map: Arc::new(numa::NumaAwareMap::new()),
         conn_per_ip: Arc::new(connlimit::PerIpConnLimiter::new()),
         inflight: numa::NumaAwareMap::new(),
+        #[cfg(feature = "tls-fingerprint")]
+        tls_fp_bans: tls_fp::BanMap::new(),
         audit: audit_handle,
         redact: compiled_redact,
         http_builder: Arc::new({

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -416,6 +416,14 @@ pub struct Metrics {
     /// (#27): an unknown fingerprint under `on_unknown = drop`, or an
     /// unfingerprintable ClientHello under `on_unfingerprintable = drop`.
     pub tls_fp_rejected: AtomicU64,
+    /// Rejections served by the ban fast path (#27 commit 4): the fingerprint
+    /// was already on the ban set, so the connection was dropped with a single
+    /// map lookup and a debug-level log. Also counted in `tls_fp_rejected`.
+    pub tls_fp_banned_hits: AtomicU64,
+    /// Connections over an allowlist entry's `rate_limit_cps` (#27 commit 4).
+    /// Dropped pre-handshake in `allowlist` mode (also counted in
+    /// `tls_fp_rejected`); in `shadow` mode counted here but never blocked.
+    pub tls_fp_rate_limited: AtomicU64,
     /// Connections closed at accept because the source IP was already at
     /// its `max_connections_per_ip` concurrent cap (anti-DDoS lever).
     pub connections_rejected_per_ip: AtomicU64,
@@ -518,6 +526,8 @@ impl Metrics {
             tls_fp_known: AtomicU64::new(0),
             tls_fp_unknown: AtomicU64::new(0),
             tls_fp_rejected: AtomicU64::new(0),
+            tls_fp_banned_hits: AtomicU64::new(0),
+            tls_fp_rate_limited: AtomicU64::new(0),
             connections_rejected_per_ip: AtomicU64::new(0),
             enforcement_denied_class: AtomicU64::new(0),
             enforcement_denied_mesh_score: AtomicU64::new(0),
@@ -801,6 +811,30 @@ impl Metrics {
         out.extend_from_slice(
             itoa_buf
                 .format(self.tls_fp_rejected.load(Relaxed))
+                .as_bytes(),
+        );
+        out.extend_from_slice(b"\n");
+
+        out.extend_from_slice(
+            b"# HELP zion_tls_fp_banned_hits Rejections served by the JA4 ban fast path (already-banned fingerprint).\n\
+                                # TYPE zion_tls_fp_banned_hits counter\n\
+                                zion_tls_fp_banned_hits ",
+        );
+        out.extend_from_slice(
+            itoa_buf
+                .format(self.tls_fp_banned_hits.load(Relaxed))
+                .as_bytes(),
+        );
+        out.extend_from_slice(b"\n");
+
+        out.extend_from_slice(
+            b"# HELP zion_tls_fp_rate_limited Connections over a per-fingerprint rate_limit_cps (dropped in allowlist mode, observed in shadow).\n\
+                                # TYPE zion_tls_fp_rate_limited counter\n\
+                                zion_tls_fp_rate_limited ",
+        );
+        out.extend_from_slice(
+            itoa_buf
+                .format(self.tls_fp_rate_limited.load(Relaxed))
                 .as_bytes(),
         );
         out.extend_from_slice(b"\n");

--- a/src/tls_fp.rs
+++ b/src/tls_fp.rs
@@ -413,16 +413,79 @@ pub fn looks_like_ja4(s: &str) -> bool {
     }
 }
 
+/// Per-fingerprint fixed-window (1 s) connection-rate state. Shared across
+/// connections through the `Arc<TlsFpRuntime>` — the window and count are
+/// packed into one `AtomicU64` and advanced by CAS, the same idiom as
+/// `security::RateEntry`, so the hot path takes no lock. Reset on config
+/// reload (the state spans one second; losing it at a reload is noise).
+#[derive(Debug)]
+struct FpRate {
+    /// Connections admitted per one-second window; always > 0 here (a
+    /// configured 0 resolves to "no limit" = no `FpRate` at all).
+    cps: u32,
+    /// `(unix_second as u32) << 32 | count` — window + count in one CAS.
+    packed: std::sync::atomic::AtomicU64,
+}
+
+impl FpRate {
+    fn new(cps: u32) -> Self {
+        FpRate {
+            cps,
+            packed: std::sync::atomic::AtomicU64::new(0),
+        }
+    }
+
+    /// Admit one connection at `now_secs` (unix seconds). `false` = over cap.
+    fn admit(&self, now_secs: u64) -> bool {
+        use std::sync::atomic::Ordering::Relaxed;
+        let window = now_secs as u32;
+        loop {
+            let old = self.packed.load(Relaxed);
+            let (old_window, old_count) = ((old >> 32) as u32, old as u32);
+            let (new, admitted) = if old_window == window {
+                // Same window — increment; saturate so a flood can't wrap the
+                // counter back under the cap.
+                (
+                    ((window as u64) << 32) | u64::from(old_count.saturating_add(1)),
+                    old_count < self.cps,
+                )
+            } else {
+                // New window — this connection is its first.
+                (((window as u64) << 32) | 1, true)
+            };
+            if self
+                .packed
+                .compare_exchange_weak(old, new, Relaxed, Relaxed)
+                .is_ok()
+            {
+                return admitted;
+            }
+        }
+    }
+}
+
+/// One resolved allowlist entry: the human label plus the optional
+/// per-fingerprint connection-rate limit.
+#[derive(Debug)]
+struct AllowedEntry {
+    name: String,
+    rate: Option<FpRate>,
+}
+
 /// Runtime-resolved fingerprint state, read on the accept path. Built once per
 /// config load from `[tls.fingerprint]`; the resolver returns `None` for
 /// `mode = off` so the hot path pays nothing when the feature is unused.
-#[derive(Clone, Debug)]
+/// Shared as `Arc<TlsFpRuntime>` (not cloned per connection): the per-entry
+/// rate atomics must be one instance across all connections.
+#[derive(Debug)]
 pub struct TlsFpRuntime {
     pub mode: crate::config::FingerprintMode,
     on_unknown: crate::config::OnUnknown,
     on_unfingerprintable: crate::config::OnUnfingerprintable,
-    /// JA4 string → allowlist entry name (for the known/unknown metric split).
-    allowed: std::collections::HashMap<String, String>,
+    /// TTL of the unknown-fingerprint ban fast path; zero = bans disabled.
+    ban_ttl: std::time::Duration,
+    /// JA4 string → allowlist entry (name + optional rate limit).
+    allowed: std::collections::HashMap<String, AllowedEntry>,
 }
 
 impl TlsFpRuntime {
@@ -437,19 +500,69 @@ impl TlsFpRuntime {
         let allowed = cfg
             .allowed
             .iter()
-            .map(|a| (a.ja4.trim().to_ascii_lowercase(), a.name.clone()))
+            .map(|a| {
+                (
+                    a.ja4.trim().to_ascii_lowercase(),
+                    AllowedEntry {
+                        name: a.name.clone(),
+                        rate: (a.rate_limit_cps > 0).then(|| FpRate::new(a.rate_limit_cps)),
+                    },
+                )
+            })
             .collect();
         Some(TlsFpRuntime {
             mode: cfg.mode.clone(),
             on_unknown: cfg.on_unknown,
             on_unfingerprintable: cfg.on_unfingerprintable,
+            ban_ttl: std::time::Duration::from_secs(cfg.ban_ttl_secs),
             allowed,
         })
     }
 
     /// The allowlist entry name for a fingerprint, if it is known.
     pub fn known_name(&self, ja4: &Ja4) -> Option<&str> {
-        self.allowed.get(ja4.as_str()).map(String::as_str)
+        self.allowed.get(ja4.as_str()).map(|e| e.name.as_str())
+    }
+
+    /// Verdict for a KNOWN (allowlisted) fingerprint: admit unless its
+    /// per-fingerprint connection-rate limit says the current second is full.
+    /// Over-cap in `allowlist` mode drops the connection pre-handshake; in
+    /// `shadow` it is counted (`zion_tls_fp_rate_limited`) but never blocks —
+    /// shadow observes, whatever the knobs say.
+    fn known_decision(&self, ja4: &Ja4, entry: &AllowedEntry, now_secs: u64) -> GateDecision {
+        use crate::config::FingerprintMode;
+        let Some(rate) = &entry.rate else {
+            return GateDecision::Proceed;
+        };
+        if rate.admit(now_secs) {
+            return GateDecision::Proceed;
+        }
+        crate::metrics::METRICS
+            .tls_fp_rate_limited
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        if self.mode == FingerprintMode::Allowlist {
+            tracing::warn!(
+                ja4 = %ja4, name = %entry.name, limit_cps = rate.cps,
+                "tls-fp: per-fingerprint connection rate exceeded — dropping pre-handshake"
+            );
+            crate::metrics::METRICS
+                .tls_fp_rejected
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            GateDecision::Reject
+        } else {
+            tracing::info!(
+                ja4 = %ja4, name = %entry.name, limit_cps = rate.cps,
+                "tls-fp: per-fingerprint connection rate exceeded (shadow — connection proceeds)"
+            );
+            GateDecision::Proceed
+        }
+    }
+
+    /// Would this runtime drop an unknown fingerprint? (The only combination
+    /// that rejects — and therefore the only one where the ban set applies.)
+    fn drops_unknown(&self) -> bool {
+        self.mode == crate::config::FingerprintMode::Allowlist
+            && self.on_unknown == crate::config::OnUnknown::Drop
     }
 
     /// Verdict for an unknown fingerprint. Rejects only in `allowlist` mode with
@@ -488,6 +601,46 @@ impl TlsFpRuntime {
             GateDecision::Proceed
         }
     }
+}
+
+/// Ban set for rejected unknown fingerprints (#27 commit 4): JA4 → banned
+/// until. Owned by `AppState` — like the per-IP `rate_map`, it tracks client
+/// behaviour, not config, so it survives hot-reloads (an operator tweaking an
+/// unrelated knob mid-attack must not amnesty every banned fingerprint).
+pub type BanMap = dashmap::DashMap<String, std::time::Instant>;
+
+/// Ceiling on tracked bans. An attacker rotating a UNIQUE JA4 per connection
+/// would otherwise grow the map without bound. At the cap, expired entries are
+/// swept; if the map is still full the insert is skipped — a ban is only the
+/// fast path, the slow path still rejects every unknown connection one by one.
+const MAX_BAN_ENTRIES: usize = 4096;
+
+/// Is `ja4` actively banned at `now`? An expired entry is removed on the way.
+fn ban_hit(bans: &BanMap, ja4: &str, now: std::time::Instant) -> bool {
+    // The read guard from `get` MUST be dropped before `remove` touches the
+    // same key — holding it across the removal deadlocks the DashMap shard.
+    {
+        let Some(until) = bans.get(ja4) else {
+            return false;
+        };
+        if *until > now {
+            return true;
+        }
+    }
+    drop(bans.remove(ja4));
+    false
+}
+
+/// Record a ban for `ja4` until `now + ttl`, sweeping expired entries (and
+/// giving up on the insert) when the map is at capacity.
+fn ban_insert(bans: &BanMap, ja4: &str, now: std::time::Instant, ttl: std::time::Duration) {
+    if bans.len() >= MAX_BAN_ENTRIES {
+        bans.retain(|_, until| *until > now);
+        if bans.len() >= MAX_BAN_ENTRIES {
+            return; // full of LIVE bans — skip; the slow path still rejects
+        }
+    }
+    bans.insert(ja4.to_owned(), now + ttl);
 }
 
 /// Bytes peeked to cover a full ClientHello — big enough for a TLS 1.3 hybrid
@@ -580,15 +733,40 @@ pub async fn fingerprint_gate(
     };
     match ja4_from_tls_record(&buf[..n]) {
         Ok(ja4) => {
-            if fp.known_name(&ja4).is_some() {
+            // The allowlist is consulted BEFORE the ban set: an operator who
+            // hot-reloads a previously-unknown fingerprint onto the allowlist
+            // must win over a stale ban immediately.
+            if let Some(entry) = fp.allowed.get(ja4.as_str()) {
                 crate::metrics::METRICS
                     .tls_fp_known
                     .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                GateDecision::Proceed
+                let now_secs = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_secs();
+                fp.known_decision(&ja4, entry, now_secs)
             } else {
                 crate::metrics::METRICS
                     .tls_fp_unknown
                     .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                // Ban fast path (#27 commit 4): only meaningful when unknowns
+                // are dropped — everywhere else nothing is ever banned.
+                if fp.drops_unknown() && !fp.ban_ttl.is_zero() {
+                    let now = std::time::Instant::now();
+                    if ban_hit(&state.tls_fp_bans, ja4.as_str(), now) {
+                        crate::metrics::METRICS
+                            .tls_fp_banned_hits
+                            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        crate::metrics::METRICS
+                            .tls_fp_rejected
+                            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        // debug, not warn: the first offense already warned when
+                        // the ban was recorded — this keeps a flood readable.
+                        tracing::debug!(ja4 = %ja4, "tls-fp: rejecting banned fingerprint (fast path)");
+                        return GateDecision::Reject;
+                    }
+                    ban_insert(&state.tls_fp_bans, ja4.as_str(), now, fp.ban_ttl);
+                }
                 fp.unknown_decision(&ja4)
             }
         }
@@ -789,6 +967,7 @@ mod tests {
             mode,
             on_unknown,
             on_unfingerprintable,
+            ban_ttl: std::time::Duration::from_secs(600),
             allowed: std::collections::HashMap::new(),
         };
         // shadow NEVER rejects, whatever the policy knobs say.
@@ -844,6 +1023,7 @@ mod tests {
             allowed: vec![AllowedFingerprint {
                 name: "chrome".into(),
                 ja4: "  T13D1516H2_8DAAF6152771_E5627EFA2AB1  ".into(), // upper + spaces
+                rate_limit_cps: 0,
             }],
             ..Default::default()
         };
@@ -870,6 +1050,7 @@ mod tests {
             allowed: vec![AllowedFingerprint {
                 name: "chrome".into(),
                 ja4: "t13d1516h2_8daaf6152771_e5627efa2ab1".into(),
+                rate_limit_cps: 0,
             }],
             ..Default::default()
         };
@@ -1021,5 +1202,163 @@ mod tests {
         let inner_len = (body.len() - 4) as u32;
         body[1..4].copy_from_slice(&inner_len.to_be_bytes()[1..]);
         assert_eq!(ja4_from_client_hello(&body), Err(TlsFpError::Malformed));
+    }
+
+    // ── #27 commit 4: per-fingerprint rate limit + ban fast path ──────────────
+
+    #[test]
+    fn fp_rate_admits_up_to_cps_within_one_second() {
+        let rate = FpRate::new(3);
+        let t = 1_000_000u64;
+        assert!(rate.admit(t));
+        assert!(rate.admit(t));
+        assert!(rate.admit(t));
+        assert!(!rate.admit(t)); // 4th connection in the same second → over cap
+        assert!(!rate.admit(t)); // stays over for the rest of the window
+    }
+
+    #[test]
+    fn fp_rate_resets_on_a_new_second() {
+        let rate = FpRate::new(1);
+        let t = 1_000_000u64;
+        assert!(rate.admit(t));
+        assert!(!rate.admit(t));
+        assert!(rate.admit(t + 1)); // next window starts fresh
+        assert!(!rate.admit(t + 1));
+    }
+
+    #[test]
+    fn fp_rate_count_saturates_instead_of_wrapping() {
+        // A u32::MAX-sized flood must not wrap the counter back under the cap.
+        let rate = FpRate::new(1);
+        let t = 42u64;
+        rate.packed.store(
+            ((t as u32 as u64) << 32) | u64::from(u32::MAX),
+            std::sync::atomic::Ordering::Relaxed,
+        );
+        assert!(!rate.admit(t));
+        assert!(!rate.admit(t)); // saturated, still over
+    }
+
+    #[test]
+    fn known_decision_drops_over_cap_in_allowlist_but_only_observes_in_shadow() {
+        use crate::config::{FingerprintMode, OnUnfingerprintable, OnUnknown};
+        let ja4 = Ja4("t13d1516h2_8daaf6152771_e5627efa2ab1".into());
+        let mk = |mode| TlsFpRuntime {
+            mode,
+            on_unknown: OnUnknown::Drop,
+            on_unfingerprintable: OnUnfingerprintable::Allow,
+            ban_ttl: std::time::Duration::from_secs(600),
+            allowed: std::collections::HashMap::new(),
+        };
+        let entry = AllowedEntry {
+            name: "chrome".into(),
+            rate: Some(FpRate::new(1)),
+        };
+        let t = 7_777u64;
+        // allowlist: first admitted, second dropped.
+        let al = mk(FingerprintMode::Allowlist);
+        assert_eq!(al.known_decision(&ja4, &entry, t), GateDecision::Proceed);
+        assert_eq!(al.known_decision(&ja4, &entry, t), GateDecision::Reject);
+        // shadow: over cap is observed, never blocked.
+        let entry_sh = AllowedEntry {
+            name: "chrome".into(),
+            rate: Some(FpRate::new(1)),
+        };
+        let sh = mk(FingerprintMode::Shadow);
+        assert_eq!(sh.known_decision(&ja4, &entry_sh, t), GateDecision::Proceed);
+        assert_eq!(sh.known_decision(&ja4, &entry_sh, t), GateDecision::Proceed);
+        // no rate configured: always Proceed.
+        let unlimited = AllowedEntry {
+            name: "curl".into(),
+            rate: None,
+        };
+        assert_eq!(
+            al.known_decision(&ja4, &unlimited, t),
+            GateDecision::Proceed
+        );
+    }
+
+    #[test]
+    fn ban_hit_respects_ttl_and_removes_expired() {
+        let bans = BanMap::new();
+        let now = std::time::Instant::now();
+        let ttl = std::time::Duration::from_secs(600);
+        ban_insert(&bans, "fp-a", now, ttl);
+        assert!(ban_hit(&bans, "fp-a", now)); // inside the TTL
+        assert!(!ban_hit(&bans, "fp-b", now)); // never banned
+                                               // Past the TTL the entry no longer bans — and is removed on the way.
+        assert!(!ban_hit(
+            &bans,
+            "fp-a",
+            now + ttl + std::time::Duration::from_secs(1)
+        ));
+        assert!(bans.get("fp-a").is_none());
+    }
+
+    #[test]
+    fn ban_insert_at_capacity_sweeps_expired_then_skips_when_full_of_live() {
+        let bans = BanMap::new();
+        let now = std::time::Instant::now();
+        let ttl = std::time::Duration::from_secs(600);
+        // Fill to the cap with entries that are already expired at `later`.
+        for i in 0..MAX_BAN_ENTRIES {
+            bans.insert(format!("old-{i}"), now); // banned_until = now → expired after now
+        }
+        let later = now + std::time::Duration::from_secs(1);
+        // The sweep clears the expired entries and the insert lands.
+        ban_insert(&bans, "fresh", later, ttl);
+        assert!(ban_hit(&bans, "fresh", later));
+        assert!(bans.len() < MAX_BAN_ENTRIES);
+        // Now fill to the cap with LIVE bans: the next insert is skipped.
+        for i in 0..MAX_BAN_ENTRIES {
+            bans.insert(format!("live-{i}"), later + ttl);
+        }
+        ban_insert(&bans, "overflow", later, ttl);
+        assert!(!ban_hit(&bans, "overflow", later));
+    }
+
+    #[test]
+    fn from_config_resolves_rate_limit_only_when_positive() {
+        use crate::config::{AllowedFingerprint, FingerprintConfig, FingerprintMode};
+        let cfg = FingerprintConfig {
+            mode: FingerprintMode::Allowlist,
+            allowed: vec![
+                AllowedFingerprint {
+                    name: "limited".into(),
+                    ja4: "t13d1516h2_8daaf6152771_e5627efa2ab1".into(),
+                    rate_limit_cps: 50,
+                },
+                AllowedFingerprint {
+                    name: "unlimited".into(),
+                    ja4: "t13d1516h2_000000000000_000000000000".into(),
+                    rate_limit_cps: 0, // 0 = no limit, same as [server] rate_limit_rps
+                },
+            ],
+            ban_ttl_secs: 0,
+            ..Default::default()
+        };
+        let rt = TlsFpRuntime::from_config(&cfg).unwrap();
+        let limited = rt
+            .allowed
+            .get("t13d1516h2_8daaf6152771_e5627efa2ab1")
+            .unwrap();
+        assert_eq!(limited.rate.as_ref().map(|r| r.cps), Some(50));
+        let unlimited = rt
+            .allowed
+            .get("t13d1516h2_000000000000_000000000000")
+            .unwrap();
+        assert!(unlimited.rate.is_none());
+        assert!(rt.ban_ttl.is_zero()); // ban_ttl_secs = 0 disables the ban set
+    }
+
+    #[test]
+    fn fingerprint_config_default_and_serde_default_agree_on_ban_ttl() {
+        use crate::config::FingerprintConfig;
+        // The manual Default impl and a TOML block omitting ban_ttl_secs must
+        // both say 600 — a derived Default would silently disagree (0).
+        assert_eq!(FingerprintConfig::default().ban_ttl_secs, 600);
+        let parsed: FingerprintConfig = toml::from_str("mode = \"shadow\"").unwrap();
+        assert_eq!(parsed.ban_ttl_secs, 600);
     }
 }

--- a/src/tls_fp.rs
+++ b/src/tls_fp.rs
@@ -556,12 +556,19 @@ impl TlsFpRuntime {
     /// attacker unbounded log amplification (the same hazard the ban fast path
     /// closes for unknown fingerprints). Every denial still counts in the
     /// metrics.
-    fn known_decision(&self, ja4: &Ja4, entry: &AllowedEntry, now_secs: u64) -> GateDecision {
+    /// `now_secs` is a closure so the common unlimited entry pays no clock
+    /// read: it is only invoked once a rate limit actually exists.
+    fn known_decision(
+        &self,
+        ja4: &Ja4,
+        entry: &AllowedEntry,
+        now_secs: impl FnOnce() -> u64,
+    ) -> GateDecision {
         use crate::config::FingerprintMode;
         let Some(rate) = &entry.rate else {
             return GateDecision::Proceed;
         };
-        let verdict = rate.admit(now_secs);
+        let verdict = rate.admit(now_secs());
         if verdict == Admit::Granted {
             return GateDecision::Proceed;
         }
@@ -831,11 +838,12 @@ pub async fn fingerprint_gate(
                 crate::metrics::METRICS
                     .tls_fp_known
                     .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                let now_secs = std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap_or_default()
-                    .as_secs();
-                fp.known_decision(&ja4, entry, now_secs)
+                fp.known_decision(&ja4, entry, || {
+                    std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap_or_default()
+                        .as_secs()
+                })
             } else {
                 crate::metrics::METRICS
                     .tls_fp_unknown
@@ -1352,23 +1360,31 @@ mod tests {
         let t = 7_777u64;
         // allowlist: first admitted, second dropped.
         let al = mk(FingerprintMode::Allowlist);
-        assert_eq!(al.known_decision(&ja4, &entry, t), GateDecision::Proceed);
-        assert_eq!(al.known_decision(&ja4, &entry, t), GateDecision::Reject);
+        assert_eq!(al.known_decision(&ja4, &entry, || t), GateDecision::Proceed);
+        assert_eq!(al.known_decision(&ja4, &entry, || t), GateDecision::Reject);
         // shadow: over cap is observed, never blocked.
         let entry_sh = AllowedEntry {
             name: "chrome".into(),
             rate: Some(FpRate::new(1)),
         };
         let sh = mk(FingerprintMode::Shadow);
-        assert_eq!(sh.known_decision(&ja4, &entry_sh, t), GateDecision::Proceed);
-        assert_eq!(sh.known_decision(&ja4, &entry_sh, t), GateDecision::Proceed);
+        assert_eq!(
+            sh.known_decision(&ja4, &entry_sh, || t),
+            GateDecision::Proceed
+        );
+        assert_eq!(
+            sh.known_decision(&ja4, &entry_sh, || t),
+            GateDecision::Proceed
+        );
         // no rate configured: always Proceed.
         let unlimited = AllowedEntry {
             name: "curl".into(),
             rate: None,
         };
         assert_eq!(
-            al.known_decision(&ja4, &unlimited, t),
+            al.known_decision(&ja4, &unlimited, || unreachable!(
+                "no rate limit — the clock must not be read"
+            )),
             GateDecision::Proceed
         );
     }

--- a/src/tls_fp.rs
+++ b/src/tls_fp.rs
@@ -435,33 +435,54 @@ impl FpRate {
         }
     }
 
-    /// Admit one connection at `now_secs` (unix seconds). `false` = over cap.
-    fn admit(&self, now_secs: u64) -> bool {
+    /// Admit one connection at `now_secs` (unix seconds).
+    ///
+    /// `FirstDenial` marks the ONE connection per window that crosses the cap
+    /// (the successful CAS from `count == cps` to `cps + 1` happens exactly
+    /// once) — the caller logs on that and stays silent on every later
+    /// `Denied`, so a flood against a rate-limited fingerprint produces at
+    /// most one log line per second instead of one per connection.
+    fn admit(&self, now_secs: u64) -> Admit {
         use std::sync::atomic::Ordering::Relaxed;
         let window = now_secs as u32;
         loop {
             let old = self.packed.load(Relaxed);
             let (old_window, old_count) = ((old >> 32) as u32, old as u32);
-            let (new, admitted) = if old_window == window {
+            let (new, verdict) = if old_window == window {
                 // Same window — increment; saturate so a flood can't wrap the
                 // counter back under the cap.
                 (
                     ((window as u64) << 32) | u64::from(old_count.saturating_add(1)),
-                    old_count < self.cps,
+                    match old_count.cmp(&self.cps) {
+                        std::cmp::Ordering::Less => Admit::Granted,
+                        std::cmp::Ordering::Equal => Admit::FirstDenial,
+                        std::cmp::Ordering::Greater => Admit::Denied,
+                    },
                 )
             } else {
                 // New window — this connection is its first.
-                (((window as u64) << 32) | 1, true)
+                (((window as u64) << 32) | 1, Admit::Granted)
             };
             if self
                 .packed
                 .compare_exchange_weak(old, new, Relaxed, Relaxed)
                 .is_ok()
             {
-                return admitted;
+                return verdict;
             }
         }
     }
+}
+
+/// Verdict of [`FpRate::admit`] for one connection.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum Admit {
+    /// Under the cap — proceed.
+    Granted,
+    /// The connection that crossed the cap: denied, and the one worth logging.
+    FirstDenial,
+    /// Over the cap, already reported this window: denied silently.
+    Denied,
 }
 
 /// One resolved allowlist entry: the human label plus the optional
@@ -529,31 +550,42 @@ impl TlsFpRuntime {
     /// Over-cap in `allowlist` mode drops the connection pre-handshake; in
     /// `shadow` it is counted (`zion_tls_fp_rate_limited`) but never blocks —
     /// shadow observes, whatever the knobs say.
+    ///
+    /// Only the window's FIRST denial is logged: a JA4 is replayable
+    /// client-controlled input, so a per-connection log line here would hand an
+    /// attacker unbounded log amplification (the same hazard the ban fast path
+    /// closes for unknown fingerprints). Every denial still counts in the
+    /// metrics.
     fn known_decision(&self, ja4: &Ja4, entry: &AllowedEntry, now_secs: u64) -> GateDecision {
         use crate::config::FingerprintMode;
         let Some(rate) = &entry.rate else {
             return GateDecision::Proceed;
         };
-        if rate.admit(now_secs) {
+        let verdict = rate.admit(now_secs);
+        if verdict == Admit::Granted {
             return GateDecision::Proceed;
         }
         crate::metrics::METRICS
             .tls_fp_rate_limited
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         if self.mode == FingerprintMode::Allowlist {
-            tracing::warn!(
-                ja4 = %ja4, name = %entry.name, limit_cps = rate.cps,
-                "tls-fp: per-fingerprint connection rate exceeded — dropping pre-handshake"
-            );
+            if verdict == Admit::FirstDenial {
+                tracing::warn!(
+                    ja4 = %ja4, name = %entry.name, limit_cps = rate.cps,
+                    "tls-fp: per-fingerprint connection rate exceeded — dropping over-cap connections this second"
+                );
+            }
             crate::metrics::METRICS
                 .tls_fp_rejected
                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             GateDecision::Reject
         } else {
-            tracing::info!(
-                ja4 = %ja4, name = %entry.name, limit_cps = rate.cps,
-                "tls-fp: per-fingerprint connection rate exceeded (shadow — connection proceeds)"
-            );
+            if verdict == Admit::FirstDenial {
+                tracing::info!(
+                    ja4 = %ja4, name = %entry.name, limit_cps = rate.cps,
+                    "tls-fp: per-fingerprint connection rate exceeded (shadow — connections proceed)"
+                );
+            }
             GateDecision::Proceed
         }
     }
@@ -603,44 +635,103 @@ impl TlsFpRuntime {
     }
 }
 
-/// Ban set for rejected unknown fingerprints (#27 commit 4): JA4 → banned
-/// until. Owned by `AppState` — like the per-IP `rate_map`, it tracks client
-/// behaviour, not config, so it survives hot-reloads (an operator tweaking an
-/// unrelated knob mid-attack must not amnesty every banned fingerprint).
-pub type BanMap = dashmap::DashMap<String, std::time::Instant>;
-
 /// Ceiling on tracked bans. An attacker rotating a UNIQUE JA4 per connection
 /// would otherwise grow the map without bound. At the cap, expired entries are
 /// swept; if the map is still full the insert is skipped — a ban is only the
 /// fast path, the slow path still rejects every unknown connection one by one.
 const MAX_BAN_ENTRIES: usize = 4096;
 
-/// Is `ja4` actively banned at `now`? An expired entry is removed on the way.
-fn ban_hit(bans: &BanMap, ja4: &str, now: std::time::Instant) -> bool {
-    // The read guard from `get` MUST be dropped before `remove` touches the
-    // same key — holding it across the removal deadlocks the DashMap shard.
-    {
-        let Some(until) = bans.get(ja4) else {
-            return false;
-        };
-        if *until > now {
-            return true;
-        }
-    }
-    drop(bans.remove(ja4));
-    false
+/// Minimum spacing between full-map sweeps of the ban set. A sweep is a
+/// `retain` that write-locks every DashMap shard and walks all entries; at
+/// capacity, doing that per connection would put O(MAX_BAN_ENTRIES) work on
+/// the accept path of the exact flood the cap defends against.
+const BAN_SWEEP_INTERVAL: std::time::Duration = std::time::Duration::from_secs(1);
+
+/// Ban set for rejected unknown fingerprints (#27 commit 4): JA4 → banned
+/// until. Owned by `AppState` — like the per-IP `rate_map`, it tracks client
+/// behaviour, not config, so it survives hot-reloads (an operator tweaking an
+/// unrelated knob mid-attack must not amnesty every banned fingerprint).
+#[derive(Debug, Default)]
+pub struct BanSet {
+    map: dashmap::DashMap<String, std::time::Instant>,
+    /// Elapsed-milliseconds-since-first-use timestamp before which no full-map
+    /// sweep may run (amortizes the at-capacity `retain` to one per
+    /// `BAN_SWEEP_INTERVAL` process-wide; a CAS elects the single sweeper).
+    next_sweep_ms: std::sync::atomic::AtomicU64,
+    /// Fixed origin for `next_sweep_ms` (set on first use).
+    epoch: std::sync::OnceLock<std::time::Instant>,
 }
 
-/// Record a ban for `ja4` until `now + ttl`, sweeping expired entries (and
-/// giving up on the insert) when the map is at capacity.
-fn ban_insert(bans: &BanMap, ja4: &str, now: std::time::Instant, ttl: std::time::Duration) {
-    if bans.len() >= MAX_BAN_ENTRIES {
-        bans.retain(|_, until| *until > now);
-        if bans.len() >= MAX_BAN_ENTRIES {
-            return; // full of LIVE bans — skip; the slow path still rejects
+impl BanSet {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Milliseconds from the set's fixed epoch to `now`. Monotonic; saturates
+    /// at 0 for a `now` predating the epoch (only synthetic test clocks).
+    fn elapsed_ms(&self, now: std::time::Instant) -> u64 {
+        let epoch = *self.epoch.get_or_init(|| now);
+        now.saturating_duration_since(epoch).as_millis() as u64
+    }
+
+    /// Is `ja4` actively banned at `now`? An expired entry is removed on the way.
+    fn hit(&self, ja4: &str, now: std::time::Instant) -> bool {
+        // The read guard from `get` MUST be dropped before `remove` touches the
+        // same key — holding it across the removal deadlocks the DashMap shard.
+        {
+            let Some(until) = self.map.get(ja4) else {
+                return false;
+            };
+            if *until > now {
+                return true;
+            }
+        }
+        drop(self.map.remove(ja4));
+        false
+    }
+
+    /// Record a ban for `ja4` until `now + ttl`. At capacity, sweep expired
+    /// entries — but at most once per `BAN_SWEEP_INTERVAL` across the whole
+    /// process (CAS elects one sweeper; everyone else skips the insert) — and
+    /// give up on the insert if the map is still full of live bans.
+    fn insert(&self, ja4: &str, now: std::time::Instant, ttl: std::time::Duration) {
+        use std::sync::atomic::Ordering::Relaxed;
+        if self.map.len() >= MAX_BAN_ENTRIES {
+            let now_ms = self.elapsed_ms(now);
+            let next = self.next_sweep_ms.load(Relaxed);
+            if now_ms < next {
+                return; // a sweep just ran and the map is still full — skip
+            }
+            if self
+                .next_sweep_ms
+                .compare_exchange(
+                    next,
+                    now_ms + BAN_SWEEP_INTERVAL.as_millis() as u64,
+                    Relaxed,
+                    Relaxed,
+                )
+                .is_err()
+            {
+                return; // another connection won the sweep election — skip
+            }
+            self.map.retain(|_, until| *until > now);
+            if self.map.len() >= MAX_BAN_ENTRIES {
+                return; // full of LIVE bans — skip; the slow path still rejects
+            }
+        }
+        // Validation caps ban_ttl_secs at one year, so this add cannot
+        // overflow in practice — checked anyway: a skipped ban is safe, an
+        // abort (release panics abort) is not.
+        if let Some(until) = now.checked_add(ttl) {
+            self.map.insert(ja4.to_owned(), until);
         }
     }
-    bans.insert(ja4.to_owned(), now + ttl);
+
+    /// Number of tracked bans (tests / introspection).
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.map.len()
+    }
 }
 
 /// Bytes peeked to cover a full ClientHello — big enough for a TLS 1.3 hybrid
@@ -753,7 +844,7 @@ pub async fn fingerprint_gate(
                 // are dropped — everywhere else nothing is ever banned.
                 if fp.drops_unknown() && !fp.ban_ttl.is_zero() {
                     let now = std::time::Instant::now();
-                    if ban_hit(&state.tls_fp_bans, ja4.as_str(), now) {
+                    if state.tls_fp_bans.hit(ja4.as_str(), now) {
                         crate::metrics::METRICS
                             .tls_fp_banned_hits
                             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
@@ -765,7 +856,7 @@ pub async fn fingerprint_gate(
                         tracing::debug!(ja4 = %ja4, "tls-fp: rejecting banned fingerprint (fast path)");
                         return GateDecision::Reject;
                     }
-                    ban_insert(&state.tls_fp_bans, ja4.as_str(), now, fp.ban_ttl);
+                    state.tls_fp_bans.insert(ja4.as_str(), now, fp.ban_ttl);
                 }
                 fp.unknown_decision(&ja4)
             }
@@ -1210,21 +1301,24 @@ mod tests {
     fn fp_rate_admits_up_to_cps_within_one_second() {
         let rate = FpRate::new(3);
         let t = 1_000_000u64;
-        assert!(rate.admit(t));
-        assert!(rate.admit(t));
-        assert!(rate.admit(t));
-        assert!(!rate.admit(t)); // 4th connection in the same second → over cap
-        assert!(!rate.admit(t)); // stays over for the rest of the window
+        assert_eq!(rate.admit(t), Admit::Granted);
+        assert_eq!(rate.admit(t), Admit::Granted);
+        assert_eq!(rate.admit(t), Admit::Granted);
+        // 4th connection in the same second crosses the cap — the ONE worth
+        // logging; every later denial in the window is silent.
+        assert_eq!(rate.admit(t), Admit::FirstDenial);
+        assert_eq!(rate.admit(t), Admit::Denied);
+        assert_eq!(rate.admit(t), Admit::Denied);
     }
 
     #[test]
     fn fp_rate_resets_on_a_new_second() {
         let rate = FpRate::new(1);
         let t = 1_000_000u64;
-        assert!(rate.admit(t));
-        assert!(!rate.admit(t));
-        assert!(rate.admit(t + 1)); // next window starts fresh
-        assert!(!rate.admit(t + 1));
+        assert_eq!(rate.admit(t), Admit::Granted);
+        assert_eq!(rate.admit(t), Admit::FirstDenial);
+        assert_eq!(rate.admit(t + 1), Admit::Granted); // next window starts fresh
+        assert_eq!(rate.admit(t + 1), Admit::FirstDenial); // and logs once again
     }
 
     #[test]
@@ -1236,8 +1330,8 @@ mod tests {
             ((t as u32 as u64) << 32) | u64::from(u32::MAX),
             std::sync::atomic::Ordering::Relaxed,
         );
-        assert!(!rate.admit(t));
-        assert!(!rate.admit(t)); // saturated, still over
+        assert_eq!(rate.admit(t), Admit::Denied);
+        assert_eq!(rate.admit(t), Admit::Denied); // saturated, still over, still silent
     }
 
     #[test]
@@ -1281,41 +1375,78 @@ mod tests {
 
     #[test]
     fn ban_hit_respects_ttl_and_removes_expired() {
-        let bans = BanMap::new();
+        let bans = BanSet::new();
         let now = std::time::Instant::now();
         let ttl = std::time::Duration::from_secs(600);
-        ban_insert(&bans, "fp-a", now, ttl);
-        assert!(ban_hit(&bans, "fp-a", now)); // inside the TTL
-        assert!(!ban_hit(&bans, "fp-b", now)); // never banned
-                                               // Past the TTL the entry no longer bans — and is removed on the way.
-        assert!(!ban_hit(
-            &bans,
-            "fp-a",
-            now + ttl + std::time::Duration::from_secs(1)
-        ));
-        assert!(bans.get("fp-a").is_none());
+        bans.insert("fp-a", now, ttl);
+        assert!(bans.hit("fp-a", now)); // inside the TTL
+        assert!(!bans.hit("fp-b", now)); // never banned
+                                         // Past the TTL the entry no longer bans — and is removed on the way.
+        assert!(!bans.hit("fp-a", now + ttl + std::time::Duration::from_secs(1)));
+        assert!(bans.map.get("fp-a").is_none());
     }
 
     #[test]
     fn ban_insert_at_capacity_sweeps_expired_then_skips_when_full_of_live() {
-        let bans = BanMap::new();
+        let bans = BanSet::new();
         let now = std::time::Instant::now();
         let ttl = std::time::Duration::from_secs(600);
         // Fill to the cap with entries that are already expired at `later`.
         for i in 0..MAX_BAN_ENTRIES {
-            bans.insert(format!("old-{i}"), now); // banned_until = now → expired after now
+            bans.map.insert(format!("old-{i}"), now); // banned_until = now → expired after now
         }
-        let later = now + std::time::Duration::from_secs(1);
+        let later = now + std::time::Duration::from_secs(2);
         // The sweep clears the expired entries and the insert lands.
-        ban_insert(&bans, "fresh", later, ttl);
-        assert!(ban_hit(&bans, "fresh", later));
+        bans.insert("fresh", later, ttl);
+        assert!(bans.hit("fresh", later));
         assert!(bans.len() < MAX_BAN_ENTRIES);
-        // Now fill to the cap with LIVE bans: the next insert is skipped.
+        // Now fill to the cap with LIVE bans: the next insert is skipped
+        // (once the sweep interval has passed, so the sweep itself runs).
         for i in 0..MAX_BAN_ENTRIES {
-            bans.insert(format!("live-{i}"), later + ttl);
+            bans.map.insert(format!("live-{i}"), later + ttl);
         }
-        ban_insert(&bans, "overflow", later, ttl);
-        assert!(!ban_hit(&bans, "overflow", later));
+        let much_later = later + BAN_SWEEP_INTERVAL + std::time::Duration::from_millis(1);
+        bans.insert("overflow", much_later, ttl);
+        assert!(!bans.hit("overflow", much_later));
+    }
+
+    #[test]
+    fn ban_sweep_is_amortized_one_full_retain_per_interval() {
+        let bans = BanSet::new();
+        let now = std::time::Instant::now();
+        let ttl = std::time::Duration::from_secs(600);
+        // Cap the map with entries that are EXPIRED at `later` — sweepable.
+        for i in 0..MAX_BAN_ENTRIES {
+            bans.map.insert(format!("old-{i}"), now);
+        }
+        let later = now + std::time::Duration::from_secs(2);
+        // First at-capacity insert runs the sweep and lands.
+        bans.insert("first", later, ttl);
+        assert!(bans.hit("first", later));
+        // Re-cap with expired entries again, WITHIN the sweep interval: the
+        // sweep must NOT run again — the insert is skipped even though every
+        // entry is sweepable. This is the amortization: O(n) retain at most
+        // once per BAN_SWEEP_INTERVAL, not per connection.
+        for i in 0..MAX_BAN_ENTRIES {
+            bans.map.insert(format!("re-{i}"), now);
+        }
+        let within = later + std::time::Duration::from_millis(10);
+        bans.insert("second", within, ttl);
+        assert!(!bans.hit("second", within));
+        // After the interval the sweep is allowed again and the insert lands.
+        let after = later + BAN_SWEEP_INTERVAL + std::time::Duration::from_millis(1);
+        bans.insert("third", after, ttl);
+        assert!(bans.hit("third", after));
+    }
+
+    #[test]
+    fn ban_insert_skips_on_instant_overflow_instead_of_panicking() {
+        // Validation caps ban_ttl_secs at one year, but the insert must stay
+        // panic-free regardless (release panics abort the proxy).
+        let bans = BanSet::new();
+        let now = std::time::Instant::now();
+        bans.insert("fp-x", now, std::time::Duration::from_secs(u64::MAX));
+        assert!(!bans.hit("fp-x", now)); // skipped, not aborted
     }
 
     #[test]


### PR DESCRIPTION
Commit 4/5 of the JA4 zero-trust gate (#27). Two gate-level enforcement primitives, both behind `--features tls-fingerprint`, zero overhead when off.

## `rate_limit_cps` per allowlist entry
Cap on **new TLS connections per second** for that fingerprint — connections, not requests: the gate runs pre-handshake, where requests don't exist yet (a per-request limit belongs to commit 5/5, once the JA4 is stashed on the connection — hence `cps`, keeping the `rps` namespace honest for later). Fixed 1 s window, `(window,count)` packed in one `AtomicU64` advanced by CAS — the `security::RateEntry` idiom — with a **saturating count** so a u32-scale flood cannot wrap back under the cap. Over-cap drops pre-handshake in `allowlist` mode; `shadow` only counts (`zion_tls_fp_rate_limited`) and never blocks. `0` = no limit, consistent with `[server] rate_limit_rps`.

## Ban fast path for rejected unknowns
`allowlist` + `on_unknown = drop` records the rejected JA4 on an `AppState` ban set (`DashMap ja4 → banned_until`, `ban_ttl_secs` default 600, `0` disables). Repeats are rejected with one map lookup and a **debug**-level log instead of a warn per connection (`zion_tls_fp_banned_hits`) — under a single-fingerprint flood this is what keeps the log readable. The set survives hot-reloads (like the per-IP `rate_map`: client behaviour, not config), but the **allowlist is consulted first**, so hot-reloading a fingerprint onto the allowlist beats any stale ban immediately. Capped at 4096 entries: expired bans swept at capacity, insert skipped when full of live ones — the ban is only the fast path, the slow path still rejects every unknown one by one.

## Notes
- New metrics `zion_tls_fp_banned_hits` and `zion_tls_fp_rate_limited` (HELP/TYPE in the exporter); both ban-hits and rate-drops also count in `zion_tls_fp_rejected`.
- `FingerprintConfig` gets a manual `Default` so `::default()` and a TOML block omitting `ban_ttl_secs` agree on 600 (a derived Default would silently say 0). Tested.
- 8 new tests (window rollover, count saturation, ban TTL/expiry/capacity sweep, shadow-observes-never-blocks, config resolution). The ban-hit test **caught a real DashMap deadlock in the first draft** — `remove` while the shard's read guard from `get` was still alive; the fix scopes the guard explicitly and documents the constraint.
- Verified: clippy `--all-targets` clean on default / acme / tls-fingerprint / all-features, 889 tests green, README stats SSOT regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)