### PR TITLE
chore(release): v0.8.0 — audit remediation (39→75.8, 0 critical/high)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,7 +21,7 @@ A clear and concise description of what you expected to happen.
 **Environment (please complete the following information):**
  - OS: [e.g. Linux, macOS]
  - Architecture: [e.g. arm64, amd64]
- - Zion Version: [e.g. 0.7.6]
+ - Zion Version: [e.g. 0.8.0]
 
 **Additional context**
 Add any other context about the problem here (e.g. logs with `RUST_LOG=trace`, upstream backend type like Go/Node).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,89 @@ All notable changes to Zion Edge Gateway are documented here.
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-09-08
+
+**Security & robustness hardening.** A full code-metrics audit of v0.7.6 scored
+39/100 ("Poor"), capped by a CRITICAL non-atomic ACME key/cert write and a weak
+state-integrity posture. This release remediates the CRITICAL, every
+high-severity finding, and ~all medium/low ones (0 critical / 0 high remain);
+the re-audit of this commit scores **75.8/100 ("Strong")**. Most changes are
+internal hardening, but several tighten config validation to **fail closed** —
+configs that were silently accepted before may now be rejected at boot. Read the
+Breaking section before upgrading.
+
+### ⚠️ Breaking (config validation — fail closed)
+
+- **JA4 enforcing allowlist**: `[tls.fingerprint] mode = "allowlist"` with
+  `on_unknown = "drop"` now **refuses to boot** unless `on_unfingerprintable`
+  is also `"drop"` — the old default (`"allow"`) let a client bypass the
+  allowlist with an unfingerprintable ClientHello. Set `on_unfingerprintable =
+  "drop"`, or use `on_unknown = "log_only"` / `mode = "shadow"` to observe.
+- **`sovereign_aimp.listen`**: a malformed value is now a validation error
+  instead of silently binding the gossip control plane to `0.0.0.0:9443`.
+- **Route/upstream integrity**: a name defined in both `[upstream.X]` and
+  `[upstreams]`, a `mode = "static"` route with an `upstream`, or a non-static
+  route with `serve_dir`/`spa_fallback`/`precompressed` are now rejected rather
+  than silently ignored.
+- **Helm**: the container now binds unprivileged `8080/8443` by default (the
+  Service still presents `80/443`); override `containerPorts` + add
+  `NET_BIND_SERVICE` if you need privileged in-container ports.
+- **Release toolchain** pinned to Rust 1.88.0 (was "latest stable").
+
+### Security
+
+- **Atomic, owner-only secret/state writes** (`src/atomic_file.rs`): the ACME
+  account key, the renewed cert/key pair, and the mesh identity seed are written
+  to a `0o600` temp sibling, fsync'd, then atomically renamed — no torn write,
+  no world-readable window. The TLS loader now verifies cert/key correspondence
+  (`keys_match`) and keeps the last-good pair on mismatch.
+- **Reserved identity headers stripped inbound**: `X-Auth-Subject` /
+  `X-Auth-Email` are removed from every request at the trust boundary before the
+  auth gate re-injects the verified values, so an upstream can trust them.
+- **Bounded HA-replay body**: the failover path caps the buffered request body
+  (16 MiB → 413, 30s → 408) instead of an unbounded `collect()`.
+- **WAF JSON depth guard runs before the parser**: the zero-alloc depth/length
+  scan now precedes `simd_json`, so a deeply-nested body can't exhaust the
+  recursive parser.
+- **JWT HMAC secret via `secret_env`** (keep the key out of `zion.toml`); the
+  JWKS refresh client now has a connect + request timeout; a startup warning
+  fires when a JWT profile omits issuer/audience scoping.
+- Race-free request-coalescing singleflight (atomic `get_or_insert_with`).
+
+### Added
+
+- **`schema_version`** config handshake: a file targeting a newer schema gets
+  targeted upgrade guidance instead of a bare unknown-field rejection.
+- **Build provenance**: `zion --version` and the `zion_build_info` metric now
+  carry the git commit + date (via `build.rs`).
+- Metrics: `zion_connections_rejected_global` (global-ceiling shedding);
+  `zion_build_info`.
+- CI: a `pip-audit` job + a Dependabot `pip` ecosystem for the Python ML
+  pipeline.
+
+### Fixed / Changed
+
+- **Observability**: every response status is now counted once, centrally — the
+  pre-routing security rejects (414/405/425/429/403/401) were previously
+  invisible in `/metrics` and undercounted `requests_total`; the W3C trace id is
+  threaded into the access log and the signed audit record.
+- **Audit log**: pre-rotation flush errors are surfaced; a broken rotation now
+  sheds (drop + count) instead of growing the segment unbounded; the durability
+  guarantee is documented accurately (process-crash, not power-loss).
+- **Reliability**: the rate-map scavenge loop exits cleanly on shutdown; the
+  per-upstream `connect_timeout_ms` is documented as advisory-only.
+- **Ops**: systemd unit gets `StateDirectory=zion` (ACME writes work under
+  `ProtectSystem=strict`); Helm gains an optional PVC for ACME state; rollback
+  runbook, exit-code table, and per-replica scaling docs added.
+- **Perf**: single-upstream routes skip the per-request upstream-URI parse; the
+  streaming-WAF path no longer double-scans the body.
+- **Docs**: corrected the daemon exit-code contract (config error is `2`, not
+  `1`), the WAF entropy scope, the FIPS provenance scope, the ADR sidebar
+  (0012–0023), and the `caddy` import reference; documented token lifetime /
+  revocation, `secret_env`, and the forwarded-header contract.
+- Reject a fail-open enforcing JA4 allowlist; new unit tests for `net.rs` bind
+  logic, the io_uring accept classifier, and the WAF depth guard.
+
 ## [0.7.6] - 2026-09-01
 
 **Sovereign correctness.** The `geo-ita` / `geo-eu` origin classifier baked its

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5150,7 +5150,7 @@ dependencies = [
 
 [[package]]
 name = "zion"
-version = "0.7.6"
+version = "0.8.0"
 dependencies = [
  "aho-corasick",
  "aimp_node",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zion"
-version = "0.7.6"
+version = "0.8.0"
 edition = "2021"
 # MSRV is the *core* default-features build (TLS proxy + WAF + cache + metrics).
 # Opt-in features (acme, auth, init, http3) pull crypto/i18n crates that have

--- a/README.md
+++ b/README.md
@@ -317,12 +317,12 @@ Every release is signed and carries SLSA v1.0 build provenance — see
 
 ```bash
 # Binary release (Sigstore-backed provenance via gh CLI)
-gh release download v0.7.6 -R fabriziosalmi/zion -p '*x86_64-unknown-linux-musl*' -p 'SHA256SUMS'
+gh release download v0.8.0 -R fabriziosalmi/zion -p '*x86_64-unknown-linux-musl*' -p 'SHA256SUMS'
 sha256sum --check --ignore-missing SHA256SUMS
-gh attestation verify zion-v0.7.6-x86_64-unknown-linux-musl.tar.gz --owner fabriziosalmi
+gh attestation verify zion-v0.8.0-x86_64-unknown-linux-musl.tar.gz --owner fabriziosalmi
 
 # Container image (cosign keyless)
-cosign verify ghcr.io/fabriziosalmi/zion:v0.7.6 \
+cosign verify ghcr.io/fabriziosalmi/zion:v0.8.0 \
     --certificate-identity-regexp "^https://github.com/fabriziosalmi/zion/\\.github/workflows/release\\.yml@refs/tags/v" \
     --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ the current version.
 
 | Version | Supported |
 | ------- | --------- |
-| < 0.7.6 | No |
+| < 0.8.0 | No |
 
 Everything at or above that line is the current release. Stated as a single
 threshold on purpose — the previous wording carried a second, hardcoded row

--- a/deploy/helm/zion/Chart.yaml
+++ b/deploy/helm/zion/Chart.yaml
@@ -3,7 +3,7 @@ name: zion
 description: Zion Edge Gateway — high-performance Rust TLS reverse proxy with WAF
 type: application
 version: 0.2.2
-appVersion: "0.7.6"
+appVersion: "0.8.0"
 home: https://fabriziosalmi.github.io/zion
 sources:
   - https://github.com/fabriziosalmi/zion
@@ -19,7 +19,7 @@ annotations:
   artifacthub.io/license: Apache-2.0
   artifacthub.io/changes: |
     - kind: changed
-      description: Bump appVersion to 0.7.6
+      description: Bump appVersion to 0.8.0
     - kind: added
       description: ZION_AUDIT_HMAC_KEY wired from a Kubernetes Secret when [audit] is enabled
     - kind: added

--- a/docs/deploy/hot-reload.md
+++ b/docs/deploy/hot-reload.md
@@ -135,7 +135,7 @@ Two surfaces report the reload state:
 
   ```json
   {
-    "version": "0.7.6",
+    "version": "0.8.0",
     "timestamp_ms": 1714425600000,
     "uptime_secs": 3712,
     "config_generation": 5,

--- a/docs/security/supply-chain.md
+++ b/docs/security/supply-chain.md
@@ -46,8 +46,8 @@ You need the GitHub CLI (`gh >= 2.49`) and `cosign >= 2.2`.
 
 ```bash
 # 1. Download the artifact + SHA256SUMS from the release page.
-gh release download v0.7.6 -R fabriziosalmi/zion \
-    -p 'zion-v0.7.6-x86_64-unknown-linux-musl.tar.gz' \
+gh release download v0.8.0 -R fabriziosalmi/zion \
+    -p 'zion-v0.8.0-x86_64-unknown-linux-musl.tar.gz' \
     -p 'SHA256SUMS' \
     -p 'zion-sbom.cdx.json'
 
@@ -55,7 +55,7 @@ gh release download v0.7.6 -R fabriziosalmi/zion \
 sha256sum --check --ignore-missing SHA256SUMS
 
 # 3. Verify the SLSA build provenance bound to the artifact's hash.
-gh attestation verify zion-v0.7.6-x86_64-unknown-linux-musl.tar.gz \
+gh attestation verify zion-v0.8.0-x86_64-unknown-linux-musl.tar.gz \
     --owner fabriziosalmi
 
 # Step 3 fails if:
@@ -78,7 +78,7 @@ grype zion-sbom.cdx.json
 ## Verifying a container image
 
 ```bash
-IMAGE=ghcr.io/fabriziosalmi/zion:v0.7.6
+IMAGE=ghcr.io/fabriziosalmi/zion:v0.8.0
 
 # 1. Pin to the digest immediately — tags are mutable, digests are not.
 DIGEST=$(crane digest "$IMAGE")
@@ -120,7 +120,7 @@ deterministically, and pins the Rust toolchain via
 [`rust-toolchain.toml`](../../rust-toolchain.toml). To reproduce locally:
 
 ```bash
-git checkout v0.7.6
+git checkout v0.8.0
 export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)
 # Linux musl example — matches the release artifact byte-for-byte
 # (modulo strip's stable behavior on your distro).


### PR DESCRIPTION
Release prep for **v0.8.0**. Cuts a release of the audit-remediation work merged in #413 + #414 (code-metrics audit re-scored **39/100 → 75.8/100 "Strong"**, 0 critical / 0 high).

## Contents
- Version bump 0.7.6 → **0.8.0** (all refs synced; `check-version-sync` green).
- CHANGELOG **[0.8.0]** entry — security fixes + a prominent **⚠️ Breaking (config validation)** section (JA4 allowlist boot-reject, `sovereign_aimp.listen` fail-closed, route/upstream integrity, Helm ports 8080/8443, release toolchain pinned).

## Why MINOR, not patch
Several changes tighten config validation to **fail closed** — configs silently accepted before may now be rejected at boot. On 0.x that's a minor-level change; the CHANGELOG flags each one.

## Local e2e (this tree, before tag)
- `cargo build --release --features dist` — clean.
- Release binary boots: `zion 0.8.0 (bb060727 2026-09-08)` (build.rs git stamp live in release).
- Integration suite (`--ignored`, real TLS termination / JWT auth / WAF / CORS / cache on live sockets): **33 passed, 0 failed**.
- Note: `release.yml`'s pinned 1.88.0 toolchain (BLD-01) runs for the first time on the tag — watch the release build.

## Merge → tag flow
Merge this, then tag `v0.8.0` on master to trigger `release.yml` (build + SBOM + cosign + GitHub release). Tag intentionally NOT pushed yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)