### PR TITLE
seo(docs): genera la sitemap.xml (VitePress)

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -11,6 +11,9 @@ export default defineConfig({
   title: 'Zion Edge Gateway',
   description: 'High-performance TLS reverse proxy with built-in WAF, written in Rust',
   base: '/zion/',
+  // The hostname must carry the base path: VitePress joins it with each page's
+  // route, so without /zion/ every URL in the sitemap points at a 404.
+  sitemap: { hostname: 'https://fabriziosalmi.github.io/zion/' },
   head: [
     // Everything this site loads is first-party. 'unsafe-inline' is required
     // because VitePress emits an inline appearance script and inline styles.


### PR DESCRIPTION
VitePress sa generare la sitemap da solo: serve solo `sitemap.hostname`.

**L'hostname deve portarsi dietro il base path.** VitePress lo unisce alla rotta di ogni pagina, quindi senza `/zion/` ogni URL della sitemap punterebbe a un 404 ([docs](https://vitepress.dev/guide/sitemap-generation#options)).

**Verificato costruendo davvero il sito**, non solo leggendo la config:
- 60 URL generati, **0** senza il base corretto
- tre presi a caso rispondono `200` in produzione

**Perché conta qui:** la home linka 8 pagine, il sito ne ha 60. Le altre 52 — gli ADR soprattutto — Google le trova solo se qualcuno ce le porta.

Tre righe in `docs/.vitepress/config.ts`, nessun file nuovo, nessuna dipendenza.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
