### PR TITLE
chore(release): v0.7.5

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,7 +21,7 @@ A clear and concise description of what you expected to happen.
 **Environment (please complete the following information):**
  - OS: [e.g. Linux, macOS]
  - Architecture: [e.g. arm64, amd64]
- - Zion Version: [e.g. 0.7.4]
+ - Zion Version: [e.g. 0.7.5]
 
 **Additional context**
 Add any other context about the problem here (e.g. logs with `RUST_LOG=trace`, upstream backend type like Go/Node).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,78 @@ All notable changes to Zion Edge Gateway are documented here.
 
 ## [Unreleased]
 
+## [0.7.5] - 2026-08-29
+
+**The JA4 release.** The zero-trust TLS fingerprint gate (#27) ships complete,
+end to end: a hand-rolled ClientHello parser, a pre-handshake enforcement gate,
+per-fingerprint policy, and the fingerprint identity forwarded to upstreams.
+Everything sits behind `--features tls-fingerprint` and costs nothing when off.
+The release also repairs a CI supply-chain gate that had been silently dead for
+three days — the kind of failure that looks green from every angle that
+matters, which is exactly why it is documented loudly below.
+
+### Added
+
+- **JA4 client-fingerprint library** (#388): `src/tls_fp.rs` computes the
+  canonical FoxIO JA4 from raw `ClientHello` bytes. The parser is hand-rolled
+  and every read is bounds-checked — adversarial input yields a typed error,
+  never a panic. Only new dependency surface: `sha2`, already in-tree.
+- **Shadow mode** (#390): `[tls.fingerprint] mode = "shadow"` peeks the
+  ClientHello pre-handshake (`MSG_PEEK`, multi-segment post-quantum hellos
+  handled, 3 s budget), counts known vs unknown against the allowlist
+  (`zion_tls_fp_known` / `zion_tls_fp_unknown`) and never blocks.
+- **Allowlist enforcement** (#391): `mode = "allowlist"` with `on_unknown`
+  (`log_only` default | `drop`) and `on_unfingerprintable` (`allow` default |
+  `drop`); a deny-all misconfiguration refuses to boot. `zion_tls_fp_rejected`.
+- **Ban fast path + per-fingerprint connection rate limit** (#396): a rejected
+  unknown fingerprint goes on a process-local ban set (`ban_ttl_secs`, default
+  600) so repeats are dropped with one map lookup and a debug-level log — a
+  single-fingerprint flood no longer floods the log. Allowlist entries accept
+  `rate_limit_cps`, a cap on new TLS connections per second, enforced
+  pre-handshake with exactly one log line per second when crossed. Metrics:
+  `zion_tls_fp_banned_hits`, `zion_tls_fp_rate_limited`.
+- **Fingerprint identity to upstreams** (#397): the computed JA4 (and the
+  matching allowlist entry name) is stashed on the connection and forwarded as
+  `X-Client-TLS-JA4` / `X-Client-TLS-Allowlisted` — with the mTLS discipline:
+  inbound copies are stripped unconditionally before the verified values are
+  injected, on every path including plaintext :80 and feature-off builds.
+  Hot-reloads now announce enforcement-posture changes (mode, `on_unknown`,
+  `on_unfingerprintable`) so "the moment enforcement begins" is a log line.
+- **Per-fingerprint route restriction** (#398): `allowed_routes` on an
+  allowlist entry — same pattern syntax and alias semantics as `[[route]]
+  path` — returns **403** for requests outside the list in `allowlist` mode
+  and observes (`zion_tls_fp_route_denied`) in `shadow`. The deny is
+  HTTP-level by design: at request time the handshake already happened, and on
+  HTTP/2 a connection drop would kill unrelated in-flight requests.
+  `/healthz` and `/readyz` are exempt structurally — a restriction list must
+  never be able to 403 the load balancer's health check.
+
+### Fixed
+
+- **The supply-chain workflow was silently dead 2026-08-25 → 08-28** and is
+  repaired in two acts. #394: a `runner` context expression in job-level
+  `env:` made GitHub reject the whole workflow file at run creation — every
+  run "failed" with zero jobs, so the six REQUIRED status checks never
+  reported and every PR sat blocked while `gh pr checks` looked all green.
+  #395: the per-job rustup isolation assumed `$RUNNER_TEMP` is wiped between
+  jobs on the self-hosted runners — it is not; a job killed mid-install left a
+  manifest-less toolchain that poisoned every later job on that runner. The
+  store is now wiped (amortized) in the isolate step. Process rule that came
+  out of it: `actionlint` gates every workflow edit.
+- **h2 advisory posture** (#387): h2 0.4.16 (RUSTSEC-2026-0258), cargo-vet
+  exemption refreshed, weekly advisory-freshness window widened to 2× cadence,
+  protobuf advisory aliases mapped in deny.toml.
+
+### Data
+
+- Weekly sovereign CIDR refreshes 2026-08-24: EU-27 (#385) and Italy (#386).
+
+### CI / Chore
+
+- GitHub Actions group bump (#389); `.pytest_cache/` and `.ruff_cache/`
+  ignored (#393); the dependabot freeze for the v0.7.4 validation window
+  (#381) stays in place.
+
 ## [0.7.4] - 2026-08-13
 
 **A stability release, cut to be held still.** Nothing here changes runtime

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5150,7 +5150,7 @@ dependencies = [
 
 [[package]]
 name = "zion"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "aho-corasick",
  "aimp_node",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zion"
-version = "0.7.4"
+version = "0.7.5"
 edition = "2021"
 # MSRV is the *core* default-features build (TLS proxy + WAF + cache + metrics).
 # Opt-in features (acme, auth, init, http3) pull crypto/i18n crates that have

--- a/README.md
+++ b/README.md
@@ -315,12 +315,12 @@ Every release is signed and carries SLSA v1.0 build provenance — see
 
 ```bash
 # Binary release (Sigstore-backed provenance via gh CLI)
-gh release download v0.7.4 -R fabriziosalmi/zion -p '*x86_64-unknown-linux-musl*' -p 'SHA256SUMS'
+gh release download v0.7.5 -R fabriziosalmi/zion -p '*x86_64-unknown-linux-musl*' -p 'SHA256SUMS'
 sha256sum --check --ignore-missing SHA256SUMS
-gh attestation verify zion-v0.7.4-x86_64-unknown-linux-musl.tar.gz --owner fabriziosalmi
+gh attestation verify zion-v0.7.5-x86_64-unknown-linux-musl.tar.gz --owner fabriziosalmi
 
 # Container image (cosign keyless)
-cosign verify ghcr.io/fabriziosalmi/zion:v0.7.4 \
+cosign verify ghcr.io/fabriziosalmi/zion:v0.7.5 \
     --certificate-identity-regexp "^https://github.com/fabriziosalmi/zion/\\.github/workflows/release\\.yml@refs/tags/v" \
     --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ the current version.
 
 | Version | Supported |
 | ------- | --------- |
-| < 0.7.4 | No |
+| < 0.7.5 | No |
 
 Everything at or above that line is the current release. Stated as a single
 threshold on purpose — the previous wording carried a second, hardcoded row

--- a/deploy/helm/zion/Chart.yaml
+++ b/deploy/helm/zion/Chart.yaml
@@ -3,7 +3,7 @@ name: zion
 description: Zion Edge Gateway — high-performance Rust TLS reverse proxy with WAF
 type: application
 version: 0.2.2
-appVersion: "0.7.4"
+appVersion: "0.7.5"
 home: https://fabriziosalmi.github.io/zion
 sources:
   - https://github.com/fabriziosalmi/zion
@@ -19,7 +19,7 @@ annotations:
   artifacthub.io/license: Apache-2.0
   artifacthub.io/changes: |
     - kind: changed
-      description: Bump appVersion to 0.7.4
+      description: Bump appVersion to 0.7.5
     - kind: added
       description: ZION_AUDIT_HMAC_KEY wired from a Kubernetes Secret when [audit] is enabled
     - kind: added

--- a/docs/deploy/hot-reload.md
+++ b/docs/deploy/hot-reload.md
@@ -130,7 +130,7 @@ Two surfaces report the reload state:
 
   ```json
   {
-    "version": "0.7.4",
+    "version": "0.7.5",
     "timestamp_ms": 1714425600000,
     "uptime_secs": 3712,
     "config_generation": 5,

--- a/docs/security/supply-chain.md
+++ b/docs/security/supply-chain.md
@@ -46,8 +46,8 @@ You need the GitHub CLI (`gh >= 2.49`) and `cosign >= 2.2`.
 
 ```bash
 # 1. Download the artifact + SHA256SUMS from the release page.
-gh release download v0.7.4 -R fabriziosalmi/zion \
-    -p 'zion-v0.7.4-x86_64-unknown-linux-musl.tar.gz' \
+gh release download v0.7.5 -R fabriziosalmi/zion \
+    -p 'zion-v0.7.5-x86_64-unknown-linux-musl.tar.gz' \
     -p 'SHA256SUMS' \
     -p 'zion-sbom.cdx.json'
 
@@ -55,7 +55,7 @@ gh release download v0.7.4 -R fabriziosalmi/zion \
 sha256sum --check --ignore-missing SHA256SUMS
 
 # 3. Verify the SLSA build provenance bound to the artifact's hash.
-gh attestation verify zion-v0.7.4-x86_64-unknown-linux-musl.tar.gz \
+gh attestation verify zion-v0.7.5-x86_64-unknown-linux-musl.tar.gz \
     --owner fabriziosalmi
 
 # Step 3 fails if:
@@ -78,7 +78,7 @@ grype zion-sbom.cdx.json
 ## Verifying a container image
 
 ```bash
-IMAGE=ghcr.io/fabriziosalmi/zion:v0.7.4
+IMAGE=ghcr.io/fabriziosalmi/zion:v0.7.5
 
 # 1. Pin to the digest immediately — tags are mutable, digests are not.
 DIGEST=$(crane digest "$IMAGE")
@@ -120,7 +120,7 @@ deterministically, and pins the Rust toolchain via
 [`rust-toolchain.toml`](../../rust-toolchain.toml). To reproduce locally:
 
 ```bash
-git checkout v0.7.4
+git checkout v0.7.5
 export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)
 # Linux musl example — matches the release artifact byte-for-byte
 # (modulo strip's stable behavior on your distro).


### PR DESCRIPTION
**The JA4 release.** Version SSOT bumped 0.7.4 → 0.7.5 across the 8 tracked files (`bump-version.sh` + `check-version-sync.sh` clean) + the hand-written CHANGELOG section.

What v0.7.5 contains (see CHANGELOG for the full story):
- **#27 complete**: JA4 library (#388) → shadow (#390) → allowlist enforcement (#391) → ban fast path + `rate_limit_cps` (#396) → identity headers to upstreams (#397) → `allowed_routes` request-level 403 (#398). All behind `--features tls-fingerprint`, zero overhead off.
- **Supply-chain CI repair** (#394, #395) after 3 silently-dead days, plus the h2 advisory posture (#387).
- Sovereign weekly data refreshes (#385, #386), actions bump (#389), tool-cache gitignore (#393).

After merge: annotated tag `v0.7.5` on the merge commit → release.yml (tarballs ×7, windows zip, PGO linux, SHA256SUMS, CycloneDX SBOM, multi-arch cosign container).

🤖 Generated with [Claude Code](https://claude.com/claude-code)