### PR TITLE
fix(release): v0.8.1 — container-build hotfix (signed image for the audit release)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,7 +21,7 @@ A clear and concise description of what you expected to happen.
 **Environment (please complete the following information):**
  - OS: [e.g. Linux, macOS]
  - Architecture: [e.g. arm64, amd64]
- - Zion Version: [e.g. 0.8.0]
+ - Zion Version: [e.g. 0.8.1]
 
 **Additional context**
 Add any other context about the problem here (e.g. logs with `RUST_LOG=trace`, upstream backend type like Go/Node).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -499,8 +499,14 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Reproducible-build epoch
-        run: echo "SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)" >> "$GITHUB_ENV"
+      - name: Reproducible-build epoch + git stamp
+        run: |
+          echo "SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)" >> "$GITHUB_ENV"
+          # Passed as Docker build-args so build.rs stamps the real commit into
+          # the container binary (the build context has no .git). Same short-12
+          # sha + commit-date format build.rs computes locally.
+          echo "ZION_GIT_SHA=$(git rev-parse --short=12 HEAD)" >> "$GITHUB_ENV"
+          echo "ZION_COMMIT_DATE=$(git show -s --format=%cd --date=format:%Y-%m-%d HEAD)" >> "$GITHUB_ENV"
 
       - name: Set up Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
@@ -542,6 +548,8 @@ jobs:
           cache-to: type=gha,mode=max,scope=container-${{ matrix.arch }}
           build-args: |
             SOURCE_DATE_EPOCH=${{ env.SOURCE_DATE_EPOCH }}
+            ZION_GIT_SHA=${{ env.ZION_GIT_SHA }}
+            ZION_COMMIT_DATE=${{ env.ZION_COMMIT_DATE }}
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
 
       # Guard against the "arm64 manifest carries an amd64 binary" class of bug.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to Zion Edge Gateway are documented here.
 
 ## [Unreleased]
 
