### PR TITLE
feat(tls-fp): per-fingerprint allowed_routes — request-level 403 (#27 follow-up)

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Client -> TLS 1.3 -> Security Gates -> Radix Router -> WAF Pipeline (5 gates) ->
 ```
 
 <!-- zion-stats:modules-lines (kept in sync by scripts/update-readme-stats.sh) -->
-49 modules, ~44,500 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
+49 modules, ~44,800 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Client -> TLS 1.3 -> Security Gates -> Radix Router -> WAF Pipeline (5 gates) ->
 ```
 
 <!-- zion-stats:modules-lines (kept in sync by scripts/update-readme-stats.sh) -->
-49 modules, ~44,800 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
+49 modules, ~44,900 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
 
 ## Features
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -471,6 +471,17 @@ pub struct AllowedFingerprint {
     /// consistent with `[server] rate_limit_rps`.
     #[serde(default)]
     pub rate_limit_cps: u32,
+    /// Routes this fingerprint may request — same pattern syntax and matching
+    /// semantics as `[[route]] path` (matchit; a catch-all also covers its
+    /// bare prefix, `/x` and `/x/` are the same). Empty (default) = no
+    /// restriction. A request outside the list gets **403** in `allowlist`
+    /// mode — request-level policy is HTTP-level: the handshake already
+    /// happened, and on HTTP/2 dropping the connection would kill unrelated
+    /// in-flight requests — and is only counted
+    /// (`zion_tls_fp_route_denied`) in `shadow`. Patterns are validated at
+    /// boot; an invalid one refuses the config.
+    #[serde(default)]
+    pub allowed_routes: Vec<String>,
 }
 
 #[derive(Deserialize, Clone, Debug)]
@@ -960,6 +971,20 @@ fn semantic_errors(config: &ZionConfig) -> Vec<String> {
                      (expected e.g. t13d1516h2_8daaf6152771_e5627efa2ab1)",
                     a.name, a.ja4
                 ));
+            }
+        }
+        // allowed_routes patterns must compile (#27 follow-up): a typo'd
+        // pattern would otherwise be discovered as a runtime surprise — either
+        // a silent no-restriction or a silent deny — instead of a boot error.
+        for a in &fp.allowed {
+            if !a.allowed_routes.is_empty() {
+                if let Err(e) = compile_path_set(&a.allowed_routes) {
+                    errors.push(format!(
+                        "[tls.fingerprint] allowed entry '{}': {e} (allowed_routes uses \
+                         the same pattern syntax as [[route]] path)",
+                        a.name
+                    ));
+                }
             }
         }
         // The entry name becomes the X-Client-TLS-Allowlisted header value
@@ -1606,6 +1631,36 @@ fn trailing_slash_variant(path: &str) -> Option<String> {
     }
 }
 
+/// Compile a set of route-path patterns into a bare matcher with the SAME
+/// alias semantics as the request router (bare prefix for catch-alls,
+/// trailing-slash variant otherwise — see `RouterBuilder::insert`). Used by
+/// `[tls.fingerprint]` `allowed_routes` (#27 follow-up) so a restriction list
+/// matches paths exactly the way `[[route]] path` does — two pattern dialects
+/// in one config would be a trap. Alias inserts are best-effort, mirroring
+/// `RouterBuilder::finish`.
+#[allow(dead_code)] // read only under `--features tls-fingerprint`
+pub(crate) fn compile_path_set(patterns: &[String]) -> Result<matchit::Router<()>, String> {
+    let mut router = matchit::Router::new();
+    let mut aliases: Vec<String> = Vec::new();
+    for p in patterns {
+        router
+            .insert(p.clone(), ())
+            .map_err(|e| format!("bad route pattern '{p}': {e}"))?;
+        match catchall_bare_prefix(p) {
+            Some(bare) => aliases.push(bare),
+            None => {
+                if let Some(v) = trailing_slash_variant(p) {
+                    aliases.push(v);
+                }
+            }
+        }
+    }
+    for a in aliases {
+        let _ = router.insert(a, ());
+    }
+    Ok(router)
+}
+
 // ═══════════════════════════════════════════════════════════════════
 // ROUTES MINI-TABLE (boot-time visualization)
 // ═══════════════════════════════════════════════════════════════════
