### PR TITLE
fix: audit follow-up — CI/build/supply-chain + remaining medium/low findings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -189,3 +189,22 @@ updates:
     # limits, noted inline, when validation ends.
     open-pull-requests-limit: 0  # was 3
     versioning-strategy: "increase-if-necessary"
+
+  # ── Python ML training pipeline (ml/requirements.txt) ─────────────────────
+  # Nothing here ships into the Zion binary (tract-onnx does inference in
+  # production), but the pipeline pulls torch/onnx/numpy/requests, which have
+  # their own advisory stream. Declared so version + security updates are
+  # proposed once the freeze below lifts; active advisory detection runs in the
+  # `pip-audit` CI job regardless of this limit.
+  - package-ecosystem: "pip"
+    directory: "/ml"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels: ["dependencies", "python"]
+    commit-message:
+      prefix: "ml"
+      include: "scope"
+    # FROZEN for the v0.7.4 field-validation window, consistent with the other
+    # ecosystems above. Restore to 5 when validation ends.
+    open-pull-requests-limit: 0  # was 5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,18 +150,21 @@ jobs:
           echo "SOURCE_DATE_EPOCH=${ts}" >> "$GITHUB_ENV"
           echo "epoch=${ts}" >> "$GITHUB_OUTPUT"
 
-      # rust-toolchain.toml in the repo root pins the dev compiler to 1.88.
-      # On a release tag we want the toolchain dtolnay/rust-toolchain installs
-      # (latest stable) instead, AND we need it to install the matrix target.
-      # When rust-toolchain.toml is present, dtolnay's `targets:` is ignored
-      # by `rustup`, so we drop the file for this job and add the target
-      # explicitly. The dev override resumes for non-release builds.
+      # Release builds are PINNED to the same toolchain as dev/CI
+      # (rust-toolchain.toml, currently 1.88.0) so the shipped binary is
+      # REPRODUCIBLE — "latest stable" would silently change the release
+      # compiler between tags and defeat the SLSA/attestation guarantee. We
+      # still drop rust-toolchain.toml for this job because, when present, it
+      # makes `rustup` ignore the target we add below; the explicit `toolchain:`
+      # input pins the exact version instead. To move the release compiler,
+      # bump BOTH this pin and rust-toolchain.toml together.
       - name: Drop dev toolchain pin for release builds
         shell: bash
         run: rm -f rust-toolchain.toml
 
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # v1
         with:
+          toolchain: 1.88.0
           # `llvm-tools` ships rustc's *own* `llvm-profdata`, whose raw
           # profile format always matches the compiler that wrote the
           # `.profraw` files. A system llvm-profdata can be older (profraw
@@ -403,7 +406,11 @@ jobs:
           path: dist
           merge-multiple: true
 
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      # Pinned to match rust-toolchain.toml (1.88.0) — this job resolves crate
+      # metadata for the SBOM, so keep it on the same toolchain as the build.
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # v1
+        with:
+          toolchain: 1.88.0
 
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -55,6 +55,24 @@ jobs:
         # Fail on any unfixed advisory + any yanked crate.
         run: cargo audit --deny warnings --deny unmaintained --deny unsound --deny yanked
 
+  # ── 1b. Python advisories for the ML training pipeline. ───────────────────
+  # ml/ is dev-only (nothing ships into the Zion binary — tract-onnx does
+  # inference in production), but torch/onnx/numpy/requests have their own
+  # advisory stream that was previously covered by nothing. Uses the runner's
+  # preinstalled Python (no new pinned action). `--no-deps` audits the declared
+  # direct dependencies; full transitive + hashed coverage arrives with the ml
+  # lockfile (ZION-DEP-02, tracked separately — torch's cross-platform wheels
+  # make a hashed lock non-trivial).
+  pip-audit:
+    name: pip-audit (python advisories)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install pip-audit
+        run: python3 -m pip install --user pip-audit
+      - name: Run pip-audit
+        run: python3 -m pip_audit -r ml/requirements.txt --no-deps
+
   # ── 2. cargo-deny: advisories+licenses+bans+sources, all in one. ──────────
   deny:
     name: cargo-deny (${{ matrix.checks }})

--- a/.github/workflows/waf-corpus.yml
+++ b/.github/workflows/waf-corpus.yml
@@ -24,12 +24,20 @@ on:
     branches: [master]
     paths:
       - "src/waf.rs"
+      # WAF effectiveness depends on the request/body pipeline that FEEDS the
+      # scanner, not just waf.rs: dispatch.rs runs the URI/body gates and the
+      # streaming scan, proxy.rs handles body collection. A recall regression
+      # can originate there, so the corpus gate must trigger on them too.
+      - "src/dispatch.rs"
+      - "src/proxy.rs"
       - "benchmarks/waf-corpus/**"
       - ".github/workflows/waf-corpus.yml"
   push:
     branches: [master]
     paths:
       - "src/waf.rs"
