### PR TITLE
chore(release): v0.7.6

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,7 +21,7 @@ A clear and concise description of what you expected to happen.
 **Environment (please complete the following information):**
  - OS: [e.g. Linux, macOS]
  - Architecture: [e.g. arm64, amd64]
- - Zion Version: [e.g. 0.7.5]
+ - Zion Version: [e.g. 0.7.6]
 
 **Additional context**
 Add any other context about the problem here (e.g. logs with `RUST_LOG=trace`, upstream backend type like Go/Node).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to Zion Edge Gateway are documented here.
 
 ## [Unreleased]
 
+## [0.7.6] - 2026-09-01
+
+**Sovereign correctness.** The `geo-ita` / `geo-eu` origin classifier baked its
+CIDR→role tables from a curated ASN list, but the pipeline chased the ASN
+*number*, not the holder — and RIPE reassigns ASNs. A curated ASN that moved to
+a different (even foreign) holder had its new ranges silently re-labelled with
+the old Italian/EU role. This patch closes that hole; the data plane is untouched.
+
+### Fixed
+
+- **ASN holder validation, fail-closed** (#408): the data generator now carries
+  each ASN's expected holder as data and verifies it against the live RIPEstat
+  holder before emitting — an accent- and case-insensitive match that requires
+  every significant expected token, so a reassignment cannot validate on a
+  coincidental shared token. On any drift it refuses to generate, and the weekly
+  refresh job blocks its PR instead of opening it silently. Curated sets were
+  corrected against the live holders: ASNs reassigned out of national/EU
+  sovereignty were removed (e.g. AS21479 → Rostelecom/RU, AS5535 → FAO),
+  legitimate Italian reassignments renamed. The live check runs only in the
+  scheduled job — the Rust test matrix reads the baked data. Adds a pinned
+  golden classification test, offline matcher fixtures (run in CI), and
+  `docs/config/sovereign.md`.
+
 ## [0.7.5] - 2026-08-29
 
 **The JA4 release.** The zero-trust TLS fingerprint gate (#27) ships complete,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5150,7 +5150,7 @@ dependencies = [
 
 [[package]]
 name = "zion"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "aho-corasick",
  "aimp_node",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zion"
-version = "0.7.5"
+version = "0.7.6"
 edition = "2021"
 # MSRV is the *core* default-features build (TLS proxy + WAF + cache + metrics).
 # Opt-in features (acme, auth, init, http3) pull crypto/i18n crates that have

--- a/README.md
+++ b/README.md
@@ -315,12 +315,12 @@ Every release is signed and carries SLSA v1.0 build provenance — see
 
 ```bash
 # Binary release (Sigstore-backed provenance via gh CLI)
-gh release download v0.7.5 -R fabriziosalmi/zion -p '*x86_64-unknown-linux-musl*' -p 'SHA256SUMS'
+gh release download v0.7.6 -R fabriziosalmi/zion -p '*x86_64-unknown-linux-musl*' -p 'SHA256SUMS'
 sha256sum --check --ignore-missing SHA256SUMS
-gh attestation verify zion-v0.7.5-x86_64-unknown-linux-musl.tar.gz --owner fabriziosalmi
+gh attestation verify zion-v0.7.6-x86_64-unknown-linux-musl.tar.gz --owner fabriziosalmi
 
 # Container image (cosign keyless)
-cosign verify ghcr.io/fabriziosalmi/zion:v0.7.5 \
+cosign verify ghcr.io/fabriziosalmi/zion:v0.7.6 \
     --certificate-identity-regexp "^https://github.com/fabriziosalmi/zion/\\.github/workflows/release\\.yml@refs/tags/v" \
     --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ the current version.
 
 | Version | Supported |
 | ------- | --------- |
-| < 0.7.5 | No |
+| < 0.7.6 | No |
 
 Everything at or above that line is the current release. Stated as a single
 threshold on purpose — the previous wording carried a second, hardcoded row

--- a/deploy/helm/zion/Chart.yaml
+++ b/deploy/helm/zion/Chart.yaml
@@ -3,7 +3,7 @@ name: zion
 description: Zion Edge Gateway — high-performance Rust TLS reverse proxy with WAF
 type: application
 version: 0.2.2
-appVersion: "0.7.5"
+appVersion: "0.7.6"
 home: https://fabriziosalmi.github.io/zion
 sources:
   - https://github.com/fabriziosalmi/zion
@@ -19,7 +19,7 @@ annotations:
   artifacthub.io/license: Apache-2.0
   artifacthub.io/changes: |
     - kind: changed
-      description: Bump appVersion to 0.7.5
+      description: Bump appVersion to 0.7.6
     - kind: added
       description: ZION_AUDIT_HMAC_KEY wired from a Kubernetes Secret when [audit] is enabled
     - kind: added

--- a/docs/deploy/hot-reload.md
+++ b/docs/deploy/hot-reload.md
@@ -135,7 +135,7 @@ Two surfaces report the reload state:
 
   ```json
   {
-    "version": "0.7.5",
+    "version": "0.7.6",
     "timestamp_ms": 1714425600000,
     "uptime_secs": 3712,
     "config_generation": 5,

--- a/docs/security/supply-chain.md
+++ b/docs/security/supply-chain.md
@@ -46,8 +46,8 @@ You need the GitHub CLI (`gh >= 2.49`) and `cosign >= 2.2`.
 
 ```bash
 # 1. Download the artifact + SHA256SUMS from the release page.
-gh release download v0.7.5 -R fabriziosalmi/zion \
-    -p 'zion-v0.7.5-x86_64-unknown-linux-musl.tar.gz' \
+gh release download v0.7.6 -R fabriziosalmi/zion \
+    -p 'zion-v0.7.6-x86_64-unknown-linux-musl.tar.gz' \
     -p 'SHA256SUMS' \
     -p 'zion-sbom.cdx.json'
 
@@ -55,7 +55,7 @@ gh release download v0.7.5 -R fabriziosalmi/zion \
 sha256sum --check --ignore-missing SHA256SUMS
 
 # 3. Verify the SLSA build provenance bound to the artifact's hash.
-gh attestation verify zion-v0.7.5-x86_64-unknown-linux-musl.tar.gz \
+gh attestation verify zion-v0.7.6-x86_64-unknown-linux-musl.tar.gz \
     --owner fabriziosalmi
 
 # Step 3 fails if:
@@ -78,7 +78,7 @@ grype zion-sbom.cdx.json
 ## Verifying a container image
 
 ```bash
-IMAGE=ghcr.io/fabriziosalmi/zion:v0.7.5
+IMAGE=ghcr.io/fabriziosalmi/zion:v0.7.6
 
 # 1. Pin to the digest immediately — tags are mutable, digests are not.
 DIGEST=$(crane digest "$IMAGE")
@@ -120,7 +120,7 @@ deterministically, and pins the Rust toolchain via
 [`rust-toolchain.toml`](../../rust-toolchain.toml). To reproduce locally:
 
 ```bash
-git checkout v0.7.5
+git checkout v0.7.6
 export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)
 # Linux musl example — matches the release artifact byte-for-byte
 # (modulo strip's stable behavior on your distro).


### PR DESCRIPTION
Patch release cutting the **sovereign ASN holder-validation** correctness fix (#408).

## What ships

The `geo-ita` / `geo-eu` origin classifier no longer trusts a curated ASN by number alone. Before the CIDR→role tables are generated, each ASN's expected holder is validated against its **live RIPEstat holder** (accent/case-insensitive, require-all-tokens); on drift the generator **fails closed** and the weekly refresh job blocks its PR instead of opening it silently. A RIPE reassignment can no longer relabel a foreign holder's ranges with an Italian/EU sovereign role.

## This PR

Version bump `0.7.5 → 0.7.6` across the 8 canonical locations (via `scripts/bump-version.sh`) + the CHANGELOG entry. `scripts/check-version-sync.sh` → all references match. No dependency changes.

Generator + data + tests + docs only — the data plane (WAF/TLS/cache/proxy) is untouched. Merge → tag `v0.7.6` → release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)