+## [0.8.1] - 2026-09-08
+
+**Container-build hotfix.** v0.8.0 published all binary artifacts, SBOM and
+checksums, but both container-image builds failed — so the multi-arch manifest
+and cosign signing were skipped and no signed `ghcr.io/fabriziosalmi/zion:0.8.0`
+was published. The v0.8.0 binaries are unaffected; this release re-runs the full
+pipeline and ships the signed container. No code changes beyond the build fix.
+
+### Fixed
+
+- **Container build compiles again** (regression from the 0.8.0 `build.rs` git
+  stamp): the stamp used the compile-time `env!("ZION_GIT_SHA")`, but the
+  Dockerfile's selective `COPY` never included `build.rs`, so inside the
+  container there was no build script and the macro failed with "environment
+  variable not defined at compile time". Now `option_env!` (compiles to
+  `"unknown"` if the script did not run), `build.rs` is copied into the image,
+  and `release.yml` passes the commit sha/date as build-args so the container
+  keeps real `--version` / `zion_build_info` provenance.
+
 ## [0.8.0] - 2026-09-08
 
 **Security & robustness hardening.** A full code-metrics audit of v0.7.6 scored

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5150,7 +5150,7 @@ dependencies = [
 
 [[package]]
 name = "zion"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "aho-corasick",
  "aimp_node",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zion"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 # MSRV is the *core* default-features build (TLS proxy + WAF + cache + metrics).
 # Opt-in features (acme, auth, init, http3) pull crypto/i18n crates that have

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ RUN apt-get update && \
 # Pre-warm the dependency closure with a stub `main`. The Cargo cache for
 # /usr/local/cargo/registry survives the next COPY thanks to BuildKit's
 # layer cache, so application changes don't rebuild every dep.
-COPY Cargo.toml Cargo.lock rust-toolchain.toml ./
+COPY Cargo.toml Cargo.lock rust-toolchain.toml build.rs ./
 RUN mkdir -p src benches && \
     echo 'fn main() {}' > src/main.rs && \
     # The manifest declares `[[bench]]` targets (Criterion, harness=false);
@@ -78,6 +78,15 @@ RUN mkdir -p src benches && \
 COPY src/ src/
 COPY benches/ benches/
 COPY .cargo/ .cargo/
+# Git provenance for the in-binary stamp (build.rs → --version / zion_build_info).
+# The build context has no .git, so release.yml passes these as build-args; they
+# sit AFTER the dep pre-warm so a new commit's sha never busts the cached
+# dependency layer. Absent (a plain `docker build`) → build.rs falls back to
+# "unknown", which is fine.
+ARG ZION_GIT_SHA=""
+ARG ZION_COMMIT_DATE=""
+ENV ZION_GIT_SHA=${ZION_GIT_SHA}
+ENV ZION_COMMIT_DATE=${ZION_COMMIT_DATE}
 # --features dist: the redistributable bundle (acme + init) so the official
 # image ships automatic HTTPS and the init wizard out of the box.
 RUN cargo build --release --locked --features dist && \

--- a/README.md
+++ b/README.md
@@ -317,12 +317,12 @@ Every release is signed and carries SLSA v1.0 build provenance — see
 
 ```bash
 # Binary release (Sigstore-backed provenance via gh CLI)
-gh release download v0.8.0 -R fabriziosalmi/zion -p '*x86_64-unknown-linux-musl*' -p 'SHA256SUMS'
+gh release download v0.8.1 -R fabriziosalmi/zion -p '*x86_64-unknown-linux-musl*' -p 'SHA256SUMS'
 sha256sum --check --ignore-missing SHA256SUMS
-gh attestation verify zion-v0.8.0-x86_64-unknown-linux-musl.tar.gz --owner fabriziosalmi
+gh attestation verify zion-v0.8.1-x86_64-unknown-linux-musl.tar.gz --owner fabriziosalmi
 
 # Container image (cosign keyless)
-cosign verify ghcr.io/fabriziosalmi/zion:v0.8.0 \
+cosign verify ghcr.io/fabriziosalmi/zion:v0.8.1 \
     --certificate-identity-regexp "^https://github.com/fabriziosalmi/zion/\\.github/workflows/release\\.yml@refs/tags/v" \
     --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ the current version.
 
 | Version | Supported |
 | ------- | --------- |
-| < 0.8.0 | No |
+| < 0.8.1 | No |
 
 Everything at or above that line is the current release. Stated as a single
 threshold on purpose — the previous wording carried a second, hardcoded row

--- a/build.rs
+++ b/build.rs
@@ -24,25 +24,41 @@ fn git(args: &[&str]) -> Option<String> {
 }
 
 fn main() {
-    // Re-run when HEAD moves or the index changes, so the stamp stays current.
+    // Re-run when HEAD moves or the index changes, so the stamp stays current;
+    // and when the injected vars change (the container build-arg path below).
     println!("cargo:rerun-if-changed=.git/HEAD");
     println!("cargo:rerun-if-changed=.git/index");
+    println!("cargo:rerun-if-env-changed=ZION_GIT_SHA");
+    println!("cargo:rerun-if-env-changed=ZION_COMMIT_DATE");
 
-    let mut sha = git(&["rev-parse", "--short=12", "HEAD"]).unwrap_or_else(|| "unknown".into());
-    // Mark a build made from a dirty working tree — it does not correspond to
-    // any published commit.
-    if git(&["status", "--porcelain"]).is_some_and(|s| !s.is_empty()) {
-        sha.push_str("-dirty");
-    }
-    let date = git(&[
-        "show",
-        "-s",
-        "--format=%cd",
-        "--date=format:%Y-%m-%d",
-        "HEAD",
-    ])
-    .unwrap_or_else(|| "unknown".into());
+    // Prefer values injected via the environment — the container build has no
+    // `.git`, so `release.yml` passes the sha/date as a Docker build-arg → ENV.
+    // Fall back to querying git (the normal + binary-artifact builds), then to
+    // "unknown" (a source tarball with neither).
+    let sha = env_nonempty("ZION_GIT_SHA").unwrap_or_else(|| {
+        let mut s = git(&["rev-parse", "--short=12", "HEAD"]).unwrap_or_else(|| "unknown".into());
+        // Mark a build made from a dirty working tree — it corresponds to no
+        // published commit.
+        if git(&["status", "--porcelain"]).is_some_and(|st| !st.is_empty()) {
+            s.push_str("-dirty");
+        }
+        s
+    });
+    let date = env_nonempty("ZION_COMMIT_DATE").unwrap_or_else(|| {
+        git(&[
+            "show",
+            "-s",
+            "--format=%cd",
+            "--date=format:%Y-%m-%d",
+            "HEAD",
+        ])
+        .unwrap_or_else(|| "unknown".into())
+    });
 
     println!("cargo:rustc-env=ZION_GIT_SHA={sha}");
     println!("cargo:rustc-env=ZION_COMMIT_DATE={date}");
+}
+
+fn env_nonempty(key: &str) -> Option<String> {
+    std::env::var(key).ok().filter(|v| !v.is_empty())
 }

--- a/deploy/helm/zion/Chart.yaml
+++ b/deploy/helm/zion/Chart.yaml
@@ -3,7 +3,7 @@ name: zion
 description: Zion Edge Gateway — high-performance Rust TLS reverse proxy with WAF
 type: application
 version: 0.2.2
-appVersion: "0.8.0"
+appVersion: "0.8.1"
 home: https://fabriziosalmi.github.io/zion
 sources:
   - https://github.com/fabriziosalmi/zion
@@ -19,7 +19,7 @@ annotations:
   artifacthub.io/license: Apache-2.0
   artifacthub.io/changes: |
     - kind: changed
-      description: Bump appVersion to 0.8.0
+      description: Bump appVersion to 0.8.1
     - kind: added
       description: ZION_AUDIT_HMAC_KEY wired from a Kubernetes Secret when [audit] is enabled
     - kind: added

--- a/docs/deploy/hot-reload.md
+++ b/docs/deploy/hot-reload.md
@@ -135,7 +135,7 @@ Two surfaces report the reload state:
 
   ```json
   {
-    "version": "0.8.0",
+    "version": "0.8.1",
     "timestamp_ms": 1714425600000,
     "uptime_secs": 3712,
     "config_generation": 5,

--- a/docs/security/supply-chain.md
+++ b/docs/security/supply-chain.md
@@ -46,8 +46,8 @@ You need the GitHub CLI (`gh >= 2.49`) and `cosign >= 2.2`.
 
 ```bash
 # 1. Download the artifact + SHA256SUMS from the release page.
-gh release download v0.8.0 -R fabriziosalmi/zion \
-    -p 'zion-v0.8.0-x86_64-unknown-linux-musl.tar.gz' \
+gh release download v0.8.1 -R fabriziosalmi/zion \
+    -p 'zion-v0.8.1-x86_64-unknown-linux-musl.tar.gz' \
     -p 'SHA256SUMS' \
     -p 'zion-sbom.cdx.json'
 
@@ -55,7 +55,7 @@ gh release download v0.8.0 -R fabriziosalmi/zion \
 sha256sum --check --ignore-missing SHA256SUMS
 
 # 3. Verify the SLSA build provenance bound to the artifact's hash.
-gh attestation verify zion-v0.8.0-x86_64-unknown-linux-musl.tar.gz \
+gh attestation verify zion-v0.8.1-x86_64-unknown-linux-musl.tar.gz \
     --owner fabriziosalmi
 
 # Step 3 fails if:
@@ -78,7 +78,7 @@ grype zion-sbom.cdx.json
 ## Verifying a container image
 
 ```bash
-IMAGE=ghcr.io/fabriziosalmi/zion:v0.8.0
+IMAGE=ghcr.io/fabriziosalmi/zion:v0.8.1
 
 # 1. Pin to the digest immediately — tags are mutable, digests are not.
 DIGEST=$(crane digest "$IMAGE")
@@ -120,7 +120,7 @@ deterministically, and pins the Rust toolchain via
 [`rust-toolchain.toml`](../../rust-toolchain.toml). To reproduce locally:
 
 ```bash
-git checkout v0.8.0
+git checkout v0.8.1
 export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)
 # Linux musl example — matches the release artifact byte-for-byte
 # (modulo strip's stable behavior on your distro).

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -428,13 +428,16 @@ fn parse_top_opts(args: &[String]) -> TopOpts {
 }
 
 pub fn print_version() {
-    // git sha + commit date are stamped by build.rs (both "unknown" when built
-    // without a .git tree), so a loose binary ties back to its exact commit.
+    // git sha + commit date are stamped by build.rs. `option_env!` (not `env!`)
+    // so the binary still COMPILES when build.rs did not run — e.g. a Docker
+    // build whose context omits build.rs — degrading to "unknown" rather than a
+    // hard compile error. build.rs is present in the normal build and in the
+    // release/container builds (which also pass the sha via a build-arg).
     println!(
         "zion {} ({} {})",
         env!("CARGO_PKG_VERSION"),
-        env!("ZION_GIT_SHA"),
-        env!("ZION_COMMIT_DATE"),
+        option_env!("ZION_GIT_SHA").unwrap_or("unknown"),
+        option_env!("ZION_COMMIT_DATE").unwrap_or("unknown"),
     );
 }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -686,11 +686,17 @@ impl Metrics {
         );
         out.extend_from_slice(env!("CARGO_PKG_VERSION").as_bytes());
         // git sha + commit date stamped by build.rs; label values are safe
-        // (hex sha / ISO date / the literal "unknown").
+        // (hex sha / ISO date / the literal "unknown"). `option_env!` (not
+        // `env!`) so the binary compiles even when build.rs did not run (e.g. a
+        // Docker context without build.rs) — it degrades to "unknown".
         out.extend_from_slice(b"\",commit=\"");
-        out.extend_from_slice(env!("ZION_GIT_SHA").as_bytes());
+        out.extend_from_slice(option_env!("ZION_GIT_SHA").unwrap_or("unknown").as_bytes());
         out.extend_from_slice(b"\",commit_date=\"");
-        out.extend_from_slice(env!("ZION_COMMIT_DATE").as_bytes());
+        out.extend_from_slice(
+            option_env!("ZION_COMMIT_DATE")
+                .unwrap_or("unknown")
+                .as_bytes(),
+        );
         out.extend_from_slice(b"\"} 1\n");
 
         out.extend_from_slice(
@@ -1533,8 +1539,8 @@ mod tests {
         assert!(out.contains(&format!(
             "zion_build_info{{version=\"{}\",commit=\"{}\",commit_date=\"{}\"}} 1",
             env!("CARGO_PKG_VERSION"),
-            env!("ZION_GIT_SHA"),
-            env!("ZION_COMMIT_DATE"),
+            option_env!("ZION_GIT_SHA").unwrap_or("unknown"),
+            option_env!("ZION_COMMIT_DATE").unwrap_or("unknown"),
         )));
         assert!(out.contains("zion_connections_rejected_global 0"));
     }


### PR DESCRIPTION
**Hotfix for v0.8.0.** v0.8.0 published all binary artifacts + SBOM + checksums, but **both container-image builds failed**, so the multi-arch manifest + cosign signing were skipped — no signed `ghcr.io/fabriziosalmi/zion:0.8.0`. This cuts **v0.8.1** to ship the signed container.

## Root cause
The 0.8.0 `build.rs` git stamp used the compile-time `env!("ZION_GIT_SHA")`, but the Dockerfile's selective `COPY` never included `build.rs` → inside the container there was no build script → `error: environment variable ZION_GIT_SHA not defined at compile time`. The binary artifacts (full checkout) were unaffected.

## Fix (defence in depth)
- `env!` → `option_env!(...).unwrap_or("unknown")` in `cli.rs` + `metrics.rs` — compiles even if `build.rs` never ran.
- `COPY build.rs` into the image; `build.rs` now prefers `ZION_GIT_SHA`/`ZION_COMMIT_DATE` from the env; `release.yml` passes them as build-args (the container context has no `.git`) so the image keeps real provenance.

## Validated locally
- `docker build` (the exact failed leg) now **compiles**; the image reports `zion <ver> (<sha> <date>)`.
- `cargo clippy` + metrics test green; `actionlint` clean.

Merge → tag `v0.8.1` re-runs the full release pipeline (binaries + **signed container** + SBOM + provenance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)