@@ -1786,6 +1841,29 @@ mod tests {
         let cfg = parse_schema(dup, "test").expect("parse");
         let err = validate_semantics(&cfg, "test").err().unwrap_or_default();
         assert!(err.contains("same JA4"), "got: {err}");
+    }
+
+    #[cfg(feature = "tls-fingerprint")]
+    #[test]
+    fn allowed_routes_bad_pattern_is_rejected() {
+        // A typo'd pattern must be a boot error, not a runtime surprise.
+        let bad = "[server]\nlisten_http=\"0.0.0.0:80\"\nlisten_https=\"0.0.0.0:443\"\n\
+             [tls]\ncert_path=\"/c\"\nkey_path=\"/k\"\n\
+             [tls.fingerprint]\nmode=\"allowlist\"\non_unknown=\"drop\"\n\
+             allowed=[{name=\"a\",ja4=\"t13d1516h2_8daaf6152771_e5627efa2ab1\",allowed_routes=[\"/api/{unclosed\"]}]\n\
+             [upstreams]\nbe=\"http://127.0.0.1:8000\"\n\
+             [[route]]\npath=\"/{*rest}\"\nupstream=\"be\"\n";
+        let cfg = parse_schema(bad, "test").expect("parse");
+        let err = validate_semantics(&cfg, "test").err().unwrap_or_default();
+        assert!(err.contains("allowed_routes"), "got: {err}");
+        // And a valid list passes.
+        let ok = bad.replace("[\"/api/{unclosed\"]", "[\"/api/{*rest}\", \"/healthz\"]");
+        let cfg = parse_schema(&ok, "test").expect("parse");
+        assert!(
+            validate_semantics(&cfg, "test").is_ok(),
+            "valid allowed_routes must pass: {:?}",
+            validate_semantics(&cfg, "test").err()
+        );
     }
 
     #[cfg(feature = "tls-fingerprint")]

