### PR TITLE
fix(release): v0.8.3 — fail-closed security fixes (2 HIGH fail-opens)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,7 +21,7 @@ A clear and concise description of what you expected to happen.
 **Environment (please complete the following information):**
  - OS: [e.g. Linux, macOS]
  - Architecture: [e.g. arm64, amd64]
- - Zion Version: [e.g. 0.8.2]
+ - Zion Version: [e.g. 0.8.3]
 
 **Additional context**
 Add any other context about the problem here (e.g. logs with `RUST_LOG=trace`, upstream backend type like Go/Node).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to Zion Edge Gateway are documented here.
 
 ## [Unreleased]
 
+## [0.8.3] - 2026-09-08
+
+**Fail-closed security fixes.** A deeper re-audit of v0.8.2 surfaced two HIGH
+fail-opens (one a residual gap in the v0.8.0 AIMP-listen fix); this closes both.
+No behaviour change for a correct config.
+
+### Fixed
+
+- **AIMP mesh empty listen no longer binds `0.0.0.0`** (closes the v0.8.0
+  `sovereign_aimp.listen` gap): an enabled mesh with no `listen` (and no
+  `ZION_AIMP_LISTEN`) fell back to `0.0.0.0:9443` — the gossip control plane on
+  every interface. v0.8.0 rejected only a *malformed* listen, not an empty one.
+  The unconfigured case now defaults to **loopback** (`127.0.0.1:9443`); set
+  `listen`/`ZION_AIMP_LISTEN` explicitly to expose it on a real interface.
+- **mTLS `client_auth` without a CA is rejected at boot**: `client_auth =
+  "required" | "optional"` with no `tls.client_ca_path` silently built the
+  listener with **no client auth** — the enforcement the operator asked for was
+  off with no signal. Config validation now rejects it (mirrors the existing
+  `admin.auth = "mtls"` check), and also rejects an unknown `client_auth` value
+  (a typo previously coerced to `"none"`).
+- **docs**: correct the connection-limit formula in the architecture guide
+  (`/50` → `/256`, ~256 KB/conn) and tag the AIMP mesh **experimental** in the
+  README (it already was in the guide).
+
 ## [0.8.2] - 2026-09-08
 
 **Audit quick-wins.** Low-risk residual findings from the re-audit (which scored

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5150,7 +5150,7 @@ dependencies = [
 
 [[package]]
 name = "zion"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "aho-corasick",
  "aimp_node",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zion"
-version = "0.8.2"
+version = "0.8.3"
 edition = "2021"
 # MSRV is the *core* default-features build (TLS proxy + WAF + cache + metrics).
 # Opt-in features (acme, auth, init, http3) pull crypto/i18n crates that have

--- a/README.md
+++ b/README.md
@@ -317,12 +317,12 @@ Every release is signed and carries SLSA v1.0 build provenance — see
 
 ```bash
 # Binary release (Sigstore-backed provenance via gh CLI)
-gh release download v0.8.2 -R fabriziosalmi/zion -p '*x86_64-unknown-linux-musl*' -p 'SHA256SUMS'
+gh release download v0.8.3 -R fabriziosalmi/zion -p '*x86_64-unknown-linux-musl*' -p 'SHA256SUMS'
 sha256sum --check --ignore-missing SHA256SUMS
-gh attestation verify zion-v0.8.2-x86_64-unknown-linux-musl.tar.gz --owner fabriziosalmi
+gh attestation verify zion-v0.8.3-x86_64-unknown-linux-musl.tar.gz --owner fabriziosalmi
 
 # Container image (cosign keyless)
-cosign verify ghcr.io/fabriziosalmi/zion:v0.8.2 \
+cosign verify ghcr.io/fabriziosalmi/zion:v0.8.3 \
     --certificate-identity-regexp "^https://github.com/fabriziosalmi/zion/\\.github/workflows/release\\.yml@refs/tags/v" \
     --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 ```

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ Client -> TLS 1.3 -> Security Gates -> Radix Router -> WAF Pipeline (5 gates) ->
 **Opt-in tracks (feature-gated, default-off)**
 - **kTLS offload** (`--features ktls`, Linux 5.10+) — *experimental*: flips the socket into in-kernel TLS after handshake toward `sendfile`-class zero-copy. The offload is wired but not yet exercised end-to-end in CI (issue #52).
 - **ML-augmented WAF** (`--features ml-waf`) — *experimental*: 16-dim tract-onnx scorer on the WAF hot path (200 µs p99 budget), advisory metric/header — never a hard gate. Ships no bundled model.
-- **AIMP serverless mesh** (`--features sovereign-aimp`) — Ed25519-signed UDP gossip of WAF deltas + IP reputation across a fleet, no central control plane.
+- **AIMP serverless mesh** (`--features sovereign-aimp`, **experimental** — off by default, wire protocol not yet stable) — Ed25519-signed UDP gossip of WAF deltas + IP reputation across a fleet, no central control plane.
 
 ## Sovereign edge & DDoS resistance
 

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Client -> TLS 1.3 -> Security Gates -> Radix Router -> WAF Pipeline (5 gates) ->
 ```
 
 <!-- zion-stats:modules-lines (kept in sync by scripts/update-readme-stats.sh) -->
-50 modules, ~46,300 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
+50 modules, ~46,400 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
 
 ## Features
 
@@ -288,7 +288,7 @@ MODE=full bash benchmarks/baseline/run-baseline.sh   # → benchmarks/baseline/z
 ## Testing
 
 <!-- zion-stats:test-count (kept in sync by scripts/update-readme-stats.sh) -->
-**911 unit tests** run on every change; **23 integration tests** need a running Zion + a backend.
+**912 unit tests** run on every change; **23 integration tests** need a running Zion + a backend.
 
 ```bash
 cargo test                          # unit tests

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ the current version.
 
 | Version | Supported |
 | ------- | --------- |
-| < 0.8.2 | No |
+| < 0.8.3 | No |
 
 Everything at or above that line is the current release. Stated as a single
 threshold on purpose — the previous wording carried a second, hardcoded row

--- a/deploy/helm/zion/Chart.yaml
+++ b/deploy/helm/zion/Chart.yaml
@@ -3,7 +3,7 @@ name: zion
 description: Zion Edge Gateway — high-performance Rust TLS reverse proxy with WAF
 type: application
 version: 0.2.2
-appVersion: "0.8.2"
+appVersion: "0.8.3"
 home: https://fabriziosalmi.github.io/zion
 sources:
   - https://github.com/fabriziosalmi/zion
@@ -19,7 +19,7 @@ annotations:
   artifacthub.io/license: Apache-2.0
   artifacthub.io/changes: |
     - kind: changed
-      description: Bump appVersion to 0.8.2
+      description: Bump appVersion to 0.8.3
     - kind: added
       description: ZION_AUDIT_HMAC_KEY wired from a Kubernetes Secret when [audit] is enabled
     - kind: added

--- a/docs/deploy/hot-reload.md
+++ b/docs/deploy/hot-reload.md
@@ -135,7 +135,7 @@ Two surfaces report the reload state:
 
   ```json
   {
-    "version": "0.8.2",
+    "version": "0.8.3",
     "timestamp_ms": 1714425600000,
     "uptime_secs": 3712,
     "config_generation": 5,

--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -149,7 +149,7 @@ Client
 | `Arc<AutoBuilder>` for HTTP builder | Per-connection clone is ref-count bump, not deep copy |
 | io_uring single-shot accept (Linux) | Dedicated accept thread; one SQE re-submitted per connection |
 | `SO_BUSY_POLL` (Linux) | Spin-poll NIC queue 50us for lower p99 latency |
-| Semaphore for connection limit | Bound from detected RAM: `(RAM_MB / 4) * 1024 / 50`, clamped 1k-100k |
+| Semaphore for connection limit | Bound from detected RAM: `(RAM_MB / 4) * 1024 / 256` (~256 KB/conn), clamped 1k-100k |
 
 ## Concurrency model
 

--- a/docs/security/supply-chain.md
+++ b/docs/security/supply-chain.md
@@ -46,8 +46,8 @@ You need the GitHub CLI (`gh >= 2.49`) and `cosign >= 2.2`.
 
 ```bash
 # 1. Download the artifact + SHA256SUMS from the release page.
-gh release download v0.8.2 -R fabriziosalmi/zion \
-    -p 'zion-v0.8.2-x86_64-unknown-linux-musl.tar.gz' \
+gh release download v0.8.3 -R fabriziosalmi/zion \
+    -p 'zion-v0.8.3-x86_64-unknown-linux-musl.tar.gz' \
     -p 'SHA256SUMS' \
     -p 'zion-sbom.cdx.json'
 
@@ -55,7 +55,7 @@ gh release download v0.8.2 -R fabriziosalmi/zion \
 sha256sum --check --ignore-missing SHA256SUMS
 
 # 3. Verify the SLSA build provenance bound to the artifact's hash.
-gh attestation verify zion-v0.8.2-x86_64-unknown-linux-musl.tar.gz \
+gh attestation verify zion-v0.8.3-x86_64-unknown-linux-musl.tar.gz \
     --owner fabriziosalmi
 
 # Step 3 fails if:
@@ -78,7 +78,7 @@ grype zion-sbom.cdx.json
 ## Verifying a container image
 
 ```bash
-IMAGE=ghcr.io/fabriziosalmi/zion:v0.8.2
+IMAGE=ghcr.io/fabriziosalmi/zion:v0.8.3
 
 # 1. Pin to the digest immediately — tags are mutable, digests are not.
 DIGEST=$(crane digest "$IMAGE")
@@ -120,7 +120,7 @@ deterministically, and pins the Rust toolchain via
 [`rust-toolchain.toml`](../../rust-toolchain.toml). To reproduce locally:
 
 ```bash
-git checkout v0.8.2
+git checkout v0.8.3
 export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)
 # Linux musl example — matches the release artifact byte-for-byte
 # (modulo strip's stable behavior on your distro).

--- a/src/config.rs
+++ b/src/config.rs
@@ -1297,6 +1297,31 @@ fn semantic_errors(config: &ZionConfig) -> Vec<String> {
         }
     }
 
+    // `client_auth` is a closed set; a typo would silently coerce to "none"
+    // (no client auth) — reject an unknown value so it fails closed at boot.
+    if !matches!(
+        config.tls.client_auth.as_str(),
+        "none" | "required" | "optional"
+    ) {
+        errors.push(format!(
+            "tls.client_auth '{}' must be \"none\", \"required\", or \"optional\"",
+            config.tls.client_auth
+        ));
+    }
+    // Data-plane mTLS: `client_auth = required|optional` needs a CA to verify
+    // presented client certs against. Without `tls.client_ca_path` the listener
+    // silently builds with NO client auth (fail-open) — the enforcement the
+    // operator asked for would be off with no signal. Reject it at boot.
+    if matches!(config.tls.client_auth.as_str(), "required" | "optional")
+        && config.tls.client_ca_path.is_none()
+    {
+        errors.push(format!(
+            "tls.client_auth = \"{}\" requires tls.client_ca_path (the CA that verifies \
+             presented client certificates); without it client-cert enforcement is silently off",
+            config.tls.client_auth
+        ));
+    }
+
     // [sovereign_aimp] — when the mesh is enabled and a listen address is set
     // in TOML, it MUST parse. Previously a malformed value silently fell back
     // to `0.0.0.0:9443` at boot, binding the gossip control plane to every
@@ -2716,6 +2741,49 @@ enabledd = true
             err.contains("schema_version") && err.contains("Upgrade zion"),
             "too-new schema must give upgrade guidance, got: {err}"
         );
