### PR TITLE
docs: align three claims with what the code actually does (wiki fact-check findings)

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ cargo build --release --features http3           # + HTTP/3 QUIC listener
 cargo build --release --features otel            # + OpenTelemetry tracing + OTLP export
 cargo build --release --features fips            # + FIPS 140-3 build (aws-lc-rs validated backend)
 cargo build --release --features geo-ita         # + Italian / EU sovereign edge classification
-cargo build --release --features io-uring-accept # Linux 5.19+: single-shot accept
+cargo build --release --features io-uring-accept # Linux: single-shot io_uring accept (validated on 5.19+ kernels)
 cargo build --release --features numa-aware      # + per-NUMA-node DashMap sharding (Linux multi-socket)
 
 # "max" build

--- a/docs/deploy/hot-reload.md
+++ b/docs/deploy/hot-reload.md
@@ -1,6 +1,6 @@
 # Hot-reload
 
-Zion watches its config file (the path in `ZION_CONFIG`, default `zion.toml`) and the certificate files referenced by `[tls]`. When either changes, the running process applies the change without a restart and without dropping in-flight connections. There is no admin endpoint, no SIGHUP, no orchestrator dance — edit the file, save, the change is live.
+Zion watches its config file (the path in `ZION_CONFIG`, default `zion.toml`) and the directories holding the certificates referenced by `[tls]` (see [What reloads (certificate files)](#what-reloads-certificate-files) for exactly what is subscribed). When either changes, the running process applies the change without a restart and without dropping in-flight connections. There is no admin endpoint, no SIGHUP, no orchestrator dance — edit the file, save, the change is live.
 
 This page is the contract: what reloads, what doesn't, what survives, and how to verify it landed.
 
@@ -31,10 +31,15 @@ Everything below is re-applied at the next request after the swap. In-flight req
 
 ## What reloads (certificate files)
 
-Independent of `zion.toml`, the TLS watcher fires on changes to:
-
-- `tls.cert_path` / `tls.key_path`
-- Each `tls.sni[*].cert_path` / `key_path`
+Independent of `zion.toml`, the TLS watcher fires on filesystem events in the
+**parent directories of `tls.cert_path` and each `tls.sni[*].cert_path`** —
+that is what it actually subscribes to. A key file saved next to its cert (the
+usual layout, and what every ACME client and `certbot` deployment does) is
+picked up by the same directory watch. The caveat: a `key_path` that lives in
+a **different directory** from its cert is *not* watched — touching only that
+key file will not trigger the reload until the cert (or anything in the cert's
+directory) changes too. Keep each cert/key pair in one directory, or touch the
+cert after rotating a remotely-located key.
 
 The `ServerConfig` is rebuilt from disk on the blocking thread pool (so file I/O does not stall the runtime), then atomic-swapped. ALPN, session tickets, 0-RTT settings, and mTLS verifier are reconstituted from the same `[tls]` section that is currently loaded.
 

--- a/docs/deploy/observability.md
+++ b/docs/deploy/observability.md
@@ -17,9 +17,13 @@ Zion exposes built-in endpoints that bypass routing and upstream forwarding:
 | `GET /_zion/snapshot.json` | JSON (metrics + quantiles + platform) | **internal IPs only** | `zion top` / dashboards |
 | `POST /_zion/cache/purge` | `{"purged":N,"scope":...}` | **internal IPs only**, POST-only (`405` on GET) | Flush the RAM cache on deploy; `?prefix=/path` for scoped purge |
 
-`/healthz` and `/readyz` are handled before rate limiting and routing, so they
-always respond even under load. `/metrics`, `/_zion/snapshot.json`, and
-`/_zion/cache/purge` are restricted to internal source IPs (external clients get
+On the HTTPS listener (HTTP/1.1 and /2), `/healthz` and `/readyz` are answered
+on a listener fast path before the request pipeline, so they respond even under
+load. Requests that do reach the pipeline (HTTP/3 is bridged into it directly)
+hit the per-IP rate limiter **before** the health endpoints — a deliberate
+choice, so `/healthz` cannot be used to bypass rate limiting in a flood.
+`/metrics`, `/_zion/snapshot.json`, and `/_zion/cache/purge` always go through
+the pipeline and are restricted to internal source IPs (external clients get
 `403`).
 
 ## Prometheus metrics

--- a/docs/guide/observability.md
+++ b/docs/guide/observability.md
@@ -147,7 +147,7 @@ event under the `access` target with these fields:
 | `latency_us` | u64    | Total request duration (client → response sent), in µs.      |
 | `method`     | str    | HTTP method.                                                 |
 | `path`       | str    | URI path with query-string redacted via `[redact.query_params]`. |
-| `remote_ip`  | str    | Client IP after XFF resolution.                              |
+| `remote_ip`  | str    | The TCP peer address (raw socket peer). Behind a trusted proxy, the XFF-resolved client IP drives rate limiting and the security gates but is **not** what this field logs — read the forwarded chain from your upstream's own logs. |
 | `headers`    | json   | Configured headers, redacted per `[redact.headers]`. Empty when `[access_log] include_headers` is empty (default). |
 | `mtls_fp`    | str    | `X-Client-Cert-Fingerprint` value (SHA-256 hex), when present and `[access_log] mtls_fingerprint = true`. Never redacted — the value is already a hash. |
 

--- a/docs/security/hardening.md
+++ b/docs/security/hardening.md
@@ -139,7 +139,7 @@ When the TLS listener is configured with client-certificate verification (`clien
 X-Client-Cert-Fingerprint: sha256:<64 hex chars>
 ```
 
-The value is the SHA-256 of the leaf DER, hex-encoded with a `sha256:` prefix — the same convention used by openssl and nginx (`$ssl_client_fingerprint`). It is collision-resistant and stable across re-issuance only when the cert bytes themselves are stable; rotating a cert produces a new fingerprint.
+The value is the SHA-256 of the leaf DER, hex-encoded with a `sha256:` prefix — the algorithm/prefix convention openssl uses for certificate digests. (nginx's `$ssl_client_fingerprint` is a similar idea but a **SHA-1** digest — do not compare the two values directly.) It is collision-resistant and stable across re-issuance only when the cert bytes themselves are stable; rotating a cert produces a new fingerprint.
 
 Earlier Zion versions emitted `X-Client-Cert-DN`, computed as a 64-bit XOR-fold of the first 64 DER bytes. That value was advertised as a "DN" but was neither a Distinguished Name nor collision-resistant; it has been removed. If your upstream still expects the old header, map it at the upstream side from `X-Client-Cert-Fingerprint` (note: the new value is a fingerprint, not a DN, and downstream identity mapping must be done via your roster).
 

--- a/docs/security/hardening.md
+++ b/docs/security/hardening.md
@@ -139,7 +139,7 @@ When the TLS listener is configured with client-certificate verification (`clien
 X-Client-Cert-Fingerprint: sha256:<64 hex chars>
 ```
 
-The value is the SHA-256 of the leaf DER, hex-encoded with a `sha256:` prefix — the algorithm/prefix convention openssl uses for certificate digests. (nginx's `$ssl_client_fingerprint` is a similar idea but a **SHA-1** digest — do not compare the two values directly.) It is collision-resistant and stable across re-issuance only when the cert bytes themselves are stable; rotating a cert produces a new fingerprint.
+The value is the SHA-256 of the leaf DER, hex-encoded with a `sha256:` prefix — Zion's pinned wire format for this header (the prefix names the algorithm so it can never be ambiguous). (nginx's `$ssl_client_fingerprint` is a similar idea but a **SHA-1** digest — do not compare the two values directly.) It is collision-resistant and stable across re-issuance only when the cert bytes themselves are stable; rotating a cert produces a new fingerprint.
 
 Earlier Zion versions emitted `X-Client-Cert-DN`, computed as a 64-bit XOR-fold of the first 64 DER bytes. That value was advertised as a "DN" but was neither a Distinguished Name nor collision-resistant; it has been removed. If your upstream still expects the old header, map it at the upstream side from `X-Client-Cert-Fingerprint` (note: the new value is a fingerprint, not a DN, and downstream identity mapping must be done via your roster).
 

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -4,10 +4,13 @@
 //! Sits between the TLS listener and the upstream/cache. For each
 //! accepted request it walks the pipeline:
 //!
-//!   1. inline fast-path (`/healthz`, `/readyz`, `/metrics`,
+//!   1. security gates (URI length, method whitelist, rate limiter,
+//!      CORS pre-flight) — the rate limiter deliberately runs BEFORE the
+//!      built-in endpoints below, so `/healthz` cannot bypass it in a
+//!      flood (the :443 h1/h2 listener answers health probes on its own
+//!      fast path in main.rs, before this pipeline)
+//!   2. built-in endpoints (`/healthz`, `/readyz`, `/metrics`,
 //!      `/_zion/snapshot.json`)
-//!   2. security gates (URI length, method whitelist, rate limiter,
-//!      CORS pre-flight)
 //!   3. radix routing → `Arc<ResolvedRoute>`
 //!   4. WAF pipeline (content-type, size, structural validation,
 //!      entropy, Aho-Corasick scan)

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -6,9 +6,11 @@
 //!
 //!   1. security gates (URI length, method whitelist, rate limiter,
 //!      CORS pre-flight) — the rate limiter deliberately runs BEFORE the
-//!      built-in endpoints below, so `/healthz` cannot bypass it in a
-//!      flood (the :443 h1/h2 listener answers health probes on its own
-//!      fast path in main.rs, before this pipeline)
+//!      built-in endpoints below, so a request that reaches THIS
+//!      pipeline cannot use `/healthz` to dodge it. (The :443 h1/h2
+//!      listener separately answers health probes on its own fast path
+//!      in main.rs, before this pipeline — unrated by design: liveness
+//!      checks must answer even when the box is saturated.)
 //!   2. built-in endpoints (`/healthz`, `/readyz`, `/metrics`,
 //!      `/_zion/snapshot.json`)
 //!   3. radix routing → `Arc<ResolvedRoute>`


### PR DESCRIPTION
The 2026-08-29 wiki fact-check verified 580 claims against the source and caught the code contradicting the docs in three places. **In all three the code is right** — verified again before editing — so these are doc corrections. Flagging the two where you might prefer a code change instead:

1. **`/healthz` vs rate limiting** — two-path truth now documented: the :443 h1/h2 listener answers health on its own fast path; everything reaching the pipeline (HTTP/3 included) hits the rate limiter first, deliberately (`dispatch.rs:289`). Fixed `docs/deploy/observability.md` + the dispatch module doc-comment.
2. **access-log `remote_ip` logs the raw TCP peer**, not the XFF-resolved client IP (which drives rate limiting/gates). Docs fixed. *Alternative if you prefer: make the code log the resolved IP — say the word and I'll flip it instead.*
3. **TLS watcher subscribes to cert PARENT DIRECTORIES** (`tls.rs:411-448`), not key files — a key in a different directory never fires it. `hot-reload.md` now documents the real trigger + the keep-pairs-together caveat. *Alternative: extend the watcher to key parent dirs (small code fix) — your call.*

Neighborhood nits also fixed: README's io-uring `5.19+` floor (multishot-era leftover — now 'validated on 5.19+'), and hardening.md's comparison to nginx's `$ssl_client_fingerprint` (that variable is SHA-1, not SHA-256).

Doc-only except the dispatch.rs doc-comment; default+tls-fingerprint `cargo check` clean. **Not armed for auto-merge — awaiting your go** (per the task's own instruction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)