--- a/src/config.rs
+++ b/src/config.rs
@@ -484,8 +484,10 @@ pub struct AllowedFingerprint {
     /// Scope: the list is a positive grant over the WHOLE request surface,
     /// built-in endpoints included — a restricted scraper needs `/metrics`
     /// on its list (the endpoint's own internal-IP gate still applies).
-    /// Exceptions: `/healthz` and `/readyz` are answered on the listener
-    /// fast path, before this gate exists, and are never restricted.
+    /// Exceptions: `/healthz` and `/readyz` are exempt BY DESIGN — the gate
+    /// itself allows them (`route_gate`), so the property holds on every
+    /// protocol: on :443 HTTP/1.1-2 they are answered on the listener fast
+    /// path before dispatch, while HTTP/3 bridges into dispatch directly.
     #[serde(default)]
     pub allowed_routes: Vec<String>,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -480,6 +480,12 @@ pub struct AllowedFingerprint {
     /// in-flight requests — and is only counted
     /// (`zion_tls_fp_route_denied`) in `shadow`. Patterns are validated at
     /// boot; an invalid one refuses the config.
+    ///
+    /// Scope: the list is a positive grant over the WHOLE request surface,
+    /// built-in endpoints included — a restricted scraper needs `/metrics`
+    /// on its list (the endpoint's own internal-IP gate still applies).
+    /// Exceptions: `/healthz` and `/readyz` are answered on the listener
+    /// fast path, before this gate exists, and are never restricted.
     #[serde(default)]
     pub allowed_routes: Vec<String>,
 }

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -343,10 +343,13 @@ async fn process_request_inner(
     // in-flight requests — 403, like the sovereign enforcement gate above.
     // The `X-Client-TLS-JA4` header is Zion's OWN attestation (any inbound
     // copy is stripped and the verified value re-injected at the listener —
-    // see `tls_fp::apply_headers`), so trusting it here is sound. Deny
-    // logging is debug-level on purpose: a JA4 is replayable
-    // client-controlled input, and the metric plus the 403 in the access log
-    // already carry the signal (see the commit-4 log-amplification findings).
+    // see `tls_fp::apply_headers`), so trusting it here is sound. Like every
+    // pre-routing gate, this early return never reaches the access log; the
+    // `zion_tls_fp_route_denied` metric is the operator signal. Policy, mode
+    // handling, metric, and (debug) logging all live in `route_gate` — and
+    // note the gate covers the WHOLE request surface reaching dispatch
+    // (built-in /metrics included; /healthz and /readyz are answered on the
+    // listener fast path and never get here).
     #[cfg(feature = "tls-fingerprint")]
     if let Some(fp) = cfg.tls_fingerprint.as_ref() {
         if let Some(ja4) = req
@@ -354,25 +357,8 @@ async fn process_request_inner(
             .get(crate::tls_fp::HDR_JA4)
             .and_then(|v| v.to_str().ok())
         {
-            if let Some(name) = fp.route_denied(ja4, req.uri().path()) {
-                metrics::METRICS
-                    .tls_fp_route_denied
-                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                if fp.mode == crate::config::FingerprintMode::Allowlist {
-                    tracing::debug!(
-                        ja4,
-                        name,
-                        path = req.uri().path(),
-                        "tls-fp: route not in allowed_routes for this fingerprint — 403"
-                    );
-                    return Ok(empty_response(StatusCode::FORBIDDEN));
-                }
-                tracing::debug!(
-                    ja4,
-                    name,
-                    path = req.uri().path(),
-                    "tls-fp: route not in allowed_routes (shadow — proceeding)"
-                );
+            if fp.route_gate(ja4, req.uri().path()) == crate::tls_fp::GateDecision::Reject {
+                return Ok(empty_response(StatusCode::FORBIDDEN));
             }
         }
     }

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -348,8 +348,10 @@ async fn process_request_inner(
     // `zion_tls_fp_route_denied` metric is the operator signal. Policy, mode
     // handling, metric, and (debug) logging all live in `route_gate` — and
     // note the gate covers the WHOLE request surface reaching dispatch
-    // (built-in /metrics included; /healthz and /readyz are answered on the
-    // listener fast path and never get here).
+    // (built-in /metrics included). /healthz and /readyz are exempt INSIDE
+    // route_gate: HTTP/3 bridges into dispatch directly (quic.rs), so the
+    // health exemption must be the gate's own property, not an accident of
+    // the :443 listener fast path.
     #[cfg(feature = "tls-fingerprint")]
     if let Some(fp) = cfg.tls_fingerprint.as_ref() {
         if let Some(ja4) = req

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -336,6 +336,47 @@ async fn process_request_inner(
         }
     }
 
+    // ── JA4 per-fingerprint route restriction (#27 follow-up) ──
+    //
+    // Request-level policy, so the deny is HTTP-level: the handshake already
+    // happened, and on HTTP/2 dropping the connection would kill unrelated
+    // in-flight requests — 403, like the sovereign enforcement gate above.
+    // The `X-Client-TLS-JA4` header is Zion's OWN attestation (any inbound
+    // copy is stripped and the verified value re-injected at the listener —
+    // see `tls_fp::apply_headers`), so trusting it here is sound. Deny
+    // logging is debug-level on purpose: a JA4 is replayable
+    // client-controlled input, and the metric plus the 403 in the access log
+    // already carry the signal (see the commit-4 log-amplification findings).
+    #[cfg(feature = "tls-fingerprint")]
+    if let Some(fp) = cfg.tls_fingerprint.as_ref() {
+        if let Some(ja4) = req
+            .headers()
+            .get(crate::tls_fp::HDR_JA4)
+            .and_then(|v| v.to_str().ok())
+        {
+            if let Some(name) = fp.route_denied(ja4, req.uri().path()) {
+                metrics::METRICS
+                    .tls_fp_route_denied
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                if fp.mode == crate::config::FingerprintMode::Allowlist {
+                    tracing::debug!(
+                        ja4,
+                        name,
+                        path = req.uri().path(),
+                        "tls-fp: route not in allowed_routes for this fingerprint — 403"
+                    );
+                    return Ok(empty_response(StatusCode::FORBIDDEN));
+                }
+                tracing::debug!(
+                    ja4,
+                    name,
+                    path = req.uri().path(),
+                    "tls-fp: route not in allowed_routes (shadow — proceeding)"
+                );
+            }
+        }
+    }
+
     // ── AIMP mesh score lookup (signal, not gate) ──
     //
     // If the AIMP control plane is up and has a reputation entry for

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -424,6 +424,9 @@ pub struct Metrics {
     /// Dropped pre-handshake in `allowlist` mode (also counted in
     /// `tls_fp_rejected`); in `shadow` mode counted here but never blocked.
     pub tls_fp_rate_limited: AtomicU64,
+    /// Requests outside an allowlisted fingerprint's `allowed_routes` (#27
+    /// follow-up): 403 in `allowlist` mode, counted-only in `shadow`.
+    pub tls_fp_route_denied: AtomicU64,
     /// Connections closed at accept because the source IP was already at
     /// its `max_connections_per_ip` concurrent cap (anti-DDoS lever).
     pub connections_rejected_per_ip: AtomicU64,
@@ -528,6 +531,7 @@ impl Metrics {
             tls_fp_rejected: AtomicU64::new(0),
             tls_fp_banned_hits: AtomicU64::new(0),
             tls_fp_rate_limited: AtomicU64::new(0),
+            tls_fp_route_denied: AtomicU64::new(0),
             connections_rejected_per_ip: AtomicU64::new(0),
             enforcement_denied_class: AtomicU64::new(0),
             enforcement_denied_mesh_score: AtomicU64::new(0),
@@ -835,6 +839,18 @@ impl Metrics {
         out.extend_from_slice(
             itoa_buf
                 .format(self.tls_fp_rate_limited.load(Relaxed))
+                .as_bytes(),
+        );
+        out.extend_from_slice(b"\n");
+
+        out.extend_from_slice(
+            b"# HELP zion_tls_fp_route_denied Requests outside an allowlisted fingerprint's allowed_routes (403 in allowlist mode, observed in shadow).\n\
+                                # TYPE zion_tls_fp_route_denied counter\n\
+                                zion_tls_fp_route_denied ",
+        );
+        out.extend_from_slice(
+            itoa_buf
+                .format(self.tls_fp_route_denied.load(Relaxed))
                 .as_bytes(),
         );
         out.extend_from_slice(b"\n");

--- a/src/tls_fp.rs
+++ b/src/tls_fp.rs
@@ -563,6 +563,41 @@ impl TlsFpRuntime {
         })
     }
 
+    /// The complete per-request route gate (#27 follow-up): restriction
+    /// lookup, mode policy, metric, and (debug) logging in one place, so the
+    /// dispatch wiring stays a dumb two-liner and the mode branch is
+    /// unit-testable here. `Reject` ONLY in `allowlist` mode for a restricted
+    /// fingerprint outside its list; `shadow` observes (counts
+    /// `zion_tls_fp_route_denied`, never blocks). Deny logging is debug-level on purpose: a JA4 is replayable
+    /// client-controlled input, and the metric is the operator signal — the
+    /// access log never sees early-gate denials (same as the sovereign gate).
+    pub fn route_gate(&self, ja4: &str, path: &str) -> GateDecision {
+        use crate::config::FingerprintMode;
+        let Some(name) = self.route_denied(ja4, path) else {
+            return GateDecision::Proceed;
+        };
+        crate::metrics::METRICS
+            .tls_fp_route_denied
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        if self.mode == FingerprintMode::Allowlist {
+            tracing::debug!(
+                ja4,
+                name,
+                path,
+                "tls-fp: route not in allowed_routes for this fingerprint — 403"
+            );
+            GateDecision::Reject
+        } else {
+            tracing::debug!(
+                ja4,
+                name,
+                path,
+                "tls-fp: route not in allowed_routes (shadow — proceeding)"
+            );
+            GateDecision::Proceed
+        }
+    }
+
     /// Per-fingerprint route restriction (#27 follow-up): `Some(entry name)`
     /// when `ja4` is allowlisted with an `allowed_routes` list that does NOT
     /// cover `path`. `None` = unrestricted entry, path covered, or `ja4` not
@@ -1825,6 +1860,65 @@ mod tests {
             rt.route_denied("t00i0000_000000000000_000000000000", "/admin"),
             None
         );
+    }
+
+    #[test]
+    fn route_gate_mode_matrix_allowlist_rejects_shadow_observes() {
+        use crate::config::{AllowedFingerprint, FingerprintConfig, FingerprintMode};
+        let chrome = "t13d1516h2_8daaf6152771_e5627efa2ab1";
+        let mk = |mode| {
+            let cfg = FingerprintConfig {
+                mode,
+                allowed: vec![AllowedFingerprint {
+                    name: "api-agent".into(),
+                    ja4: chrome.into(),
+                    rate_limit_cps: 0,
+                    allowed_routes: vec!["/api/{*rest}".into()],
+                }],
+                ..Default::default()
+            };
+            TlsFpRuntime::from_config(&cfg).unwrap()
+        };
+        // allowlist: outside the list → Reject (the dispatch 403); inside → Proceed.
+        let al = mk(FingerprintMode::Allowlist);
+        assert_eq!(al.route_gate(chrome, "/admin"), GateDecision::Reject);
+        assert_eq!(al.route_gate(chrome, "/api/v1"), GateDecision::Proceed);
+        // shadow: NEVER rejects, even outside the list (observe-only rollout).
+        let sh = mk(FingerprintMode::Shadow);
+        assert_eq!(sh.route_gate(chrome, "/admin"), GateDecision::Proceed);
+        // unknown ja4 / unrestricted: not this gate's business.
+        assert_eq!(
+            al.route_gate("t00i0000_000000000000_000000000000", "/admin"),
+            GateDecision::Proceed
+        );
+    }
+
+    #[test]
+    fn route_gate_counts_denials_in_both_modes() {
+        use crate::config::{AllowedFingerprint, FingerprintConfig, FingerprintMode};
+        let chrome = "t13d1516h2_8daaf6152771_e5627efa2ab1";
+        let cfg = FingerprintConfig {
+            mode: FingerprintMode::Shadow,
+            allowed: vec![AllowedFingerprint {
+                name: "api-agent".into(),
+                ja4: chrome.into(),
+                rate_limit_cps: 0,
+                allowed_routes: vec!["/api/{*rest}".into()],
+            }],
+            ..Default::default()
+        };
+        let rt = TlsFpRuntime::from_config(&cfg).unwrap();
+        let before = crate::metrics::METRICS
+            .tls_fp_route_denied
+            .load(std::sync::atomic::Ordering::Relaxed);
+        rt.route_gate(chrome, "/admin"); // shadow denial: counted, not blocked
+        rt.route_gate(chrome, "/api/ok"); // allowed: NOT counted
+        let after = crate::metrics::METRICS
+            .tls_fp_route_denied
+            .load(std::sync::atomic::Ordering::Relaxed);
+        // >= 1 rather than == 1: the metric is a global atomic shared with
+        // parallel tests — only the delta from THIS test's denial is asserted.
+        assert!(after > before, "denial must increment the metric");
     }
 
     #[test]

--- a/src/tls_fp.rs
+++ b/src/tls_fp.rs
@@ -573,6 +573,15 @@ impl TlsFpRuntime {
     /// access log never sees early-gate denials (same as the sovereign gate).
     pub fn route_gate(&self, ja4: &str, path: &str) -> GateDecision {
         use crate::config::FingerprintMode;
+        // Health probes are NEVER policy-gated — a restriction list that
+        // 403s the load balancer's health check is an outage lever. On :443
+        // HTTP/1.1-2 these are answered on the listener fast path and never
+        // reach dispatch, but HTTP/3 bridges straight into process_request
+        // (see quic.rs handle_h3_request), so the exemption must live HERE
+        // to be a structural property rather than a per-protocol accident.
+        if path == "/healthz" || path == "/readyz" {
+            return GateDecision::Proceed;
+        }
         let Some(name) = self.route_denied(ja4, path) else {
             return GateDecision::Proceed;
         };
@@ -1891,6 +1900,11 @@ mod tests {
             al.route_gate("t00i0000_000000000000_000000000000", "/admin"),
             GateDecision::Proceed
         );
+        // health probes: exempt BY DESIGN even for a restricted fingerprint —
+        // over HTTP/3 they reach dispatch, and a 403 on the LB's health check
+        // would be an outage lever.
+        assert_eq!(al.route_gate(chrome, "/healthz"), GateDecision::Proceed);
+        assert_eq!(al.route_gate(chrome, "/readyz"), GateDecision::Proceed);
     }
 
     #[test]

--- a/src/tls_fp.rs
+++ b/src/tls_fp.rs
@@ -491,6 +491,10 @@ enum Admit {
 struct AllowedEntry {
     name: String,
     rate: Option<FpRate>,
+    /// Compiled `allowed_routes` matcher (#27 follow-up); `None` = no
+    /// restriction. Same pattern semantics as the request router — built by
+    /// `config::compile_path_set`.
+    routes: Option<matchit::Router<()>>,
 }
 
 /// Runtime-resolved fingerprint state, read on the accept path. Built once per
@@ -527,6 +531,25 @@ impl TlsFpRuntime {
                     AllowedEntry {
                         name: a.name.clone(),
                         rate: (a.rate_limit_cps > 0).then(|| FpRate::new(a.rate_limit_cps)),
+                        routes: if a.allowed_routes.is_empty() {
+                            None
+                        } else {
+                            match crate::config::compile_path_set(&a.allowed_routes) {
+                                Ok(r) => Some(r),
+                                // Validation refuses bad patterns at load, so
+                                // this arm is unreachable in practice — but if
+                                // it ever fires, fail OPEN (unrestricted) and
+                                // say so loudly: a silent total deny for an
+                                // allowlisted client is the worse failure.
+                                Err(e) => {
+                                    tracing::error!(
+                                        name = %a.name, error = %e,
+                                        "tls-fp: allowed_routes failed to compile past validation — entry left UNRESTRICTED"
+                                    );
+                                    None
+                                }
+                            }
+                        },
                     },
                 )
             })
@@ -538,6 +561,20 @@ impl TlsFpRuntime {
             ban_ttl: std::time::Duration::from_secs(cfg.ban_ttl_secs),
             allowed,
         })
+    }
+
+    /// Per-fingerprint route restriction (#27 follow-up): `Some(entry name)`
+    /// when `ja4` is allowlisted with an `allowed_routes` list that does NOT
+    /// cover `path`. `None` = unrestricted entry, path covered, or `ja4` not
+    /// on the allowlist at all (unknowns are the gate's business, not this).
+    pub fn route_denied(&self, ja4: &str, path: &str) -> Option<&str> {
+        let entry = self.allowed.get(ja4)?;
+        let routes = entry.routes.as_ref()?;
+        if routes.at(path).is_ok() {
+            None
+        } else {
+            Some(entry.name.as_str())
+        }
     }
 
     /// The allowlist entry name for a fingerprint, if it is known.
@@ -1240,6 +1277,7 @@ mod tests {
                 name: "chrome".into(),
                 ja4: "  T13D1516H2_8DAAF6152771_E5627EFA2AB1  ".into(), // upper + spaces
                 rate_limit_cps: 0,
+                allowed_routes: vec![],
             }],
             ..Default::default()
         };
@@ -1267,6 +1305,7 @@ mod tests {
                 name: "chrome".into(),
                 ja4: "t13d1516h2_8daaf6152771_e5627efa2ab1".into(),
                 rate_limit_cps: 0,
+                allowed_routes: vec![],
             }],
             ..Default::default()
         };