+    }
+
+    #[test]
+    fn client_auth_requires_ca_and_valid_value() {
+        let base = "[server]\nlisten_http=\"0.0.0.0:80\"\nlisten_https=\"0.0.0.0:443\"\n\
+             [upstreams]\nbe=\"http://127.0.0.1:8000\"\n[[route]]\npath=\"/{*rest}\"\nupstream=\"be\"\n";
+
+        // required without a CA → fail-open, must be rejected.
+        let no_ca =
+            format!("{base}[tls]\ncert_path=\"/c\"\nkey_path=\"/k\"\nclient_auth=\"required\"\n");
+        let err = validate_str(&no_ca, "test").err().unwrap_or_default();
+        assert!(
+            err.contains("client_auth") && err.contains("client_ca_path"),
+            "required client_auth without a CA must be rejected, got: {err}"
+        );
+
+        // A typo'd value must be rejected (would silently coerce to none).
+        let typo =
+            format!("{base}[tls]\ncert_path=\"/c\"\nkey_path=\"/k\"\nclient_auth=\"requird\"\n");
+        let err = validate_str(&typo, "test").err().unwrap_or_default();
+        assert!(
+            err.contains("client_auth") && err.contains("must be"),
+            "unknown client_auth must be rejected, got: {err}"
+        );
+
+        // required WITH a CA passes semantics (cert files are a deploy check).
+        let ok = format!(
+            "{base}[tls]\ncert_path=\"/c\"\nkey_path=\"/k\"\nclient_auth=\"required\"\nclient_ca_path=\"/ca\"\n"
+        );
+        let cfg = parse_schema(&ok, "test").expect("parse");
+        assert!(
+            !semantic_errors(&cfg)
+                .iter()
+                .any(|e| e.contains("client_auth")),
+            "required client_auth WITH a CA must pass semantics"
+        );
+
+        // Default (none) needs no CA.
+        let none = format!("{base}[tls]\ncert_path=\"/c\"\nkey_path=\"/k\"\n");
+        let cfg = parse_schema(&none, "test").expect("parse");
+        assert!(!semantic_errors(&cfg)
+            .iter()
+            .any(|e| e.contains("client_auth")));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1038,14 +1038,20 @@ async fn async_main(platform: &'static bootstrap::Platform) -> error::ZionResult
             let listen_raw = if !toml_cfg.listen.is_empty() {
                 toml_cfg.listen.clone()
             } else {
-                std::env::var("ZION_AIMP_LISTEN").unwrap_or_else(|_| "0.0.0.0:9443".to_string())
+                // Fail closed on an ENABLED-but-unconfigured listen: default to
+                // LOOPBACK, never `0.0.0.0` — an operator who enabled the mesh
+                // without naming an interface must not get the gossip control
+                // plane bound to every interface by accident (the world-open
+                // default was the ZION-CONF gap). Set `sovereign_aimp.listen`
+                // (or ZION_AIMP_LISTEN) explicitly to expose it on a real NIC.
+                std::env::var("ZION_AIMP_LISTEN").unwrap_or_else(|_| "127.0.0.1:9443".to_string())
             };
             // Fail closed: a malformed listen address must NOT silently fall back
-            // to `0.0.0.0:9443` — that would bind the gossip control plane to
-            // every interface. The TOML path is already rejected at config
-            // validation; this also covers the `ZION_AIMP_LISTEN` env override,
-            // which bypasses that check. On a bad value, skip mesh bootstrap
-            // (aimp_cp = None) — bootstrap failure is non-fatal by design.
+            // to a default — that could bind the gossip control plane somewhere
+            // unintended. The TOML path is already rejected at config validation;
+            // this also covers the `ZION_AIMP_LISTEN` env override, which bypasses
+            // that check. On a bad value, skip mesh bootstrap (aimp_cp = None) —
+            // bootstrap failure is non-fatal by design.
             let listen: Option<std::net::SocketAddr> = match listen_raw.parse() {
                 Ok(addr) => Some(addr),
                 Err(e) => {


### PR DESCRIPTION
Closes the two HIGH fail-opens the v0.8.2 re-audit surfaced (the first capped the audit score to 59 despite a 75.9 raw mean). No behaviour change for a correct config.

## Fixed
- **AIMP empty listen → world-open** (residual gap in the v0.8.0 fix): enabled mesh with no `listen`/`ZION_AIMP_LISTEN` fell back to `0.0.0.0:9443` (every interface). v0.8.0 rejected only a *malformed* listen. Unconfigured case now defaults to **loopback** `127.0.0.1:9443`. (`src/main.rs`)
- **mTLS `client_auth` without a CA → silently no client auth**: `required`/`optional` with no `tls.client_ca_path` built the listener `.with_no_client_auth()`. Now rejected at config validation (mirrors the `admin.auth=mtls` check); an unknown `client_auth` value is rejected too. (`src/config.rs`)
- **docs**: conn-limit formula `/50`→`/256` in the architecture guide; AIMP tagged experimental in the README.

## Tests
`client_auth` required-without-CA and a typo'd value are rejected; required+CA and the `none` default pass. clippy `--all-features --all-targets` + fmt clean; full suite green.

Merge → tag `v0.8.3` re-runs the full release (binaries + signed container). Restores the audit cap to ~76-79.

🤖 Generated with [Claude Code](https://claude.com/claude-code)