+      - "src/dispatch.rs"
+      - "src/proxy.rs"
       - "benchmarks/waf-corpus/**"
 
 permissions:

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Client -> TLS 1.3 -> Security Gates -> Radix Router -> WAF Pipeline (5 gates) ->
 ```
 
 <!-- zion-stats:modules-lines (kept in sync by scripts/update-readme-stats.sh) -->
-50 modules, ~46,000 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
+50 modules, ~46,300 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
 
 ## Features
 
@@ -288,7 +288,7 @@ MODE=full bash benchmarks/baseline/run-baseline.sh   # → benchmarks/baseline/z
 ## Testing
 
 <!-- zion-stats:test-count (kept in sync by scripts/update-readme-stats.sh) -->
-**910 unit tests** run on every change; **23 integration tests** need a running Zion + a backend.
+**911 unit tests** run on every change; **23 integration tests** need a running Zion + a backend.
 
 ```bash
 cargo test                          # unit tests

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Build script: stamp the git revision into the binary so a loose artifact can
+//! be tied back to the exact commit it was built from (a SLSA/attestation gap
+//! when only CARGO_PKG_VERSION is embedded).
+//!
+//! Dependency-free — it shells out to `git`. When `.git` is absent (a source
+//! tarball, a vendored build), every value degrades to "unknown" and the build
+//! still succeeds. The commit DATE (not wall-clock build time) is used so the
+//! stamp stays reproducible across rebuilds of the same commit.
+
+use std::process::Command;
+
+fn git(args: &[&str]) -> Option<String> {
+    let out = Command::new("git").args(args).output().ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let s = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if s.is_empty() {
+        None
+    } else {
+        Some(s)
+    }
+}
+
+fn main() {
+    // Re-run when HEAD moves or the index changes, so the stamp stays current.
+    println!("cargo:rerun-if-changed=.git/HEAD");
+    println!("cargo:rerun-if-changed=.git/index");
+
+    let mut sha = git(&["rev-parse", "--short=12", "HEAD"]).unwrap_or_else(|| "unknown".into());
+    // Mark a build made from a dirty working tree — it does not correspond to
+    // any published commit.
+    if git(&["status", "--porcelain"]).is_some_and(|s| !s.is_empty()) {
+        sha.push_str("-dirty");
+    }
+    let date = git(&[
+        "show",
+        "-s",
+        "--format=%cd",
+        "--date=format:%Y-%m-%d",
+        "HEAD",
+    ])
+    .unwrap_or_else(|| "unknown".into());
+
+    println!("cargo:rustc-env=ZION_GIT_SHA={sha}");
+    println!("cargo:rustc-env=ZION_COMMIT_DATE={date}");
+}