@@ -1473,6 +1512,7 @@ mod tests {
         let entry = AllowedEntry {
             name: "chrome".into(),
             rate: Some(FpRate::new(1)),
+            routes: None,
         };
         let t = 7_777u64;
         // allowlist: first admitted, second dropped.
@@ -1483,6 +1523,7 @@ mod tests {
         let entry_sh = AllowedEntry {
             name: "chrome".into(),
             rate: Some(FpRate::new(1)),
+            routes: None,
         };
         let sh = mk(FingerprintMode::Shadow);
         assert_eq!(
@@ -1497,6 +1538,7 @@ mod tests {
         let unlimited = AllowedEntry {
             name: "curl".into(),
             rate: None,
+            routes: None,
         };
         assert_eq!(
             al.known_decision(&ja4, &unlimited, || unreachable!(
@@ -1593,6 +1635,7 @@ mod tests {
             AllowedEntry {
                 name: "chrome".into(),
                 rate: None,
+                routes: None,
             },
         );
         TlsFpRuntime {
@@ -1742,6 +1785,49 @@ mod tests {
     }
 
     #[test]
+    fn route_denied_matrix_with_router_alias_semantics() {
+        use crate::config::{AllowedFingerprint, FingerprintConfig, FingerprintMode};
+        let chrome = "t13d1516h2_8daaf6152771_e5627efa2ab1";
+        let curl = "t13d1516h2_000000000000_000000000000";
+        let cfg = FingerprintConfig {
+            mode: FingerprintMode::Allowlist,
+            allowed: vec![
+                AllowedFingerprint {
+                    name: "api-agent".into(),
+                    ja4: chrome.into(),
+                    rate_limit_cps: 0,
+                    allowed_routes: vec!["/api/{*rest}".into(), "/healthz".into()],
+                },
+                AllowedFingerprint {
+                    name: "unrestricted".into(),
+                    ja4: curl.into(),
+                    rate_limit_cps: 0,
+                    allowed_routes: vec![],
+                },
+            ],
+            ..Default::default()
+        };
+        let rt = TlsFpRuntime::from_config(&cfg).unwrap();
+        // Covered paths — including the catch-all's BARE prefix (router alias
+        // semantics: /api/{*rest} also serves /api) and the trailing-slash
+        // variant of an explicit path.
+        assert_eq!(rt.route_denied(chrome, "/api/v1/users"), None);
+        assert_eq!(rt.route_denied(chrome, "/api"), None);
+        assert_eq!(rt.route_denied(chrome, "/healthz"), None);
+        assert_eq!(rt.route_denied(chrome, "/healthz/"), None);
+        // Outside the list → denied, reporting the entry name.
+        assert_eq!(rt.route_denied(chrome, "/admin"), Some("api-agent"));
+        assert_eq!(rt.route_denied(chrome, "/"), Some("api-agent"));
+        // No restriction list → never denied.
+        assert_eq!(rt.route_denied(curl, "/anything"), None);
+        // Not on the allowlist at all → not this check's business.
+        assert_eq!(
+            rt.route_denied("t00i0000_000000000000_000000000000", "/admin"),
+            None
+        );
+    }
+
+    #[test]
     fn from_config_resolves_rate_limit_only_when_positive() {
         use crate::config::{AllowedFingerprint, FingerprintConfig, FingerprintMode};
         let cfg = FingerprintConfig {
@@ -1751,11 +1837,13 @@ mod tests {
                     name: "limited".into(),
                     ja4: "t13d1516h2_8daaf6152771_e5627efa2ab1".into(),
                     rate_limit_cps: 50,
+                    allowed_routes: vec![],
                 },
                 AllowedFingerprint {
                     name: "unlimited".into(),
                     ja4: "t13d1516h2_000000000000_000000000000".into(),
                     rate_limit_cps: 0, // 0 = no limit, same as [server] rate_limit_rps
+                    allowed_routes: vec![],
                 },
             ],
             ban_ttl_secs: 0,


### PR DESCRIPTION
The follow-up deliberately deferred from #397, with the design call now made: **403, not drop**. `allowed_routes` is request-level policy — at request time the handshake already happened, and on HTTP/2 dropping the connection would kill unrelated in-flight requests; 403 matches the sovereign-enforcement precedent and shows up in observable places where a drop is a silent hole. Pre-handshake stays the drop domain (the gate); post-handshake is HTTP's.

## What
- `allowed_routes` on each `[tls.fingerprint]` allowed entry — **same pattern syntax and matching semantics as `[[route]] path`**: `compile_path_set` reuses the router's alias rules (a catch-all also serves its bare prefix; `/x` ≡ `/x/`). Two pattern dialects in one config would be a trap. Empty (default) = unrestricted; invalid pattern = boot/reload refusal.
- Enforcement in dispatch beside the sovereign gate, keyed on `X-Client-TLS-JA4` — Zion's own attestation (inbound copies stripped and re-injected at the listener, #397), so trusting it is sound. `allowlist` → 403 + `zion_tls_fp_route_denied`; `shadow` observes. Deny logging is debug-level (JA4 is replayable client-controlled input — the #396 log-amplification lesson).
- Scope documented honestly: the list is a positive grant over the whole request surface reaching dispatch (built-in `/metrics` included — its internal-IP gate still applies); `/healthz`/`readyz` are answered on the listener fast path and never restricted.
- Fail-open **loudly** on the theoretically-unreachable compile-after-validation failure: an entry left unrestricted with an error log beats a silent total deny for an allowlisted client.

## Adversarial review (2nd commit; 13 agents, 3 lenses × 2 refuters, 3/5 findings survived)
- Fixed the gate comment's false claim that the 403 reaches the access log (early returns never do — the metric is the signal, like every pre-routing gate).
- Documented the built-in-endpoints scope + health-probe bypass (both real, both previously silent).
- Extracted `route_gate()` so the mode branch (allowlist→403 vs shadow→proceed) is pinned by tests instead of living untested in dispatch.

Verified: clippy `--all-targets` clean on default / acme / tls-fingerprint / all-features; full suite green (+4 tests); README SSOT regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)