### PR TITLE
chore(release): v0.8.2 — audit quick-wins

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,7 +21,7 @@ A clear and concise description of what you expected to happen.
 **Environment (please complete the following information):**
  - OS: [e.g. Linux, macOS]
  - Architecture: [e.g. arm64, amd64]
- - Zion Version: [e.g. 0.8.1]
+ - Zion Version: [e.g. 0.8.2]
 
 **Additional context**
 Add any other context about the problem here (e.g. logs with `RUST_LOG=trace`, upstream backend type like Go/Node).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to Zion Edge Gateway are documented here.
 
 ## [Unreleased]
 
+## [0.8.2] - 2026-09-08
+
+**Audit quick-wins.** Low-risk residual findings from the re-audit (which scored
+75.8/100, 0 critical/high); the larger items are tracked as issues (#417–#424).
+No breaking changes.
+
+### Fixed
+
+- **docs**: the inline systemd unit in the deployment guide now includes
+  `StateDirectory=zion` (it had drifted from the shipped `deploy/zion.service`,
+  reintroducing the read-only `/var/lib/zion` write-path trap for anyone
+  transcribing it); the ACME `state_dir` doc comment now says
+  `/var/lib/zion/acme` (was `/etc/zion/acme`, contradicting the code default);
+  the Docker recipe is flagged as illustrative/root vs the shipped distroless
+  non-root image; the AIMP mesh is marked experimental in the guide.
+- **observability**: a local WAF-block that can't be gossiped (publish queue
+  full / control plane not bootstrapped) now increments a new
+  `zion_mesh_claims_dropped_publish_total` counter instead of dropping silently;
+  the `publish_block` docstring corrected to match.
+
+### Changed
+
+- **perf**: CORS requests validate the `Origin` once (reuse the pre-computed
+  allow-origin) instead of calling `check_origin` — and re-lowercasing the
+  origin — a second time per request.
+- **build**: the container image carries an `org.opencontainers.image.revision`
+  (commit sha) label.
+
 ## [0.8.1] - 2026-09-08
 
 **Container-build hotfix.** v0.8.0 published all binary artifacts, SBOM and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5150,7 +5150,7 @@ dependencies = [
 
 [[package]]
 name = "zion"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "aho-corasick",
  "aimp_node",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zion"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 # MSRV is the *core* default-features build (TLS proxy + WAF + cache + metrics).
 # Opt-in features (acme, auth, init, http3) pull crypto/i18n crates that have

--- a/Dockerfile
+++ b/Dockerfile
@@ -108,8 +108,12 @@ RUN mkdir -p /out/var/lib/zion && \
 # by the CI release workflow when building from the precompiled musl artifact.
 FROM gcr.io/distroless/cc-debian12:nonroot@sha256:bd2899c12b335c827750ccf2359879eab09c09b206023dcebea408947d54127c AS runtime
 
-# Re-declare so labels can interpolate it.
+# Re-declare so labels can interpolate them.
 ARG SOURCE_DATE_EPOCH=0
+# The commit the image was built from — the same value stamped into the binary
+# (build.rs). Makes the image self-describing via `org.opencontainers.image.revision`
+# without unpacking the binary or reading the SLSA attestation.
+ARG ZION_GIT_SHA=""
 
 # OCI labels — surfaced by GHCR/Quay UIs and by image scanners.
 LABEL org.opencontainers.image.title="Zion Edge Gateway" \
@@ -119,6 +123,7 @@ LABEL org.opencontainers.image.title="Zion Edge Gateway" \
       org.opencontainers.image.url="https://github.com/fabriziosalmi/zion" \
       org.opencontainers.image.documentation="https://fabriziosalmi.github.io/zion" \
       org.opencontainers.image.vendor="Fabrizio Salmi" \
+      org.opencontainers.image.revision="$ZION_GIT_SHA" \
       org.opencontainers.image.created="$SOURCE_DATE_EPOCH"
 
 COPY --from=builder /build/target/release/zion /usr/local/bin/zion

--- a/README.md
+++ b/README.md
@@ -317,12 +317,12 @@ Every release is signed and carries SLSA v1.0 build provenance — see
 
 ```bash
 # Binary release (Sigstore-backed provenance via gh CLI)
-gh release download v0.8.1 -R fabriziosalmi/zion -p '*x86_64-unknown-linux-musl*' -p 'SHA256SUMS'
+gh release download v0.8.2 -R fabriziosalmi/zion -p '*x86_64-unknown-linux-musl*' -p 'SHA256SUMS'
 sha256sum --check --ignore-missing SHA256SUMS
-gh attestation verify zion-v0.8.1-x86_64-unknown-linux-musl.tar.gz --owner fabriziosalmi
+gh attestation verify zion-v0.8.2-x86_64-unknown-linux-musl.tar.gz --owner fabriziosalmi
 
 # Container image (cosign keyless)
-cosign verify ghcr.io/fabriziosalmi/zion:v0.8.1 \
+cosign verify ghcr.io/fabriziosalmi/zion:v0.8.2 \
     --certificate-identity-regexp "^https://github.com/fabriziosalmi/zion/\\.github/workflows/release\\.yml@refs/tags/v" \
     --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ the current version.
 
 | Version | Supported |
 | ------- | --------- |
-| < 0.8.1 | No |
+| < 0.8.2 | No |
 
 Everything at or above that line is the current release. Stated as a single
 threshold on purpose — the previous wording carried a second, hardcoded row

--- a/deploy/helm/zion/Chart.yaml
+++ b/deploy/helm/zion/Chart.yaml
@@ -3,7 +3,7 @@ name: zion
 description: Zion Edge Gateway — high-performance Rust TLS reverse proxy with WAF
 type: application
 version: 0.2.2
-appVersion: "0.8.1"
+appVersion: "0.8.2"
 home: https://fabriziosalmi.github.io/zion
 sources:
   - https://github.com/fabriziosalmi/zion
@@ -19,7 +19,7 @@ annotations:
   artifacthub.io/license: Apache-2.0
   artifacthub.io/changes: |
     - kind: changed
-      description: Bump appVersion to 0.8.1
+      description: Bump appVersion to 0.8.2
     - kind: added
       description: ZION_AUDIT_HMAC_KEY wired from a Kubernetes Secret when [audit] is enabled
     - kind: added

--- a/docs/deploy/hot-reload.md
+++ b/docs/deploy/hot-reload.md
@@ -135,7 +135,7 @@ Two surfaces report the reload state:
 
   ```json
   {
-    "version": "0.8.1",
+    "version": "0.8.2",
     "timestamp_ms": 1714425600000,
     "uptime_secs": 3712,
     "config_generation": 5,

--- a/docs/deploy/index.md
+++ b/docs/deploy/index.md
@@ -50,6 +50,13 @@ ProtectHome=true
 ReadOnlyPaths=/etc/zion
 PrivateTmp=true
 
+# Writable runtime state. ProtectSystem=strict makes the FS read-only, so
+# without this the ACME subsystem (account key + renewed cert/key under
+# /var/lib/zion) and the panic last-gasp file cannot be written. StateDirectory
+# creates /var/lib/zion owned by the service user and grants write access.
+StateDirectory=zion
+Environment=ZION_LAST_GASP_PATH=/var/lib/zion/last_panic.jsonl
+
 # Allow binding to privileged ports (80, 443)
 AmbientCapabilities=CAP_NET_BIND_SERVICE
 CapabilityBoundingSet=CAP_NET_BIND_SERVICE
@@ -69,6 +76,16 @@ sudo systemctl enable --now zion
 ```
 
 ## Docker
+
+::: tip Use the official image for production
+This is a **minimal illustrative** Dockerfile — it runs as **root** on a
+`debian-slim` base and is not the hardened image. For production pull the
+official image, which is **distroless, non-root (UID 65532)**, multi-arch, and
+cosign-signed with SLSA provenance:
+`docker pull ghcr.io/fabriziosalmi/zion:latest`. Build it from the repo
+[`Dockerfile`](https://github.com/fabriziosalmi/zion/blob/master/Dockerfile) if
+you need to build locally.
+:::
 
 ```dockerfile
 FROM rust:1.82-bookworm AS builder

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -20,7 +20,7 @@ Zion is a TLS reverse proxy with a built-in WAF, written in Rust. One binary, on
 | Platform detection | Reads CPU count, RAM, AES-NI, SO_REUSEPORT, TCP_FASTOPEN at boot |
 | kTLS offload (experimental) | Post-handshake socket flip into in-kernel TLS; wired but not yet exercised end-to-end in CI. `--features ktls` (Linux 5.10+) |
 | ML-augmented WAF (experimental) | 16-dim ONNX model on the WAF hot path, 200µs p99 budget. Score is a signal, never a hard gate; ships no bundled model. `--features ml-waf` |
-| AIMP mesh (v0.2.x) | Ed25519-signed UDP gossip of WAF + IP-reputation deltas across a fleet. Anti-entropy convergence. `--features sovereign-aimp` |
+| AIMP mesh (**experimental**, v0.2.x) | Ed25519-signed UDP gossip of WAF + IP-reputation deltas across a fleet. Anti-entropy convergence. `--features sovereign-aimp` (off by default; the wire protocol is not yet stable). |
 
 ## When to use Zion
 

--- a/docs/security/supply-chain.md
+++ b/docs/security/supply-chain.md
@@ -46,8 +46,8 @@ You need the GitHub CLI (`gh >= 2.49`) and `cosign >= 2.2`.
 
 ```bash
 # 1. Download the artifact + SHA256SUMS from the release page.
-gh release download v0.8.1 -R fabriziosalmi/zion \
-    -p 'zion-v0.8.1-x86_64-unknown-linux-musl.tar.gz' \
+gh release download v0.8.2 -R fabriziosalmi/zion \
+    -p 'zion-v0.8.2-x86_64-unknown-linux-musl.tar.gz' \
     -p 'SHA256SUMS' \
     -p 'zion-sbom.cdx.json'
 
@@ -55,7 +55,7 @@ gh release download v0.8.1 -R fabriziosalmi/zion \
 sha256sum --check --ignore-missing SHA256SUMS
 
 # 3. Verify the SLSA build provenance bound to the artifact's hash.
-gh attestation verify zion-v0.8.1-x86_64-unknown-linux-musl.tar.gz \
+gh attestation verify zion-v0.8.2-x86_64-unknown-linux-musl.tar.gz \
     --owner fabriziosalmi
 
 # Step 3 fails if:
@@ -78,7 +78,7 @@ grype zion-sbom.cdx.json
 ## Verifying a container image
 
 ```bash
-IMAGE=ghcr.io/fabriziosalmi/zion:v0.8.1
+IMAGE=ghcr.io/fabriziosalmi/zion:v0.8.2
 
 # 1. Pin to the digest immediately — tags are mutable, digests are not.
 DIGEST=$(crane digest "$IMAGE")
@@ -120,7 +120,7 @@ deterministically, and pins the Rust toolchain via
 [`rust-toolchain.toml`](../../rust-toolchain.toml). To reproduce locally:
 
 ```bash
-git checkout v0.8.1
+git checkout v0.8.2
 export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)
 # Linux musl example — matches the release artifact byte-for-byte
 # (modulo strip's stable behavior on your distro).

--- a/examples/_shared/aimp_metrics_stub.rs
+++ b/examples/_shared/aimp_metrics_stub.rs
@@ -23,6 +23,7 @@ use std::sync::atomic::AtomicU64;
 
 pub struct Metrics {
     pub mesh_claims_emitted: AtomicU64,
+    pub mesh_claims_dropped_publish: AtomicU64,
     pub mesh_claims_received: AtomicU64,
     pub mesh_claims_dropped_signature: AtomicU64,
     pub mesh_claims_dropped_replay: AtomicU64,
@@ -37,6 +38,7 @@ impl Metrics {
     const fn new() -> Self {
         Self {
             mesh_claims_emitted: AtomicU64::new(0),
+            mesh_claims_dropped_publish: AtomicU64::new(0),
             mesh_claims_received: AtomicU64::new(0),
             mesh_claims_dropped_signature: AtomicU64::new(0),
             mesh_claims_dropped_replay: AtomicU64::new(0),

--- a/src/aimp_cp.rs
+++ b/src/aimp_cp.rs
@@ -200,8 +200,9 @@ impl AimpControlPlane {
 
     /// Publish a local block to the gossip mesh. Returns immediately —
     /// the actual UDP send happens in the publish task. If the channel
-    /// is full (catastrophic back-pressure), the delta is silently
-    /// dropped and a counter is bumped.
+    /// is full (catastrophic back-pressure), the delta is dropped, the
+    /// `mesh_claims_dropped_publish` counter is bumped, and `Err` is returned
+    /// (the local block itself already took effect; only gossip is lost).
     pub fn publish_block(&self, ip: IpAddr, score: f32, reason: u8) -> Result<(), &'static str> {
         let ip_v6 = match ip {
             IpAddr::V4(v4) => v4.to_ipv6_mapped().octets(),
@@ -213,9 +214,15 @@ impl AimpControlPlane {
             ts_secs: now_secs(),
             reason,
         };
-        self.publish_tx
-            .try_send(delta)
-            .map_err(|_| "aimp-cp: publish queue full or closed")?;
+        if self.publish_tx.try_send(delta).is_err() {
+            // Back-pressure drop: the local block already took effect, only its
+            // gossip propagation is lost. Count it (send-side counterpart to the
+            // receive-side mesh_claims_dropped_* buckets) so it isn't silent.
+            crate::metrics::METRICS
+                .mesh_claims_dropped_publish
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            return Err("aimp-cp: publish queue full or closed");
+        }
         // Successful local emit (the publisher task drains and signs +
         // sends). Increment AFTER a successful enqueue so a
         // back-pressure drop doesn't get counted as an emit.

--- a/src/config.rs
+++ b/src/config.rs
@@ -535,7 +535,9 @@ pub struct AcmeConfig {
     /// Days before expiry to trigger renewal. Default: 30.
     #[serde(default = "default_acme_renew_days")]
     pub renew_before_days: u64,
-    /// Where to store ACME account key + certs. Default: /etc/zion/acme/
+    /// Where to store ACME account key + certs. Default: `/var/lib/zion/acme`
+    /// (a runtime-writable state dir — NOT `/etc`, which is read-only under the
+    /// hardened systemd unit and the distroless container).
     #[serde(default = "default_acme_state_dir")]
     pub state_dir: String,
 }

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -633,38 +633,47 @@ async fn process_request_inner(
         .and_then(|o| rule.cors.as_ref().and_then(|c| c.check_origin(o)));
 
     if let Some(ref cors) = rule.cors {
-        if let Some(ref origin_val) = req_origin {
-            let origin_str = origin_val.to_str().unwrap_or("");
-            if let Some(allow_origin) = cors.check_origin(origin_str) {
-                // Pre-flight OPTIONS — respond immediately without proxying
-                if *req.method() == hyper::Method::OPTIONS {
-                    let mut resp = empty_response(StatusCode::NO_CONTENT);
-                    let h = resp.headers_mut();
-                    h.insert(hyper::header::ACCESS_CONTROL_ALLOW_ORIGIN, allow_origin);
-                    h.insert(
-                        hyper::header::ACCESS_CONTROL_ALLOW_METHODS,
-                        cors.allow_methods.clone(),
-                    );
-                    h.insert(
-                        hyper::header::ACCESS_CONTROL_ALLOW_HEADERS,
-                        cors.allow_headers.clone(),
-                    );
-                    h.insert(hyper::header::ACCESS_CONTROL_MAX_AGE, cors.max_age.clone());
-                    inject_security_headers(&mut resp);
-                    return Ok(resp);
+        // An origin is present: reuse the `cors_allow_origin` computed above
+        // instead of calling `check_origin` (and re-lowercasing the origin) a
+        // second time per request.
+        if req_origin.is_some() {
+            match cors_allow_origin.as_ref() {
+                Some(allow_origin) => {
+                    // Pre-flight OPTIONS — respond immediately without proxying.
+                    if *req.method() == hyper::Method::OPTIONS {
+                        let mut resp = empty_response(StatusCode::NO_CONTENT);
+                        let h = resp.headers_mut();
+                        h.insert(
+                            hyper::header::ACCESS_CONTROL_ALLOW_ORIGIN,
+                            allow_origin.clone(),
+                        );
+                        h.insert(
+                            hyper::header::ACCESS_CONTROL_ALLOW_METHODS,
+                            cors.allow_methods.clone(),
+                        );
+                        h.insert(
+                            hyper::header::ACCESS_CONTROL_ALLOW_HEADERS,
+                            cors.allow_headers.clone(),
+                        );
+                        h.insert(hyper::header::ACCESS_CONTROL_MAX_AGE, cors.max_age.clone());
+                        inject_security_headers(&mut resp);
+                        return Ok(resp);
+                    }
                 }
-            } else {
-                // Origin not in allowed list — block state-changing methods AND preflight.
-                if *req.method() == hyper::Method::OPTIONS
-                    || matches!(
-                        *req.method(),
-                        hyper::Method::POST
-                            | hyper::Method::PUT
-                            | hyper::Method::PATCH
-                            | hyper::Method::DELETE
-                    )
-                {
-                    return Ok(empty_response(StatusCode::FORBIDDEN));
+                None => {
+                    // Origin present but not allowed — block state-changing
+                    // methods AND preflight.
+                    if *req.method() == hyper::Method::OPTIONS
+                        || matches!(
+                            *req.method(),
+                            hyper::Method::POST
+                                | hyper::Method::PUT
+                                | hyper::Method::PATCH
+                                | hyper::Method::DELETE
+                        )
+                    {
+                        return Ok(empty_response(StatusCode::FORBIDDEN));
+                    }
                 }
             }
         }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -459,6 +459,11 @@ pub struct Metrics {
     // regardless of which build their distro produced).
     /// Successful local emits — bumped in `aimp_cp::publish_block`.
     pub mesh_claims_emitted: AtomicU64,
+    /// LOCAL blocks that could NOT be gossiped because the publish queue was
+    /// full or the control plane was not bootstrapped (back-pressure drop).
+    /// Send-side counterpart to the receive-side `mesh_claims_dropped_*`; the
+    /// local block still took effect, only its fleet-wide propagation was lost.
+    pub mesh_claims_dropped_publish: AtomicU64,
     /// Inbound envelopes that *passed* the merge policy gates.
     pub mesh_claims_received: AtomicU64,
     /// Inbound envelopes rejected on signature verification.
@@ -547,6 +552,7 @@ impl Metrics {
             tarpit_held_ms_total: AtomicU64::new(0),
             mesh_claims_emitted: AtomicU64::new(0),
             mesh_claims_received: AtomicU64::new(0),
+            mesh_claims_dropped_publish: AtomicU64::new(0),
             mesh_claims_dropped_signature: AtomicU64::new(0),
             mesh_claims_dropped_replay: AtomicU64::new(0),
             mesh_claims_dropped_other: AtomicU64::new(0),
@@ -1027,6 +1033,18 @@ impl Metrics {
         out.extend_from_slice(
             itoa_buf
                 .format(self.mesh_claims_emitted.load(Relaxed))
+                .as_bytes(),
+        );
+        out.extend_from_slice(b"\n");
+
+        out.extend_from_slice(
+            b"# HELP zion_mesh_claims_dropped_publish_total Local blocks not gossiped (publish queue full / control plane down).\n\
+                                # TYPE zion_mesh_claims_dropped_publish_total counter\n\
+                                zion_mesh_claims_dropped_publish_total ",
+        );
+        out.extend_from_slice(
+            itoa_buf
+                .format(self.mesh_claims_dropped_publish.load(Relaxed))
                 .as_bytes(),
         );
         out.extend_from_slice(b"\n");


### PR DESCRIPTION
Low-risk residual findings from the re-audit (75.8/100, 0 critical/high). Larger items tracked as issues #417–#424. **No breaking changes.**

## Fixed
- **docs**: inline systemd unit in the deploy guide gets `StateDirectory=zion` (had drifted from `deploy/zion.service`); ACME `state_dir` doc says `/var/lib/zion/acme` (was `/etc/zion/acme`); Docker recipe flagged illustrative/root vs the shipped distroless non-root image; AIMP mesh marked experimental.
- **observability**: a local WAF-block that can't be gossiped now bumps `zion_mesh_claims_dropped_publish_total` instead of a silent drop; `publish_block` docstring corrected.

## Changed
- **perf**: CORS `Origin` validated once per request (reuse the pre-computed allow-origin) instead of twice.
- **build**: image carries `org.opencontainers.image.revision` (commit sha).

Follows v0.8.1 (container hotfix, already released with signed image). Merge → tag `v0.8.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)