--- a/deny.toml
+++ b/deny.toml
@@ -53,9 +53,9 @@ ignore = [
     # reason serves as the manual review checkpoint.
     #
     # ── Unmaintained transitive deps (no safe upgrade currently available) ──
-    { id = "RUSTSEC-2024-0384", reason = "[review by 2026-09-01] `instant` is unmaintained but pulled in transitively only (no direct dep). Informational, no actual vulnerability. Re-evaluate after upstream deps migrate to `web-time`." },
+    { id = "RUSTSEC-2024-0384", reason = "[review by 2026-12-01; re-assessed 2026-09-08] `instant` is unmaintained but pulled in transitively only (no direct dep). Informational, no actual vulnerability. Re-evaluate after upstream deps migrate to `web-time`." },
     # ── Direct dep that needs migration to a new API ──
-    { id = "RUSTSEC-2025-0134", reason = "[review by 2026-08-01] `rustls-pemfile` is archived; replacement is `rustls-pki-types::pem::PemObject`. Migration tracked as a follow-up task in src/tls.rs and src/acme.rs. Not a vulnerability." },
+    { id = "RUSTSEC-2025-0134", reason = "[review by 2026-12-01; re-assessed 2026-09-08: rustls-pemfile 2.x still stable + in wide use, no known vulnerability — it's an unmaintained/archived advisory only] `rustls-pemfile` is archived; replacement is `rustls-pki-types::pem::PemObject`. Migration across the cert-loading sites (src/tls.rs, src/acme.rs, src/quic.rs) is tracked as a follow-up — deferred over blindly touching the TLS-critical path. Not a vulnerability." },
     # ── DoS in a feature-gated transitive dep (acme/init/ml-waf, not core) ──
     # NOTE: RUSTSEC-2026-0002 (`lru` via ratatui/TUI) and -0217 (`tract-nnef`
     # 0.21.14) were RESOLVED by the v0.7.1 dependency bumps (tract 0.21.17 + the

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -4,6 +4,21 @@ Zion is configured via a single TOML file. Default path: `./zion.toml`. Override
 
 All configuration is validated at startup. Invalid config produces actionable error messages and exits immediately.
 
+## Schema version
+
+An optional top-level `schema_version` (integer) declares which config schema the
+file targets:
+
+```toml
+schema_version = 1
+```
+
+It is read **before** the strict parse. If the file targets a schema **newer**
+than the running binary understands, Zion exits with targeted upgrade guidance
+instead of a generic "unknown field" error. Omit it (the default) and the config
+is treated as compatible; the current schema version is `1`. Bump it only when a
+breaking config change lands (documented in the CHANGELOG).
+
 ## `[server]`
 
 | Key | Type | Default | Description |

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -428,7 +428,14 @@ fn parse_top_opts(args: &[String]) -> TopOpts {
 }
 
 pub fn print_version() {
-    println!("zion {}", env!("CARGO_PKG_VERSION"));
+    // git sha + commit date are stamped by build.rs (both "unknown" when built
+    // without a .git tree), so a loose binary ties back to its exact commit.
+    println!(
+        "zion {} ({} {})",
+        env!("CARGO_PKG_VERSION"),
+        env!("ZION_GIT_SHA"),
+        env!("ZION_COMMIT_DATE"),
+    );
 }
 
 pub fn print_help() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,9 +19,25 @@ use std::sync::Arc;
 // TOP-LEVEL CONFIG
 // ============================================================================
 
+/// The config-schema version THIS binary understands. Bump it (and document
+/// the migration) whenever a breaking config change lands. A config may declare
+/// `schema_version` to opt into the version handshake below.
+pub const CURRENT_SCHEMA_VERSION: u32 = 1;
+
 #[derive(Deserialize, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct ZionConfig {
+    /// Optional schema version the file targets. When present and NEWER than
+    /// this binary's `CURRENT_SCHEMA_VERSION`, the loader emits targeted upgrade
+    /// guidance (see `check_schema_version`) instead of a bare unknown-field
+    /// rejection. Absent = "no version declared", treated as compatible.
+    ///
+    /// `#[allow(dead_code)]`: the value is consumed by the lenient pre-parse
+    /// probe in `check_schema_version`, not read off this struct — but the field
+    /// must exist so the strict `deny_unknown_fields` parse ACCEPTS the key.
+    #[allow(dead_code)]
+    #[serde(default)]
+    pub schema_version: Option<u32>,
     pub server: ServerConfig,
     pub tls: TlsConfig,
     #[serde(default)]
@@ -769,8 +785,38 @@ pub struct ResolvedRoute {
 // LOADING & BUILDING
 // ============================================================================
 
+/// Read the file's declared `schema_version` FIRST, before the strict typed
+/// parse — a lenient probe that ignores every other key. If the file targets a
+/// NEWER schema than this binary understands, return targeted upgrade guidance
+/// rather than letting the strict parse fail on an unknown key it can't explain.
+/// A missing, older, or equal version is accepted (the strict parse then runs).
+pub fn check_schema_version(raw: &str, label: &str) -> Result<(), String> {
+    // No deny_unknown_fields: this probe deliberately tolerates every other key.
+    #[derive(Deserialize)]
+    struct SchemaProbe {
+        #[serde(default)]
+        schema_version: Option<u32>,
+    }
+    // A malformed TOML is reported by the real parse with a better message; the
+    // probe stays silent on parse errors so we don't double-report.
+    if let Ok(probe) = toml::from_str::<SchemaProbe>(raw) {
+        if let Some(v) = probe.schema_version {
+            if v > CURRENT_SCHEMA_VERSION {
+                return Err(format!(
+                    "{label}: config declares schema_version = {v}, but this zion supports up to \
+                     {CURRENT_SCHEMA_VERSION}. Upgrade zion to a build that understands schema \
+                     {v}, or target the older schema (see the CHANGELOG for the config changes \
+                     between schema versions)."
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
 pub fn load_config(path: &str) -> Result<ZionConfig, String> {
     let raw = fs::read_to_string(path).map_err(|e| format!("Cannot read {path}: {e}"))?;
+    check_schema_version(&raw, path)?;
     let config: ZionConfig =
         toml::from_str(&raw).map_err(|e| format!("Invalid TOML in {path}: {e}"))?;
     validate_config(&config, path)?;
@@ -785,6 +831,7 @@ pub fn load_config(path: &str) -> Result<ZionConfig, String> {
 /// suggested config carries placeholder cert paths the operator fills in, so
 /// file existence isn't a schema concern.
 pub fn parse_schema(raw: &str, label: &str) -> Result<ZionConfig, String> {
+    check_schema_version(raw, label)?;
     toml::from_str(raw).map_err(|e| format!("Invalid TOML in {label}: {e}"))
 }
 
@@ -794,6 +841,7 @@ pub fn parse_schema(raw: &str, label: &str) -> Result<ZionConfig, String> {
 /// the pushed body must be fully deployable (real cert paths and all), unlike
 /// `zion suggest` which only needs the schema-level [`parse_schema`].
 pub fn validate_str(raw: &str, label: &str) -> Result<ZionConfig, String> {
+    check_schema_version(raw, label)?;
     let config: ZionConfig =
         toml::from_str(raw).map_err(|e| format!("Invalid TOML in {label}: {e}"))?;
     validate_config(&config, label)?;
@@ -2638,6 +2686,33 @@ enabledd = true
         assert!(
             err.contains("client_ca_path"),
             "auth=mtls without client_ca_path must be rejected, got: {err}"
+        );
+    }
+
+    #[test]
+    fn schema_version_handshake() {
+        let base = "[server]\nlisten_http=\"0.0.0.0:80\"\nlisten_https=\"0.0.0.0:443\"\n\
+             [tls]\ncert_path=\"/c\"\nkey_path=\"/k\"\n[upstreams]\nbe=\"http://127.0.0.1:8000\"\n\
+             [[route]]\npath=\"/{*rest}\"\nupstream=\"be\"\n";
+
+        // No schema_version → accepted (backward compatible).
+        assert!(check_schema_version(base, "t").is_ok());
+        assert!(parse_schema(base, "t").is_ok());
+
+        // Equal / older → accepted.
+        let cur = format!("schema_version = {CURRENT_SCHEMA_VERSION}\n{base}");
+        assert!(parse_schema(&cur, "t").is_ok());
+
+        // Newer than this binary → targeted guidance, even before the strict
+        // parse would choke on hypothetical new keys.
+        let newer = format!(
+            "schema_version = {}\nfuture_key = \"x\"\n{base}",
+            CURRENT_SCHEMA_VERSION + 1
+        );
+        let err = check_schema_version(&newer, "t").unwrap_err();
+        assert!(
+            err.contains("schema_version") && err.contains("Upgrade zion"),
+            "too-new schema must give upgrade guidance, got: {err}"
         );
     }
 

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -104,7 +104,7 @@ fn check_rate_limit(state: &AppState, ip: std::net::IpAddr) -> bool {
     security::check_rate_limit(
         cfg.rate_limit_rps,
         cfg.rate_limit_window,
-        &state.rate_map,
+        &state.limiters.rate_map,
         ip,
     )
 }

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -695,22 +695,37 @@ async fn process_request_inner(
             }
         };
 
-    // SAFETY (inner unwrap): "/" is a compile-time-constant single-char URI
-    // that always parses successfully. Used as a defensive fallback when the
-    // configured upstream URL fails to parse — a config-validation error
-    // that should have been caught at boot, but keeping this as a runtime
-    // soft fallback prevents a panic if a hot-reload sneaks in a bad URL.
-    let target_uri: hyper::Uri = target_upstream_url
-        .parse()
-        .unwrap_or_else(|_| "/".parse().unwrap());
-    let dyn_scheme = target_uri
-        .scheme()
-        .cloned()
-        .unwrap_or_else(|| rule.upstream_scheme.clone());
-    let dyn_authority = target_uri
-        .authority()
-        .cloned()
-        .unwrap_or_else(|| rule.upstream_authority.clone());
+    // Resolve scheme + authority for the selected upstream. Fast path: a
+    // single-upstream (or static, empty) route always resolves to
+    // `upstream_url[0]`, whose scheme+authority were parsed ONCE at
+    // config-build time into `rule.upstream_scheme` / `rule.upstream_authority`
+    // — so skip the per-request `hyper::Uri` parse entirely (the common case).
+    // Only a multi-upstream HA/latency pool, where the selected member varies
+    // per request, needs to parse the chosen URL.
+    //
+    // SAFETY (inner unwrap on the slow path): "/" is a compile-time-constant
+    // single-char URI that always parses. Used as a defensive fallback if a
+    // hot-reload sneaks in a bad URL (config validation should have caught it).
+    let (dyn_scheme, dyn_authority) = if rule.upstream_url.len() <= 1 {
+        (
+            rule.upstream_scheme.clone(),
+            rule.upstream_authority.clone(),
+        )
+    } else {
+        let target_uri: hyper::Uri = target_upstream_url
+            .parse()
+            .unwrap_or_else(|_| "/".parse().unwrap());
+        (
+            target_uri
+                .scheme()
+                .cloned()
+                .unwrap_or_else(|| rule.upstream_scheme.clone()),
+            target_uri
+                .authority()
+                .cloned()
+                .unwrap_or_else(|| rule.upstream_authority.clone()),
+        )
+    };
 
     // --- Gate: Auth (JWT/OIDC) ---
     #[cfg(feature = "auth")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -456,6 +456,32 @@ impl ResolvedAppConfig {
     }
 }
 
+/// Behaviour-persistent per-source limiters, grouped so churn in one of them
+/// stays local to this struct instead of rippling through the whole `AppState`
+/// and all of its consumers (ZION-ARCH-02). Unlike the config-derived state
+/// (isolated in `ResolvedAppConfig`), these track live client behaviour and
+/// therefore persist across config reloads — a rate/conn/ban count is about the
+/// client, not the config.
+struct Limiters {
+    /// Per-IP rate limiter map.
+    ///
+    /// NUMA wrapper (issue #50): on a single-socket box / non-Linux /
+    /// `--no-default-features` build this is a transparent newtype
+    /// around `DashMap`. With `--features numa-aware` on a multi-socket
+    /// Linux host, `NumaAwareMap` shards by NUMA node and routes by the
+    /// calling thread's current node — same-socket workers stay
+    /// cache-local, cross-socket fallback scans on get-miss.
+    rate_map: Arc<numa::NumaAwareMap<std::net::IpAddr, RateEntry>>,
+    /// Per-IP concurrent-connection limiter. The cap is read from the config
+    /// snapshot at accept time; the global ceiling stays the `conn_limit`
+    /// semaphore on `AppState`.
+    conn_per_ip: Arc<connlimit::PerIpConnLimiter>,
+    /// Rejected-unknown JA4 ban set (#27 commit 4): fingerprint → banned until.
+    /// Only ever consulted while the CURRENT config drops unknown fingerprints.
+    #[cfg(feature = "tls-fingerprint")]
+    tls_fp_bans: tls_fp::BanSet,
+}
+
 /// Global shared state — lock-free reads via Arc + ArcSwap.
 struct AppState {
     /// Config-derived snapshot, atomically swappable. The hot path reads
@@ -477,21 +503,9 @@ struct AppState {
     http_builder: Arc<AutoBuilder<TokioExecutor>>,
     /// ACME HTTP-01 challenge tokens (empty when no challenge active).
     acme_challenges: acme::ChallengeStore,
-    /// Per-IP rate limiter map. Persists across config reloads — the IP
-    /// counters are about the IP's behaviour, not about the config.
-    ///
-    /// NUMA wrapper (issue #50): on a single-socket box / non-Linux /
-    /// `--no-default-features` build this is a transparent newtype
-    /// around `DashMap`. With `--features numa-aware` on a multi-socket
-    /// Linux host, `NumaAwareMap` shards by NUMA node and routes by the
-    /// calling thread's current node — same-socket workers stay
-    /// cache-local, cross-socket fallback scans on get-miss.
-    rate_map: Arc<numa::NumaAwareMap<std::net::IpAddr, RateEntry>>,
-    /// Per-IP concurrent-connection limiter. Like `rate_map`, persists
-    /// across config reloads (it tracks live sockets, not config); the cap
-    /// is read from the config snapshot at accept time. The global ceiling
-    /// stays the `conn_limit` semaphore above.
-    conn_per_ip: Arc<connlimit::PerIpConnLimiter>,
+    /// Behaviour-persistent per-source limiters (rate map, per-IP conn cap,
+    /// JA4 ban set) — grouped so subsystem churn stays local. See [`Limiters`].
+    limiters: Limiters,
     /// Singleflight: coalesce concurrent cache misses for the same key.
     /// First request fetches from upstream and inserts a `watch::Sender<bool>`;
     /// subsequent requests subscribe and await `true`. Watch (vs Notify) is
@@ -515,12 +529,6 @@ struct AppState {
     /// local block to the mesh). Cloning is cheap — internal `Arc`s.
     #[cfg(feature = "sovereign-aimp")]
     pub(crate) aimp_cp: Option<aimp_cp::AimpControlPlane>,
-    /// Rejected-unknown JA4 ban set (#27 commit 4): fingerprint → banned
-    /// until. Like `rate_map`, it persists across config reloads — a ban is
-    /// about the client's behaviour, not about the config — and is only ever
-    /// consulted while the CURRENT config drops unknown fingerprints.
-    #[cfg(feature = "tls-fingerprint")]
-    pub(crate) tls_fp_bans: tls_fp::BanSet,
 }
 
 impl AppState {
@@ -1113,11 +1121,13 @@ async fn async_main(platform: &'static bootstrap::Platform) -> error::ZionResult
         static_cache: cache::StaticCache::new(),
         conn_limit: Arc::new(Semaphore::new(platform.conn_limit)),
         acme_challenges: acme::new_challenge_store(),
-        rate_map: Arc::new(numa::NumaAwareMap::new()),
-        conn_per_ip: Arc::new(connlimit::PerIpConnLimiter::new()),
+        limiters: Limiters {
+            rate_map: Arc::new(numa::NumaAwareMap::new()),
+            conn_per_ip: Arc::new(connlimit::PerIpConnLimiter::new()),
+            #[cfg(feature = "tls-fingerprint")]
+            tls_fp_bans: tls_fp::BanSet::new(),
+        },
         inflight: numa::NumaAwareMap::new(),
-        #[cfg(feature = "tls-fingerprint")]
-        tls_fp_bans: tls_fp::BanSet::new(),
         audit: audit_handle,
         redact: compiled_redact,
         http_builder: Arc::new({
@@ -1291,15 +1301,17 @@ async fn async_main(platform: &'static bootstrap::Platform) -> error::ZionResult
                         // `.max(1)` guards scavenge_rate_map's `now / window`
                         // against a 0 window ever reaching the snapshot.
                         let window = state_for_scavenge.cfg().rate_limit_window.max(1);
-                        let removed =
-                            security::scavenge_rate_map(&state_for_scavenge.rate_map, window);
+                        let removed = security::scavenge_rate_map(
+                            &state_for_scavenge.limiters.rate_map,
+                            window,
+                        );
                         if removed > 0 {
                             logging::info(
                                 "rate_limit",
                                 &format!(
                                     "scavenged {} stale IPs ({} tracked)",
                                     removed,
-                                    state_for_scavenge.rate_map.len()
+                                    state_for_scavenge.limiters.rate_map.len()
                                 ),
                             );
                         }
@@ -1710,6 +1722,7 @@ async fn handle_http_connection(
         }
     };
     let _ip_slot = match state
+        .limiters
         .conn_per_ip
         .try_acquire(addr.ip(), state.config.load().max_connections_per_ip)
     {
@@ -1872,6 +1885,7 @@ fn spawn_https_handler(
     // `cap == 0` short-circuits inside `try_acquire` (zero overhead). A
     // rejected source is closed immediately, before the TLS handshake.
     let ip_slot = match state
+        .limiters
         .conn_per_ip
         .try_acquire(remote_addr.ip(), state.config.load().max_connections_per_ip)
     {
@@ -2255,7 +2269,7 @@ fn check_rate_limit(state: &AppState, ip: std::net::IpAddr) -> bool {
     security::check_rate_limit(
         cfg.rate_limit_rps,
         cfg.rate_limit_window,
-        &state.rate_map,
+        &state.limiters.rate_map,
         ip,
     )
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1268,22 +1268,42 @@ async fn async_main(platform: &'static bootstrap::Platform) -> error::ZionResult
     // stays ~empty and the 60 s scavenge is a cheap no-op.
     {
         let state_for_scavenge = state.clone();
+        // Subscribe to the process shutdown signal so this loop exits cleanly
+        // on SIGINT/SIGTERM instead of being force-aborted mid-iteration when
+        // the runtime is dropped (#151 follow-up / ZION-CONC-03). The work here
+        // is idempotent stale-entry cleanup, so a lost iteration is harmless —
+        // but a deterministic exit keeps shutdown ordering predictable and
+        // matches the accept loops' shutdown idiom. The sibling maintenance
+        // loops (health checker, ACME renewal, AIMP mesh) similarly tolerate an
+        // abort: health probing is idempotent, ACME cert writes are atomic
+        // (see src/atomic_file.rs), and the audit writer flushes per event.
+        let mut scavenge_shutdown = super_shutdown_tx.subscribe();
         tokio::spawn(async move {
             loop {
-                tokio::time::sleep(std::time::Duration::from_secs(60)).await;
-                // `.max(1)` guards scavenge_rate_map's `now / window` against a
-                // 0 window ever reaching the snapshot.
-                let window = state_for_scavenge.cfg().rate_limit_window.max(1);
-                let removed = security::scavenge_rate_map(&state_for_scavenge.rate_map, window);
-                if removed > 0 {
-                    logging::info(
-                        "rate_limit",
-                        &format!(
-                            "scavenged {} stale IPs ({} tracked)",
-                            removed,
-                            state_for_scavenge.rate_map.len()
-                        ),
-                    );
+                tokio::select! {
+                    biased;
+                    res = scavenge_shutdown.changed() => {
+                        if res.is_err() || *scavenge_shutdown.borrow() {
+                            break; // shutting down (or sender dropped) — stop cleanly
+                        }
+                    }
+                    _ = tokio::time::sleep(std::time::Duration::from_secs(60)) => {
+                        // `.max(1)` guards scavenge_rate_map's `now / window`
+                        // against a 0 window ever reaching the snapshot.
+                        let window = state_for_scavenge.cfg().rate_limit_window.max(1);
+                        let removed =
+                            security::scavenge_rate_map(&state_for_scavenge.rate_map, window);
+                        if removed > 0 {
+                            logging::info(
+                                "rate_limit",
+                                &format!(
+                                    "scavenged {} stale IPs ({} tracked)",
+                                    removed,
+                                    state_for_scavenge.rate_map.len()
+                                ),
+                            );
+                        }
+                    }
                 }
             }
         });

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -680,11 +680,17 @@ impl Metrics {
         // own e2e harness queries this series. `CARGO_PKG_VERSION` is a
         // compile-time literal with no label-unsafe characters.
         out.extend_from_slice(
-            b"# HELP zion_build_info Build metadata (constant 1; see the version label).\n\
+            b"# HELP zion_build_info Build metadata (constant 1; see the labels).\n\
                                 # TYPE zion_build_info gauge\n\
                                 zion_build_info{version=\"",
         );
         out.extend_from_slice(env!("CARGO_PKG_VERSION").as_bytes());
+        // git sha + commit date stamped by build.rs; label values are safe
+        // (hex sha / ISO date / the literal "unknown").
+        out.extend_from_slice(b"\",commit=\"");
+        out.extend_from_slice(env!("ZION_GIT_SHA").as_bytes());
+        out.extend_from_slice(b"\",commit_date=\"");
+        out.extend_from_slice(env!("ZION_COMMIT_DATE").as_bytes());
         out.extend_from_slice(b"\"} 1\n");
 
         out.extend_from_slice(
@@ -1525,8 +1531,10 @@ mod tests {
         assert!(out.contains("zion_tls_handshake_duration_seconds_bucket"));
         // build-info gauge with the compiled version label.
         assert!(out.contains(&format!(
-            "zion_build_info{{version=\"{}\"}} 1",
-            env!("CARGO_PKG_VERSION")
+            "zion_build_info{{version=\"{}\",commit=\"{}\",commit_date=\"{}\"}} 1",
+            env!("CARGO_PKG_VERSION"),
+            env!("ZION_GIT_SHA"),
+            env!("ZION_COMMIT_DATE"),
         )));
         assert!(out.contains("zion_connections_rejected_global 0"));
     }

--- a/src/tls_fp.rs
+++ b/src/tls_fp.rs
@@ -1033,7 +1033,11 @@ pub async fn fingerprint_gate(
             identity: None,
         };
     };
-    classify(&fp, &state.tls_fp_bans, ja4_from_tls_record(&buf[..n]))
+    classify(
+        &fp,
+        &state.limiters.tls_fp_bans,
+        ja4_from_tls_record(&buf[..n]),
+    )
 }
 
 /// The upstream header carrying the connection's JA4. Zion's attestation — a

--- a/src/uring.rs
+++ b/src/uring.rs
@@ -101,6 +101,41 @@ mod inner {
         Ok(())
     }
 
+    /// Bail after this many consecutive non-transient accept errors — a
+    /// persistently-bad listener fd (the ENOTSOCK race that motivated the
+    /// single-shot rewrite) would otherwise spin the loop forever.
+    const MAX_CONSECUTIVE_ACCEPT_ERRORS: u32 = 50;
+
+    /// What to do with a single accept CQE `result()`. Extracted from the loop
+    /// so the transient/error/accepted decision — including the ENOTSOCK
+    /// re-submit path and the error-cap bail — is unit-testable without an
+    /// io_uring instance or a real socket.
+    #[derive(Debug, PartialEq, Eq)]
+    enum AcceptOutcome {
+        /// EAGAIN / EINTR: skip this CQE, do not count it as an error.
+        Transient,
+        /// A real accept error. `consecutive` is the running count *after* this
+        /// one; `stop` is true once the bail threshold is reached.
+        Error { consecutive: u32, stop: bool },
+        /// A valid accepted fd.
+        Accepted(RawFd),
+    }
+
+    fn classify_accept_result(res: i32, consecutive_errors: u32) -> AcceptOutcome {
+        if res >= 0 {
+            return AcceptOutcome::Accepted(res as RawFd);
+        }
+        let errno = -res;
+        if errno == libc::EAGAIN || errno == libc::EINTR {
+            return AcceptOutcome::Transient;
+        }
+        let consecutive = consecutive_errors.saturating_add(1);
+        AcceptOutcome::Error {
+            consecutive,
+            stop: consecutive >= MAX_CONSECUTIVE_ACCEPT_ERRORS,
+        }
+    }
+
     fn uring_accept_loop(listener_fd: RawFd, tx: mpsc::Sender<AcceptedConn>) {
         // Ring with 256 entries — enough for burst accept without overflowing
         let mut ring = IoUring::new(256).expect("io_uring init failed");
@@ -145,22 +180,25 @@ mod inner {
                     return;
                 }
 
-                if fd < 0 {
-                    let errno = -fd;
-                    if errno == libc::EAGAIN || errno == libc::EINTR {
+                match classify_accept_result(fd, consecutive_errors) {
+                    AcceptOutcome::Transient => continue,
+                    AcceptOutcome::Error { consecutive, stop } => {
+                        consecutive_errors = consecutive;
+                        let errno = -fd;
+                        if consecutive_errors <= 3 || consecutive_errors % 1000 == 0 {
+                            eprintln!(
+                                "  io_uring accept error: errno {errno} (#{consecutive_errors})"
+                            );
+                        }
+                        if stop {
+                            eprintln!(
+                                "  io_uring accept: {consecutive_errors} consecutive errors (errno {errno}); listener fd unusable — stopping accept loop"
+                            );
+                            return;
+                        }
                         continue;
                     }
-                    consecutive_errors += 1;
-                    if consecutive_errors <= 3 || consecutive_errors % 1000 == 0 {
-                        eprintln!("  io_uring accept error: errno {errno} (#{consecutive_errors})");
-                    }
-                    if consecutive_errors >= 50 {
-                        eprintln!(
-                            "  io_uring accept: {consecutive_errors} consecutive errors (errno {errno}); listener fd unusable — stopping accept loop"
-                        );
-                        return;
-                    }
-                    continue;
+                    AcceptOutcome::Accepted(_) => {}
                 }
                 consecutive_errors = 0;
 
@@ -226,6 +264,52 @@ mod inner {
                 Some(SocketAddr::from((ip, u16::from_be(addr.sin6_port))))
             }
             _ => None,
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn accepted_fd_is_classified() {
+            assert_eq!(classify_accept_result(7, 0), AcceptOutcome::Accepted(7));
+            // A prior error streak does not affect a successful accept.
+            assert_eq!(classify_accept_result(7, 40), AcceptOutcome::Accepted(7));
+        }
+
+        #[test]
+        fn eagain_and_eintr_are_transient() {
+            assert_eq!(
+                classify_accept_result(-libc::EAGAIN, 5),
+                AcceptOutcome::Transient
+            );
+            assert_eq!(
+                classify_accept_result(-libc::EINTR, 5),
+                AcceptOutcome::Transient
+            );
+        }
+
+        #[test]
+        fn enotsock_counts_as_error_and_caps() {
+            // The ENOTSOCK race (errno 88) that motivated single-shot accept:
+            // counted, and once the streak hits the cap the loop is told to stop.
+            let first = classify_accept_result(-libc::ENOTSOCK, 0);
+            assert_eq!(
+                first,
+                AcceptOutcome::Error {
+                    consecutive: 1,
+                    stop: false
+                }
+            );
+            let at_cap = classify_accept_result(-libc::ENOTSOCK, MAX_CONSECUTIVE_ACCEPT_ERRORS - 1);
+            assert_eq!(
+                at_cap,
+                AcceptOutcome::Error {
+                    consecutive: MAX_CONSECUTIVE_ACCEPT_ERRORS,
+                    stop: true
+                }
+            );
         }
     }
 }


### PR DESCRIPTION
Follow-up to #413: clears the findings deliberately deferred there (CI-workflow, build, and the remaining medium/low items). 11 commits, all with regression tests where they touch code; clean on `cargo clippy --all-features --all-targets` + `cargo fmt --check`, full suite green per commit.

## What's here

**Config / forward-compat**
- `schema_version` handshake (ZION-API-03): an optional top-level key read before the strict parse, so a config from a newer release gets targeted upgrade guidance instead of a bare unknown-field error.

**Build / release reproducibility**
- Pin the release toolchain to 1.88.0 instead of "latest stable" (ZION-BLD-01) — reproducible, matches dev/CI.
- `build.rs` stamps the git commit + date into `--version` and `zion_build_info` (ZION-BLD-03), so a loose binary ties back to its commit.

**Supply chain**
- Python advisory coverage: a `pip-audit` job + a dependabot `pip` ecosystem for `/ml` (ZION-DEP-03).
- Refresh two lapsed advisory review checkpoints after re-assessment (ZION-DEP-04).

**Perf / hot path**
- Skip the per-request upstream URI parse for single-upstream routes (ZION-PERF-02).

**Reliability / CI coverage**
- Clean shutdown path for the rate-map scavenge loop (ZION-CONC-03).
- Trigger the WAF corpus recall/false-positive gate on the request pipeline (dispatch/proxy), not just waf.rs (ZION-TEST-05, path-filter half).
- Extract + unit-test the io_uring accept-CQE classification incl. the ENOTSOCK path (ZION-TEST-02, uring half).

**Architecture**
- Group the behaviour-persistent limiters (rate_map / conn_per_ip / tls_fp_bans) into a `Limiters` sub-struct on AppState (ZION-ARCH-02).

## Deliberately NOT here

- **ZION-ARCH-01** (rewrite `process_request_inner`'s gate section into a data-driven slice): a rewrite of the security-critical request pipeline where a subtle gate-reorder is a silent security regression. It deserves a dedicated, heavily-tested PR, not a sweep — left for a focused effort.
- **ZION-TEST-01 / TEST-03** and the *required-check* half of **TEST-05**: making the e2e/integration/corpus jobs gate merges is a **branch-protection** setting (a repo config, not a file) — GitHub `needs:` can't aggregate jobs across separate workflow files. A maintainer action.
- **ZION-DEP-05**: the dependabot freeze is a deliberate v0.7.4 policy, not a defect.
- **ZION-DEP-02** (hashed Python lockfile): torch's cross-platform wheels make a hashed lock non-trivial; tracked, and the pip-audit gate above covers direct-dep advisories now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
