### PR TITLE
fix(acme): renewal-loop liveness heartbeat + owner-only cert-key writes (v0.8.4)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,7 +21,7 @@ A clear and concise description of what you expected to happen.
 **Environment (please complete the following information):**
  - OS: [e.g. Linux, macOS]
  - Architecture: [e.g. arm64, amd64]
- - Zion Version: [e.g. 0.8.3]
+ - Zion Version: [e.g. 0.8.4]
 
 **Additional context**
 Add any other context about the problem here (e.g. logs with `RUST_LOG=trace`, upstream backend type like Go/Node).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,29 @@ All notable changes to Zion Edge Gateway are documented here.
 
 ## [Unreleased]
 
-## [0.8.3] - 2026-09-08
+## [0.8.4] - 2026-09-08
+
+**ACME renewal-loop liveness + owner-only cert-key writes.** A confirming
+re-audit of v0.8.3 (raw quality "Strong", all prior fail-opens verified fixed)
+flagged one HIGH — a silent-failure observability gap — and one at-rest MEDIUM.
+Both are closed here. No behaviour change for a correct config.
+
+### Fixed
+
+- **ACME renewal loop now exposes a liveness heartbeat**: the renewal counters
+  (`zion_acme_renewals_total` / `_failures_total`) only advance on an actual
+  attempt, so a *dead* renewal loop was indistinguishable from the normal
+  months-long idle steady state — the certificate could silently expire with no
+  signal. The loop now advances `zion_acme_loop_checks_total` (a monotonic
+  iteration counter) and sets `zion_acme_loop_last_check_timestamp_seconds` (a
+  heartbeat gauge) on **every** ~12h wake-up, including the no-op case. Alert on
+  `time() - zion_acme_loop_last_check_timestamp_seconds` exceeding the check
+  interval, or on `rate(zion_acme_loop_checks_total[1d]) == 0`.
+- **`zion init` / `zion auto` write the serving TLS private key owner-only**:
+  the generated key was written via a bare `std::fs::write` (default umask,
+  typically world-readable `0644`), unlike the hardened `0600` atomic path
+  already used for the ACME account and mesh identity keys. Both now use
+  `write_cert_key_atomic` (created `0600`, never wider even in transit).
 
 **Fail-closed security fixes.** A deeper re-audit of v0.8.2 surfaced two HIGH
 fail-opens (one a residual gap in the v0.8.0 AIMP-listen fix); this closes both.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5150,7 +5150,7 @@ dependencies = [
 
 [[package]]
 name = "zion"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "aho-corasick",
  "aimp_node",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zion"
-version = "0.8.3"
+version = "0.8.4"
 edition = "2021"
 # MSRV is the *core* default-features build (TLS proxy + WAF + cache + metrics).
 # Opt-in features (acme, auth, init, http3) pull crypto/i18n crates that have

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Client -> TLS 1.3 -> Security Gates -> Radix Router -> WAF Pipeline (5 gates) ->
 ```
 
 <!-- zion-stats:modules-lines (kept in sync by scripts/update-readme-stats.sh) -->
-50 modules, ~46,400 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
+50 modules, ~46,500 lines of Rust. See [architecture docs](https://fabriziosalmi.github.io/zion/guide/architecture) for the full module map and request lifecycle.
 
 ## Features
 
@@ -288,7 +288,7 @@ MODE=full bash benchmarks/baseline/run-baseline.sh   # → benchmarks/baseline/z
 ## Testing
 
 <!-- zion-stats:test-count (kept in sync by scripts/update-readme-stats.sh) -->
-**912 unit tests** run on every change; **23 integration tests** need a running Zion + a backend.
+**913 unit tests** run on every change; **23 integration tests** need a running Zion + a backend.
 
 ```bash
 cargo test                          # unit tests
@@ -317,12 +317,12 @@ Every release is signed and carries SLSA v1.0 build provenance — see
 
 ```bash
 # Binary release (Sigstore-backed provenance via gh CLI)
-gh release download v0.8.3 -R fabriziosalmi/zion -p '*x86_64-unknown-linux-musl*' -p 'SHA256SUMS'
+gh release download v0.8.4 -R fabriziosalmi/zion -p '*x86_64-unknown-linux-musl*' -p 'SHA256SUMS'
 sha256sum --check --ignore-missing SHA256SUMS
-gh attestation verify zion-v0.8.3-x86_64-unknown-linux-musl.tar.gz --owner fabriziosalmi
+gh attestation verify zion-v0.8.4-x86_64-unknown-linux-musl.tar.gz --owner fabriziosalmi
 
 # Container image (cosign keyless)
-cosign verify ghcr.io/fabriziosalmi/zion:v0.8.3 \
+cosign verify ghcr.io/fabriziosalmi/zion:v0.8.4 \
     --certificate-identity-regexp "^https://github.com/fabriziosalmi/zion/\\.github/workflows/release\\.yml@refs/tags/v" \
     --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ the current version.
 
 | Version | Supported |
 | ------- | --------- |
-| < 0.8.3 | No |
+| < 0.8.4 | No |
 
 Everything at or above that line is the current release. Stated as a single
 threshold on purpose — the previous wording carried a second, hardcoded row

--- a/deploy/helm/zion/Chart.yaml
+++ b/deploy/helm/zion/Chart.yaml
@@ -3,7 +3,7 @@ name: zion
 description: Zion Edge Gateway — high-performance Rust TLS reverse proxy with WAF
 type: application
 version: 0.2.2
-appVersion: "0.8.3"
+appVersion: "0.8.4"
 home: https://fabriziosalmi.github.io/zion
 sources:
   - https://github.com/fabriziosalmi/zion
@@ -19,7 +19,7 @@ annotations:
   artifacthub.io/license: Apache-2.0
   artifacthub.io/changes: |
     - kind: changed
-      description: Bump appVersion to 0.8.3
+      description: Bump appVersion to 0.8.4
     - kind: added
       description: ZION_AUDIT_HMAC_KEY wired from a Kubernetes Secret when [audit] is enabled
     - kind: added

--- a/docs/deploy/hot-reload.md
+++ b/docs/deploy/hot-reload.md
@@ -135,7 +135,7 @@ Two surfaces report the reload state:
 
   ```json
   {
-    "version": "0.8.3",
+    "version": "0.8.4",
     "timestamp_ms": 1714425600000,
     "uptime_secs": 3712,
     "config_generation": 5,

--- a/docs/security/supply-chain.md
+++ b/docs/security/supply-chain.md
@@ -46,8 +46,8 @@ You need the GitHub CLI (`gh >= 2.49`) and `cosign >= 2.2`.
 
 ```bash
 # 1. Download the artifact + SHA256SUMS from the release page.
-gh release download v0.8.3 -R fabriziosalmi/zion \
-    -p 'zion-v0.8.3-x86_64-unknown-linux-musl.tar.gz' \
+gh release download v0.8.4 -R fabriziosalmi/zion \
+    -p 'zion-v0.8.4-x86_64-unknown-linux-musl.tar.gz' \
     -p 'SHA256SUMS' \
     -p 'zion-sbom.cdx.json'
 
@@ -55,7 +55,7 @@ gh release download v0.8.3 -R fabriziosalmi/zion \
 sha256sum --check --ignore-missing SHA256SUMS
 
 # 3. Verify the SLSA build provenance bound to the artifact's hash.
-gh attestation verify zion-v0.8.3-x86_64-unknown-linux-musl.tar.gz \
+gh attestation verify zion-v0.8.4-x86_64-unknown-linux-musl.tar.gz \
     --owner fabriziosalmi
 
 # Step 3 fails if:
@@ -78,7 +78,7 @@ grype zion-sbom.cdx.json
 ## Verifying a container image
 
 ```bash
-IMAGE=ghcr.io/fabriziosalmi/zion:v0.8.3
+IMAGE=ghcr.io/fabriziosalmi/zion:v0.8.4
 
 # 1. Pin to the digest immediately — tags are mutable, digests are not.
 DIGEST=$(crane digest "$IMAGE")
@@ -120,7 +120,7 @@ deterministically, and pins the Rust toolchain via
 [`rust-toolchain.toml`](../../rust-toolchain.toml). To reproduce locally:
 
 ```bash
-git checkout v0.8.3
+git checkout v0.8.4
 export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)
 # Linux musl example — matches the release artifact byte-for-byte
 # (modulo strip's stable behavior on your distro).

--- a/src/acme.rs
+++ b/src/acme.rs
@@ -52,6 +52,23 @@ pub fn spawn_renewal_task(
         tokio::time::sleep(std::time::Duration::from_secs(10)).await;
 
         loop {
+            // Liveness heartbeat: advance on every wake-up, *before* the
+            // work, so a dead loop is distinguishable from the normal
+            // months-long idle steady state (a stopped loop freezes both
+            // signals). The renewal counters below only move on an actual
+            // attempt, which is silent when the cert is simply still fresh.
+            use std::sync::atomic::Ordering::Relaxed;
+            crate::metrics::METRICS
+                .acme_loop_checks_total
+                .fetch_add(1, Relaxed);
+            let now_secs = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_secs())
+                .unwrap_or(0);
+            crate::metrics::METRICS
+                .acme_loop_last_check_timestamp_seconds
+                .store(now_secs, Relaxed);
+
             // Check if renewal is needed (uses blocking fs)
             let cert_path = tls_config.cert_path.clone();
             let renew_days = acme_config.renew_before_days;

--- a/src/init.rs
+++ b/src/init.rs
@@ -215,9 +215,14 @@ pub fn run_auto(opts: AutoOpts) -> Result<PathBuf, String> {
         sans.push("localhost".to_string());
     }
     let cert = generate_simple_self_signed(sans).map_err(|e| format!("rcgen: {e}"))?;
-    std::fs::write(&cert_path, cert.cert.pem()).map_err(|e| format!("write {cert_path:?}: {e}"))?;
-    std::fs::write(&key_path, cert.signing_key.serialize_pem())
-        .map_err(|e| format!("write {key_path:?}: {e}"))?;
+    // Owner-only (0o600) atomic write — even a throwaway dev key must not be
+    // world-readable on a shared machine's $TMPDIR.
+    crate::atomic_file::write_cert_key_atomic(
+        &key_path,
+        cert.signing_key.serialize_pem().as_bytes(),
+        &cert_path,
+        cert.cert.pem().as_bytes(),
+    )?;
 
     let toml = format!(
         "# zion auto-mode — generated for one-shot dev / demo use.\n\
@@ -706,11 +711,17 @@ fn generate_tls_cert(r: &ResolvedInit) -> CertOutcome {
         let _ = std::fs::create_dir_all(parent);
     }
 
-    if let Err(e) = std::fs::write(&r.cert_path, &cert_pem) {
-        return CertOutcome::Failed(format!("write {}: {}", r.cert_path, e));
-    }
-    if let Err(e) = std::fs::write(&r.key_path, &key_pem) {
-        return CertOutcome::Failed(format!("write {}: {}", r.key_path, e));
+    // Owner-only (0o600) atomic write of the pair — the serving private key
+    // must never be world-readable, not even for the instant between create
+    // and a later chmod. Same hardened path used for the ACME/mesh keys,
+    // rather than a bare `std::fs::write` (default umask, typically 0644).
+    if let Err(e) = crate::atomic_file::write_cert_key_atomic(
+        Path::new(&r.key_path),
+        key_pem.as_bytes(),
+        Path::new(&r.cert_path),
+        cert_pem.as_bytes(),
+    ) {
+        return CertOutcome::Failed(e);
     }
 
     CertOutcome::Generated
@@ -945,6 +956,28 @@ mod tests {
                 .collect(),
             ..InitOpts::default()
         }
+    }
+
+    #[cfg(all(unix, feature = "init"))]
+    #[test]
+    fn generated_tls_key_is_owner_only() {
+        // The serving private key must be created 0o600, never world-readable
+        // (the bare std::fs::write default was 0o644). Drives the self-signed
+        // branch of generate_tls_cert and checks the on-disk key mode.
+        use std::os::unix::fs::PermissionsExt;
+        let dir = std::env::temp_dir().join(format!("zion-init-perm-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let mut r =
+            build_non_interactive(opts_with_upstreams(&[("backend", "127.0.0.1:8000")]), &[])
+                .unwrap();
+        r.gen_tls = true;
+        r.acme = false; // self-signed path → the long-lived cert is the serving cert
+        r.cert_path = dir.join("server.crt").to_string_lossy().into_owned();
+        r.key_path = dir.join("server.key").to_string_lossy().into_owned();
+        assert!(matches!(generate_tls_cert(&r), CertOutcome::Generated));
+        let mode = std::fs::metadata(&r.key_path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "serving private key must be owner-only");
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -490,6 +490,19 @@ pub struct Metrics {
     /// ACME renewal attempts that failed (any stage: account, order,
     /// challenge, finalize, write).
     pub acme_renewal_failures_total: AtomicU64,
+    /// Total iterations of the ACME renewal background loop (monotonic
+    /// counter). Advances on every 12h wake-up, *including* the common
+    /// no-op case where the cert is still fresh — unlike the renewal
+    /// counters, which only move on an actual attempt. `rate() == 0`
+    /// over more than one interval means the loop is dead.
+    pub acme_loop_checks_total: AtomicU64,
+    /// Unix timestamp (seconds) of the last ACME loop wake-up (gauge, a
+    /// liveness heartbeat). A stopped loop leaves this frozen, so
+    /// `time() - zion_acme_loop_last_check_timestamp_seconds` exceeding
+    /// the ~12h check interval distinguishes a dead loop from the normal
+    /// months-long idle steady state (the cert-silently-expires gap). 0
+    /// until the first wake-up.
+    pub acme_loop_last_check_timestamp_seconds: AtomicU64,
 
     // Gauges
     pub active_connections: AtomicI64,
@@ -562,6 +575,8 @@ impl Metrics {
             mesh_gossip_bytes_out: AtomicU64::new(0),
             acme_renewals_total: AtomicU64::new(0),
             acme_renewal_failures_total: AtomicU64::new(0),
+            acme_loop_checks_total: AtomicU64::new(0),
+            acme_loop_last_check_timestamp_seconds: AtomicU64::new(0),
             active_connections: AtomicI64::new(0),
             process_resident_memory_bytes: AtomicU64::new(0),
             process_open_fds: AtomicU64::new(0),
@@ -1146,6 +1161,26 @@ impl Metrics {
                 .format(self.acme_renewal_failures_total.load(Relaxed))
                 .as_bytes(),
         );
+        out.extend_from_slice(
+            b"\n# HELP zion_acme_loop_checks_total ACME renewal loop iterations (advances every ~12h wake-up, including no-op checks; rate()==0 means the loop is dead).\n\
+                                # TYPE zion_acme_loop_checks_total counter\n\
+                                zion_acme_loop_checks_total ",
+        );
+        out.extend_from_slice(
+            itoa_buf
+                .format(self.acme_loop_checks_total.load(Relaxed))
+                .as_bytes(),
+        );
+        out.extend_from_slice(
+            b"\n# HELP zion_acme_loop_last_check_timestamp_seconds Unix time of the last ACME loop wake-up (liveness heartbeat; 0 until first check). Alert when time()-this exceeds the check interval.\n\
+                                # TYPE zion_acme_loop_last_check_timestamp_seconds gauge\n\
+                                zion_acme_loop_last_check_timestamp_seconds ",
+        );
+        out.extend_from_slice(
+            itoa_buf
+                .format(self.acme_loop_last_check_timestamp_seconds.load(Relaxed))
+                .as_bytes(),
+        );
         out.extend_from_slice(b"\n");
 
         self.request_duration.render(
@@ -1573,6 +1608,31 @@ mod tests {
         assert!(out.contains("zion_process_resident_memory_bytes "));
         assert!(out.contains("# TYPE zion_process_open_fds gauge"));
         assert!(out.contains("zion_process_open_fds "));
+    }
+
+    #[test]
+    fn acme_loop_liveness_heartbeat_rendered() {
+        // The heartbeat that distinguishes a dead ACME renewal loop from the
+        // normal months-long idle steady state: a monotonic iteration counter
+        // and a last-check timestamp gauge, both always emitted so a dashboard
+        // can alert on staleness. (`render` caches per wall-clock second, so a
+        // fresh Metrics is used for each assertion to force a cache-miss.)
+        let fresh = Metrics::new();
+        let out0 = String::from_utf8(fresh.render(false).to_vec()).unwrap();
+        assert!(out0.contains("# TYPE zion_acme_loop_checks_total counter"));
+        assert!(out0.contains("\nzion_acme_loop_checks_total 0\n"));
+        assert!(out0.contains("# TYPE zion_acme_loop_last_check_timestamp_seconds gauge"));
+        assert!(out0.contains("\nzion_acme_loop_last_check_timestamp_seconds 0\n"));
+
+        // A wake-up advances both signals; a frozen loop leaves them put.
+        let bumped = Metrics::new();
+        bumped.acme_loop_checks_total.fetch_add(1, Relaxed);
+        bumped
+            .acme_loop_last_check_timestamp_seconds
+            .store(1_700_000_000, Relaxed);
+        let out1 = String::from_utf8(bumped.render(false).to_vec()).unwrap();
+        assert!(out1.contains("\nzion_acme_loop_checks_total 1\n"));
+        assert!(out1.contains("\nzion_acme_loop_last_check_timestamp_seconds 1700000000\n"));
     }
 
     #[test]


### PR DESCRIPTION
Closes the two findings from the **confirming re-audit of v0.8.3** (raw quality "Strong" — all three prior fail-opens verified fixed in-code; overall still capped by a single confirmed finding). No behaviour change for a correct config.

## HIGH (observability) — ACME renewal loop had no liveness signal
The renewal counters (`zion_acme_renewals_total` / `_failures_total`) advance **only** on an actual renewal/failure, so a *dead* renewal loop was indistinguishable from the normal months-long idle steady state — the certificate could silently expire with no signal (`src/acme.rs`).

Fix: the loop now advances a heartbeat on **every** ~12h wake-up (including the common no-op case, before the work):
- `zion_acme_loop_checks_total` — monotonic iteration counter
- `zion_acme_loop_last_check_timestamp_seconds` — last-wake-up gauge

Alert on `time() - zion_acme_loop_last_check_timestamp_seconds` exceeding the interval, or `rate(zion_acme_loop_checks_total[1d]) == 0`.

## MEDIUM (secrets-at-rest) — `zion init`/`auto` wrote the TLS key world-readable
The generated serving private key used a bare `std::fs::write` (default umask, typically `0644`), unlike the hardened `0600` atomic path already used for the ACME account and mesh identity keys. Both `generate_tls_cert` and `run_auto` now use `write_cert_key_atomic` (created `0600`, never wider even in transit).

## Tests
- `metrics::tests::acme_loop_liveness_heartbeat_rendered` — both series emitted with expected values (uses fresh instances to defeat the per-second render cache).
- `init::tests::generated_tls_key_is_owner_only` — on-disk key mode is `0600` (gated `all(unix, feature = "init")`).
- fmt + `clippy --all-targets -D warnings` clean across default / `init` / `acme` / `--all-features`; full suite green; README SSOT regen (913).

🤖 Generated with [Claude Code](https://claude.com/claude-code)